### PR TITLE
Add Speechify Simba 3.2 TTS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ A generic HTTP / OpenAI-compatible agent endpoint that requires no Go code is on
 |----------------|-----------|
 | Streaming STT | Deepgram, OpenAI, VibeVoice (local) |
 | LLM | OpenAI, Ollama (local or self-hosted) |
-| Streaming TTS | Cartesia, Deepgram, ElevenLabs, VibeVoice (local) |
+| Streaming TTS | Cartesia, Deepgram, ElevenLabs, Speechify, VibeVoice (local) |
 | Retrieval | pgvector, Supabase |
 | Custom tools | Python / TypeScript / JavaScript plugins, native Go tools |
 
@@ -471,7 +471,7 @@ The CLI reads your server's `config.toml` for provider credentials, so nothing i
 |------|-----------|----------------------|
 | STT | `deepgram`, `openai`, `vibevoice` | Deepgram API key, OpenAI API key, or a local VibeVoice ASR server |
 | LLM | `openai`, `ollama` | OpenAI API key, or an Ollama instance you control |
-| TTS | `cartesia`, `deepgram`, `elevenlabs`, `vibevoice` | Matching provider API key, or a local VibeVoice TTS server |
+| TTS | `cartesia`, `deepgram`, `elevenlabs`, `speechify`, `vibevoice` | Matching provider API key, or a local VibeVoice TTS server |
 | RAG (optional) | `pgvector`, `supabase` | Postgres connection string or Supabase URL + key, plus an OpenAI key for embeddings |
 
 Notes:
@@ -593,6 +593,11 @@ api_key = ""
 voice_id = ""
 
 [elevenlabs]
+api_key = ""
+voice_id = ""
+model = ""
+
+[speechify]
 api_key = ""
 voice_id = ""
 model = ""

--- a/config.toml.example
+++ b/config.toml.example
@@ -25,7 +25,7 @@ provider = "deepgram"   # Supported: deepgram, openai, vibevoice
 provider = "openai"     # Supported: openai, ollama
 
 [tts]
-provider = "cartesia"   # Supported: cartesia, deepgram, elevenlabs, vibevoice
+provider = "cartesia"   # Supported: cartesia, deepgram, elevenlabs, speechify, vibevoice
 
 # Provider credentials
 
@@ -51,6 +51,11 @@ voice_id = ""           # Optional; defaults to Cartesia Katie
 api_key = ""            # Required if tts.provider = "elevenlabs"
 voice_id = ""           # Optional; defaults to ElevenLabs Rachel
 model = ""              # Optional; defaults to eleven_turbo_v2_5
+
+[speechify]
+api_key = ""            # Required if tts.provider = "speechify"
+voice_id = ""           # Optional; defaults to Geffen (geffen_32). Simba 3.2 uses its curated voice set.
+model = ""              # Optional; defaults to simba-3.2
 
 # VibeVoice — local STT and TTS via external Python services.
 # Start the servers first:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	VibeVoice  VibeVoiceConfig  `toml:"vibevoice"`
 	Cartesia   CartesiaConfig   `toml:"cartesia"`
 	ElevenLabs ElevenLabsConfig `toml:"elevenlabs"`
+	Speechify  SpeechifyConfig  `toml:"speechify"`
 	Pgvector   PgvectorConfig   `toml:"pgvector"`
 	Supabase   SupabaseConfig   `toml:"supabase"`
 }
@@ -82,6 +83,12 @@ type CartesiaConfig struct {
 }
 
 type ElevenLabsConfig struct {
+	APIKey  string `toml:"api_key"`
+	VoiceID string `toml:"voice_id"`
+	Model   string `toml:"model"`
+}
+
+type SpeechifyConfig struct {
 	APIKey  string `toml:"api_key"`
 	VoiceID string `toml:"voice_id"`
 	Model   string `toml:"model"`

--- a/internal/tts/client.go
+++ b/internal/tts/client.go
@@ -30,9 +30,14 @@ func NewClient(cfg *config.Config) (Client, error) {
 			return nil, ErrMissingAPIKey{Provider: "elevenlabs", Field: "[elevenlabs] api_key"}
 		}
 		return NewElevenLabsClient(cfg.ElevenLabs.APIKey, cfg.ElevenLabs.VoiceID, cfg.ElevenLabs.Model), nil
+	case "speechify":
+		if cfg.Speechify.APIKey == "" {
+			return nil, ErrMissingAPIKey{Provider: "speechify", Field: "[speechify] api_key"}
+		}
+		return NewSpeechifyClient(cfg.Speechify.APIKey, cfg.Speechify.VoiceID, cfg.Speechify.Model), nil
 	case "vibevoice":
 		return NewVibeVoiceClient(cfg.VibeVoice.TTSURL, cfg.VibeVoice.Voice), nil
 	default:
-		return nil, fmt.Errorf("unknown tts provider %q (supported: cartesia, deepgram, elevenlabs, vibevoice)", cfg.TTS.Provider)
+		return nil, fmt.Errorf("unknown tts provider %q (supported: cartesia, deepgram, elevenlabs, speechify, vibevoice)", cfg.TTS.Provider)
 	}
 }

--- a/internal/tts/speechify.go
+++ b/internal/tts/speechify.go
@@ -1,0 +1,133 @@
+package tts
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+const (
+	speechifyAPIURL = "https://api.speechify.ai/v1/audio/speech"
+	// Geffen — Simba 3.2 curated voice (Speechify docs example)
+	defaultSpeechifyVoiceID = "geffen_32"
+	defaultSpeechifyModel   = "simba-3.2"
+)
+
+type speechifyClient struct {
+	apiKey     string
+	voiceID    string
+	model      string
+	httpClient *http.Client
+}
+
+// NewSpeechifyClient creates a Speechify Simba TTS client.
+// voiceID defaults to Geffen if empty. model defaults to simba-3.2.
+func NewSpeechifyClient(apiKey, voiceID, model string) Client {
+	if voiceID == "" {
+		voiceID = defaultSpeechifyVoiceID
+	}
+	if model == "" {
+		model = defaultSpeechifyModel
+	}
+	return &speechifyClient{
+		apiKey:     apiKey,
+		voiceID:    voiceID,
+		model:      model,
+		httpClient: &http.Client{},
+	}
+}
+
+type speechifyRequest struct {
+	Input        string `json:"input"`
+	VoiceID      string `json:"voice_id"`
+	Model        string `json:"model"`
+	AudioFormat  string `json:"audio_format"`
+	OutputFormat string `json:"output_format"`
+}
+
+// speechifyResponse — unlike Cartesia/ElevenLabs, Speechify returns the audio
+// base64-encoded inside a JSON envelope rather than as raw bytes.
+type speechifyResponse struct {
+	AudioData   string `json:"audio_data"`
+	AudioFormat string `json:"audio_format"`
+}
+
+func (c *speechifyClient) Synthesize(ctx context.Context, text string) ([]byte, error) {
+	// The API silently ignores pcm_16000 for the simba-3.x models and returns
+	// their native 24kHz instead (only legacy simba-english honors it), so
+	// request pcm_24000 — honored by every model — and downsample to 16kHz.
+	body := speechifyRequest{
+		Input:        text,
+		VoiceID:      c.voiceID,
+		Model:        c.model,
+		AudioFormat:  "pcm",
+		OutputFormat: "pcm_24000",
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("speechify marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, speechifyAPIURL, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("speechify create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("speechify request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("speechify error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("speechify read response: %w", err)
+	}
+
+	var parsed speechifyResponse
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, fmt.Errorf("speechify parse response: %w", err)
+	}
+
+	data, err := base64.StdEncoding.DecodeString(parsed.AudioData)
+	if err != nil {
+		return nil, fmt.Errorf("speechify decode audio: %w", err)
+	}
+
+	pcm := downsample24kTo16k(data)
+
+	log.Printf("[tts:speechify] synthesized %d bytes for %d chars of text", len(pcm), len(text))
+	return pcm, nil
+}
+
+// downsample24kTo16k converts s16le mono PCM from 24kHz to 16kHz, emitting two
+// samples per three: the first unchanged, the second the average of the
+// remaining pair. Up to two trailing samples (<0.1ms) are dropped.
+func downsample24kTo16k(in []byte) []byte {
+	samples := len(in) / 2
+	out := make([]byte, 0, (samples*2/3+1)*2)
+	for i := 0; i+2 < samples; i += 3 {
+		s0 := int16(uint16(in[2*i]) | uint16(in[2*i+1])<<8)
+		s1 := int16(uint16(in[2*i+2]) | uint16(in[2*i+3])<<8)
+		s2 := int16(uint16(in[2*i+4]) | uint16(in[2*i+5])<<8)
+		mid := int16((int32(s1) + int32(s2)) / 2)
+		out = append(out,
+			byte(uint16(s0)), byte(uint16(s0)>>8),
+			byte(uint16(mid)), byte(uint16(mid)>>8))
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Adds `tts.provider = "speechify"` — a new TTS provider backed by the Speechify API using the **Simba 3.2** model ([currently #1 on the Artificial Analysis TTS leaderboard](https://speechify.ai/blog/simba-3-2-and-the-models-endpoint)).

- New `internal/tts/speechify.go` client following the existing Cartesia/ElevenLabs pattern: `POST https://api.speechify.ai/v1/audio/speech` with Bearer auth. Unlike Cartesia/ElevenLabs, Speechify returns audio base64-encoded in a JSON envelope, so the client decodes `audio_data` before returning PCM.
- **Sample-rate quirk discovered in live testing:** the API silently ignores `output_format: "pcm_16000"` for the simba-3.x models and returns their native 24kHz instead (only legacy `simba-english` honors 16k). Playing that as 16k means 2/3-speed audio. The client therefore requests `pcm_24000` — honored by every model — and downsamples 3:2 to the pipeline's linear16/16kHz format (simple decimation with pair-averaging; adequate for speech).
- Defaults: model `simba-3.2`, voice `geffen_32` (Simba 3.2 serves a curated voice set — `beatrice_32`, `dominic_32`, `edmund_32`, `geffen_32`, `harper_32`, `hugh_32`, `imogen_32`, `wyatt_32` — plus approved cloned voices; `geffen_32` also works on the legacy models, so the default survives model overrides). Both overridable via `[speechify] voice_id` / `model`.
- Config plumbing (`SpeechifyConfig`), `config.toml.example`, and README provider tables updated.

## Config

```toml
[tts]
provider = "speechify"

[speechify]
api_key = "sk_..."   # required
voice_id = ""        # optional; defaults to geffen_32
model = ""           # optional; defaults to simba-3.2
```

## Testing

- `go build ./...` and `go vet` pass.
- Verified end-to-end against the live Speechify API: synthesis round trip ~2s, output is non-silent s16le PCM whose duration at 16kHz matches the WAV-header ground truth from the same API (~5.6s for an 88-char sentence).
- Sample-rate behavior was validated empirically per model (`pcm_8000`/`pcm_16000`/`pcm_24000` byte-count comparisons), which is how the simba-3.x 16k-ignored quirk was found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)