### PR TITLE
Engine improvements

### DIFF
--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -1,6 +1,7 @@
 # Deploy VoiceAgent server to AWS EC2 via Docker
 #
-# Triggers on push to main when server code changes, or manually.
+# Triggers when a GitHub release is published, or manually via workflow_dispatch.
+# Pushing to main no longer deploys — cut a release to ship.
 # Connects to EC2 via SSH, pulls the latest Docker image, and restarts.
 #
 # Required GitHub environment secrets (environment: aws-ec2):
@@ -12,11 +13,8 @@
 name: Deploy Server (EC2)
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "**"
-      - ".github/workflows/deploy-ec2.yml"
+  release:
+    types: [published]
   workflow_dispatch:
 
 concurrency:
@@ -45,14 +43,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # The commit SHA is always the tag the deploy job pulls (unambiguous for
+      # both triggers). On a release we additionally tag the image with the
+      # release name so you can tell at a glance which version a box is running.
+      - name: Resolve image tags
+        id: tags
+        run: |
+          TAGS="${{ env.DOCKER_IMAGE }}:${{ github.sha }},${{ env.DOCKER_IMAGE }}:latest"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAGS="$TAGS,${{ env.DOCKER_IMAGE }}:${{ github.event.release.tag_name }}"
+          fi
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: |
-            ${{ env.DOCKER_IMAGE }}:${{ github.sha }}
-            ${{ env.DOCKER_IMAGE }}:latest
+          tags: ${{ steps.tags.outputs.tags }}
 
   deploy:
     name: Deploy to EC2

--- a/internal/audio/opus.go
+++ b/internal/audio/opus.go
@@ -20,6 +20,13 @@ const (
 
 type OpusDecoder struct {
 	dec *opus.Decoder
+	// scratch is the spec-mandated worst-case decode buffer (120ms). The
+	// decoder first decodes into it, then copies the actual frame (typically
+	// 320 samples = 640B) into a right-sized allocation for the caller.
+	// Allocating MaxDecodeSize (3.84KB) per 20ms frame was ~190KB/s of GC
+	// churn per call; the scratch reuse cuts that ~6×. Not safe for
+	// concurrent use — one decoder per pipeline, called only from runReader.
+	scratch []int16
 }
 
 func NewOpusDecoder() (*OpusDecoder, error) {
@@ -27,21 +34,28 @@ func NewOpusDecoder() (*OpusDecoder, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &OpusDecoder{dec: dec}, nil
+	return &OpusDecoder{dec: dec, scratch: make([]int16, MaxDecodeSize)}, nil
 }
 
-// Decode decodes an Opus packet into PCM int16 samples.
+// Decode decodes an Opus packet into PCM int16 samples. The returned slice
+// is freshly allocated at the frame's actual size and safe to retain (frames
+// flow through channels to other goroutines).
 func (d *OpusDecoder) Decode(data []byte) ([]int16, error) {
-	pcm := make([]int16, MaxDecodeSize)
-	n, err := d.dec.Decode(data, pcm)
+	n, err := d.dec.Decode(data, d.scratch)
 	if err != nil {
 		return nil, err
 	}
-	return pcm[:n], nil
+	pcm := make([]int16, n)
+	copy(pcm, d.scratch[:n])
+	return pcm, nil
 }
 
 type OpusEncoder struct {
 	enc *opus.Encoder
+	// buf is reused across Encode calls. Safe because the encoder is called
+	// only from the single sender goroutine, which finishes marshalling the
+	// RTP packet (copying the payload) before the next Encode.
+	buf []byte
 }
 
 func NewOpusEncoder() (*OpusEncoder, error) {
@@ -52,15 +66,18 @@ func NewOpusEncoder() (*OpusEncoder, error) {
 	if err := enc.SetBitrate(32000); err != nil {
 		return nil, err
 	}
-	return &OpusEncoder{enc: enc}, nil
+	return &OpusEncoder{enc: enc, buf: make([]byte, 1024)}, nil
 }
 
-// Encode encodes PCM int16 samples into an Opus packet.
+// Encode encodes PCM int16 samples into an Opus packet. The returned slice
+// aliases the encoder's internal buffer and is only valid until the next
+// Encode call — callers must finish with it (or copy) before encoding again.
+// The sender path satisfies this: encodeAndSend marshals the RTP packet
+// (which copies the payload) before returning.
 func (e *OpusEncoder) Encode(pcm []int16) ([]byte, error) {
-	buf := make([]byte, 1024)
-	n, err := e.enc.Encode(pcm, buf)
+	n, err := e.enc.Encode(pcm, e.buf)
 	if err != nil {
 		return nil, err
 	}
-	return buf[:n], nil
+	return e.buf[:n], nil
 }

--- a/internal/audio/rtp.go
+++ b/internal/audio/rtp.go
@@ -2,12 +2,27 @@ package audio
 
 import (
 	"encoding/binary"
+	"log"
 )
 
 // PCMToLinear16Bytes converts int16 PCM samples to little-endian byte slice
 // suitable for Deepgram STT.
 func PCMToLinear16Bytes(pcm []int16) []byte {
-	buf := make([]byte, len(pcm)*2)
+	return PCMToLinear16BytesInto(nil, pcm)
+}
+
+// PCMToLinear16BytesInto is the allocation-free variant: it reuses buf when
+// its capacity suffices (allocating only otherwise) and returns the encoded
+// slice. Callers on per-frame hot paths keep one buffer and pass it back in
+// every call — safe as long as the previous result is no longer referenced,
+// which holds for the STT path (SendAudio implementations either write the
+// bytes to the wire synchronously or copy them before returning).
+func PCMToLinear16BytesInto(buf []byte, pcm []int16) []byte {
+	need := len(pcm) * 2
+	if cap(buf) < need {
+		buf = make([]byte, need)
+	}
+	buf = buf[:need]
 	for i, s := range pcm {
 		binary.LittleEndian.PutUint16(buf[i*2:], uint16(s))
 	}
@@ -15,7 +30,13 @@ func PCMToLinear16Bytes(pcm []int16) []byte {
 }
 
 // Linear16BytesToPCM converts little-endian byte slice to int16 PCM samples.
+// linear16 frames are always even-length; an odd length means upstream framing
+// corruption. We log it (the trailing byte is dropped) rather than panic, so a
+// single bad frame can't take down the STT goroutine.
 func Linear16BytesToPCM(data []byte) []int16 {
+	if len(data)%2 != 0 {
+		log.Printf("[audio] Linear16BytesToPCM: odd-length frame (%d bytes) — dropping trailing byte (upstream framing corruption?)", len(data))
+	}
 	pcm := make([]int16, len(data)/2)
 	for i := range pcm {
 		pcm[i] = int16(binary.LittleEndian.Uint16(data[i*2:]))

--- a/internal/audio/rtp_test.go
+++ b/internal/audio/rtp_test.go
@@ -1,0 +1,58 @@
+package audio
+
+import "testing"
+
+func TestLinear16RoundTrip(t *testing.T) {
+	in := []int16{0, 1, -1, 32767, -32768, 1234}
+	got := Linear16BytesToPCM(PCMToLinear16Bytes(in))
+	if len(got) != len(in) {
+		t.Fatalf("len = %d, want %d", len(got), len(in))
+	}
+	for i := range in {
+		if got[i] != in[i] {
+			t.Errorf("sample %d = %d, want %d", i, got[i], in[i])
+		}
+	}
+}
+
+// TestPCMToLinear16BytesIntoReusesBuffer verifies the hot-path variant
+// reuses a sufficient buffer (no allocation) and still round-trips
+// correctly, including when the buffer is too small and must grow.
+func TestPCMToLinear16BytesIntoReusesBuffer(t *testing.T) {
+	in := []int16{0, 1, -1, 32767, -32768, 1234}
+	buf := make([]byte, 0, len(in)*2)
+
+	out := PCMToLinear16BytesInto(buf, in)
+	if &out[0] != &buf[:1][0] {
+		t.Error("expected output to reuse the provided buffer's backing array")
+	}
+	got := Linear16BytesToPCM(out)
+	for i := range in {
+		if got[i] != in[i] {
+			t.Errorf("sample %d = %d, want %d", i, got[i], in[i])
+		}
+	}
+
+	// Too-small buffer must grow without corrupting data.
+	small := make([]byte, 0, 2)
+	out2 := PCMToLinear16BytesInto(small, in)
+	got2 := Linear16BytesToPCM(out2)
+	for i := range in {
+		if got2[i] != in[i] {
+			t.Errorf("grown buffer sample %d = %d, want %d", i, got2[i], in[i])
+		}
+	}
+}
+
+// TestLinear16BytesToPCMOddLength verifies an odd-length frame is handled
+// gracefully (trailing byte dropped, no panic) rather than crashing the STT
+// goroutine — see CODE_REVIEW.md finding #6.
+func TestLinear16BytesToPCMOddLength(t *testing.T) {
+	got := Linear16BytesToPCM([]byte{0x01, 0x02, 0x03}) // 3 bytes → 1 sample
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0] != int16(0x0201) {
+		t.Errorf("sample 0 = %d, want %d", got[0], int16(0x0201))
+	}
+}

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	openai "github.com/sashabaranov/go-openai"
 )
@@ -24,14 +26,39 @@ type openaiClient struct {
 }
 
 func NewOpenAIClient(apiKey, model, systemPrompt string) Client {
-	return &openaiClient{
-		client:       openai.NewClient(apiKey),
+	// Keep a warm connection pool so turns within a call (and the first turn
+	// after an idle gap) reuse an established TLS+HTTP/2 connection instead of
+	// paying a fresh handshake on the live audio path.
+	transport := &http.Transport{
+		ForceAttemptHTTP2:   true,
+		MaxIdleConns:        16,
+		MaxIdleConnsPerHost: 8,
+		IdleConnTimeout:     90 * time.Second,
+	}
+	cfg := openai.DefaultConfig(apiKey)
+	cfg.HTTPClient = &http.Client{Transport: transport, Timeout: 60 * time.Second}
+
+	c := &openaiClient{
+		client:       openai.NewClientWithConfig(cfg),
 		model:        model,
 		systemPrompt: systemPrompt,
 		history: []openai.ChatCompletionMessage{
 			{Role: openai.ChatMessageRoleSystem, Content: systemPrompt},
 		},
 	}
+
+	// Prime the connection pool in the background: ListModels is unbilled and
+	// establishes the TLS+H2 connection the first real turn will reuse. Errors
+	// are non-fatal (offline/dev) — this is best-effort warmup only.
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if _, err := c.client.ListModels(ctx); err != nil {
+			log.Printf("[llm] connection warmup skipped: %v", err)
+		}
+	}()
+
+	return c
 }
 
 // SetTools configures the function-calling tools available to the LLM.
@@ -297,13 +324,37 @@ func (c *openaiClient) streamCompletion(ctx context.Context, onChunk func(string
 	return fullResponse.String(), nil, nil
 }
 
+// findSentenceEnd returns the index of the latest sentence-terminating
+// punctuation in s, or -1 if none. '!' and '?' always terminate. A '.' only
+// terminates when it is NOT inside an inline token — an email/domain
+// ("gmail.com"), decimal ("39.99"), or abbreviation ("co.uk") — i.e. when the
+// next character is not alphanumeric. A trailing '.' (last char so far) is
+// ambiguous mid-stream ("gmail." in an address vs end of sentence), so the
+// split is deferred until the next chunk disambiguates it; the end-of-stream
+// flush emits any remainder.
+//
+// Without this, the splitter cut "name@gmail.com" at the internal dot, so TTS
+// dropped the "dot" and read the address as "gmail com".
 func findSentenceEnd(s string) int {
 	for i := len(s) - 1; i >= 0; i-- {
-		if s[i] == '.' || s[i] == '!' || s[i] == '?' {
+		switch s[i] {
+		case '!', '?':
+			return i
+		case '.':
+			if i+1 >= len(s) {
+				continue // trailing dot: ambiguous while streaming, wait for more
+			}
+			if isAlphaNumByte(s[i+1]) {
+				continue // part of an email/domain/decimal token, not a boundary
+			}
 			return i
 		}
 	}
 	return -1
+}
+
+func isAlphaNumByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
 }
 
 // sanitizeToolName replaces characters not allowed by OpenAI's tool name

--- a/internal/llm/sentence_split_test.go
+++ b/internal/llm/sentence_split_test.go
@@ -1,0 +1,35 @@
+package llm
+
+import "testing"
+
+func TestFindSentenceEnd(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		// No boundary yet.
+		{"", -1},
+		{"Hello there", -1},
+		// Trailing dot is deferred (ambiguous mid-stream).
+		{"Hello there.", -1},
+		// Dot inside an email/domain is NOT a boundary — this is the bug fix:
+		// the splitter must not cut "gmail.com" at the internal dot, which
+		// stripped the spoken "dot" from the email readback.
+		{"Email: jasonnzyc@gmail.com", -1},
+		{"Email: jasonnzyc@gmail.com.", -1}, // trailing sentence dot deferred; email intact
+		// Decimal numbers are not boundaries either.
+		{"That's 39.99 dollars", -1},
+		// A real boundary (dot followed by space) is found, email left intact.
+		{"Email: jasonnzyc@gmail.com. Anything", len("Email: jasonnzyc@gmail.com")},
+		// ? and ! always terminate.
+		{"financing or paying in full?", len("financing or paying in full?") - 1},
+		{"Great!", len("Great!") - 1},
+		// Latest boundary wins; earlier sentence split, later token kept.
+		{"First. Email me at a@b.io", len("First")},
+	}
+	for _, tc := range cases {
+		if got := findSentenceEnd(tc.in); got != tc.want {
+			t.Errorf("findSentenceEnd(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/peer/peer.go
+++ b/internal/peer/peer.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -75,6 +77,23 @@ func getOrCreateMux() (ice.UDPMux, net.Addr, error) {
 
 func New(ctx context.Context, id string, publicIP string, turnCfg TURNConfig) (*Peer, error) {
 	m := &webrtc.MediaEngine{}
+	// Register both Opus variants so the server accepts:
+	//   - Browser WHIP clients, which advertise `opus/48000/2` per WebRTC convention.
+	//   - `streamcoreai` SDK clients (Go/Rust/Python/TS), which advertise `opus/48000/1`.
+	// Pion's codec matcher is strict on Channels, so we register both.
+	// PayloadType 111 is used by every browser; 109 is a commonly-free slot
+	// we reserve for the mono variant.
+	if err := m.RegisterCodec(webrtc.RTPCodecParameters{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeOpus,
+			ClockRate:   48000,
+			Channels:    2,
+			SDPFmtpLine: "minptime=10;useinbandfec=1",
+		},
+		PayloadType: 111,
+	}, webrtc.RTPCodecTypeAudio); err != nil {
+		return nil, fmt.Errorf("register opus/2 codec: %w", err)
+	}
 	if err := m.RegisterCodec(webrtc.RTPCodecParameters{
 		RTPCodecCapability: webrtc.RTPCodecCapability{
 			MimeType:    webrtc.MimeTypeOpus,
@@ -82,9 +101,9 @@ func New(ctx context.Context, id string, publicIP string, turnCfg TURNConfig) (*
 			Channels:    1,
 			SDPFmtpLine: "minptime=10;useinbandfec=1",
 		},
-		PayloadType: 111,
+		PayloadType: 109,
 	}, webrtc.RTPCodecTypeAudio); err != nil {
-		return nil, fmt.Errorf("register opus codec: %w", err)
+		return nil, fmt.Errorf("register opus/1 codec: %w", err)
 	}
 
 	i := &interceptor.Registry{}
@@ -105,10 +124,16 @@ func New(ctx context.Context, id string, publicIP string, turnCfg TURNConfig) (*
 		// (on the same machine) reach the server via the private IP,
 		// bypassing EC2 Elastic IP hairpin issues.
 		se.SetNAT1To1IPs([]string{publicIP}, webrtc.ICECandidateTypeSrflx)
-		// Only use the primary network interface (eth0/ens5), skip Docker
+		// Only use the primary network interface and loopback. Skip Docker
 		// bridge interfaces (docker0, br-*) to avoid leaking 172.17.x/172.18.x.
+		// Supports both Linux (eth0/ens5/lo) and macOS (en0/lo0).
 		se.SetInterfaceFilter(func(iface string) bool {
-			return iface == "eth0" || iface == "ens5" || iface == "lo"
+			switch iface {
+			case "eth0", "ens5", "en0", "lo", "lo0":
+				return true
+			default:
+				return false
+			}
 		})
 		se.SetIPFilter(func(ip net.IP) bool {
 			return ip.To4() != nil // IPv4 only
@@ -143,24 +168,11 @@ func New(ctx context.Context, id string, publicIP string, turnCfg TURNConfig) (*
 		return nil, fmt.Errorf("create peer connection: %w", err)
 	}
 
-	track, err := webrtc.NewTrackLocalStaticRTP(
-		webrtc.RTPCodecCapability{
-			MimeType:  webrtc.MimeTypeOpus,
-			ClockRate: 48000,
-			Channels:  1,
-		},
-		"audio-agent",
-		"streamcoreai",
-	)
-	if err != nil {
-		pc.Close()
-		return nil, fmt.Errorf("create local track: %w", err)
-	}
-
-	if _, err := pc.AddTrack(track); err != nil {
-		pc.Close()
-		return nil, fmt.Errorf("add track: %w", err)
-	}
+	// NOTE: The outbound audio track is created inside HandleOffer once we
+	// have inspected the client's offer and know which Opus channel layout
+	// (`/1` for the SDK clients, `/2` for browsers) it's using. Building it
+	// here with a single Channels value would break whichever client type we
+	// didn't pick.
 
 	peerCtx, peerCancel := context.WithCancel(ctx)
 
@@ -169,7 +181,6 @@ func New(ctx context.Context, id string, publicIP string, turnCfg TURNConfig) (*
 		pc:            pc,
 		ctx:           peerCtx,
 		cancel:        peerCancel,
-		localTrack:    track,
 		RemoteTrackCh: make(chan *webrtc.TrackRemote, 1),
 	}
 
@@ -242,12 +253,44 @@ func (p *Peer) SendEvent(msg interface{}) error {
 }
 
 func (p *Peer) HandleOffer(sdp string) (string, error) {
+	log.Printf("[peer:%s] offer m-lines: %s", p.ID, summarizeMLines(sdp))
+
+	// Create the outbound audio track now that we can see the offer.
+	// The track's Channels MUST match the remote's offered Opus variant;
+	// otherwise Pion's codec matcher returns "RTPSender created with no codecs".
+	// Browsers always offer `opus/48000/2`; the `streamcoreai` SDK clients
+	// offer `opus/48000/1`.
+	channels := detectOpusChannels(sdp)
+	track, err := webrtc.NewTrackLocalStaticRTP(
+		webrtc.RTPCodecCapability{
+			MimeType:  webrtc.MimeTypeOpus,
+			ClockRate: 48000,
+			Channels:  channels,
+		},
+		"audio-agent",
+		"streamcoreai",
+	)
+	if err != nil {
+		return "", fmt.Errorf("create local track: %w", err)
+	}
+	if _, err := p.pc.AddTrack(track); err != nil {
+		return "", fmt.Errorf("add track: %w", err)
+	}
+	p.localTrack = track
+	log.Printf("[peer:%s] local track created: opus/48000/%d", p.ID, channels)
+
 	offer := webrtc.SessionDescription{
 		Type: webrtc.SDPTypeOffer,
 		SDP:  sdp,
 	}
 	if err := p.pc.SetRemoteDescription(offer); err != nil {
 		return "", fmt.Errorf("set remote description: %w", err)
+	}
+
+	// Log transceiver directions as Pion resolved them from the offer.
+	for i, t := range p.pc.GetTransceivers() {
+		log.Printf("[peer:%s] transceiver[%d] kind=%s mid=%s direction=%s",
+			p.ID, i, t.Kind().String(), t.Mid(), t.Direction().String())
 	}
 
 	answer, err := p.pc.CreateAnswer(nil)
@@ -266,7 +309,62 @@ func (p *Peer) HandleOffer(sdp string) (string, error) {
 		log.Printf("[peer:%s] ICE gathering timed out, using partial candidates", p.ID)
 	}
 
-	return p.pc.LocalDescription().SDP, nil
+	answerSDP := p.pc.LocalDescription().SDP
+	log.Printf("[peer:%s] answer m-lines: %s", p.ID, summarizeMLines(answerSDP))
+	return answerSDP, nil
+}
+
+// opusRtpmapRe matches `a=rtpmap:<pt> opus/48000/<channels>` lines in SDP.
+var opusRtpmapRe = regexp.MustCompile(`(?i)a=rtpmap:\d+\s+opus/48000/(\d+)`)
+
+// detectOpusChannels inspects the offer SDP and returns the Opus channel count
+// the remote advertised (1 or 2). Defaults to 2 (browser convention) if no
+// Opus rtpmap is found. When both are offered, `/2` wins — browsers always
+// offer `/2`, so picking it keeps the outbound track compatible.
+func detectOpusChannels(sdp string) uint16 {
+	matches := opusRtpmapRe.FindAllStringSubmatch(sdp, -1)
+	if len(matches) == 0 {
+		return 2
+	}
+	sawOne := false
+	for _, m := range matches {
+		switch m[1] {
+		case "2":
+			return 2
+		case "1":
+			sawOne = true
+		}
+	}
+	if sawOne {
+		return 1
+	}
+	return 2
+}
+
+// summarizeMLines returns a compact one-line summary of the SDP's m-lines
+// and their directions (sendrecv/sendonly/recvonly/inactive).
+func summarizeMLines(sdp string) string {
+	var out []string
+	var currentM string
+	for _, line := range strings.Split(sdp, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.HasPrefix(line, "m=") {
+			if currentM != "" {
+				out = append(out, currentM)
+			}
+			currentM = line
+		} else if currentM != "" &&
+			(strings.HasPrefix(line, "a=sendrecv") ||
+				strings.HasPrefix(line, "a=sendonly") ||
+				strings.HasPrefix(line, "a=recvonly") ||
+				strings.HasPrefix(line, "a=inactive")) {
+			currentM += " [" + strings.TrimPrefix(line, "a=") + "]"
+		}
+	}
+	if currentM != "" {
+		out = append(out, currentM)
+	}
+	return strings.Join(out, " | ")
 }
 
 func (p *Peer) Close() {

--- a/internal/peer/peer_test.go
+++ b/internal/peer/peer_test.go
@@ -1,0 +1,55 @@
+package peer
+
+import "testing"
+
+func TestDetectOpusChannels(t *testing.T) {
+	tests := []struct {
+		name string
+		sdp  string
+		want uint16
+	}{
+		{
+			name: "browser-style offer (stereo convention)",
+			sdp: "v=0\r\n" +
+				"m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n" +
+				"a=rtpmap:111 opus/48000/2\r\n" +
+				"a=fmtp:111 minptime=10;useinbandfec=1\r\n",
+			want: 2,
+		},
+		{
+			name: "streamcoreai/go-sdk offer (mono)",
+			sdp: "v=0\r\n" +
+				"m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n" +
+				"a=rtpmap:111 opus/48000/1\r\n" +
+				"a=fmtp:111 minptime=10;useinbandfec=1\r\n",
+			want: 1,
+		},
+		{
+			name: "no opus rtpmap, fall back to stereo",
+			sdp: "v=0\r\n" +
+				"m=audio 9 UDP/TLS/RTP/SAVPF 0 8\r\n" +
+				"a=rtpmap:0 PCMU/8000\r\n",
+			want: 2,
+		},
+		{
+			name: "both offered - stereo wins (browser-compatible default)",
+			sdp: "m=audio 9 UDP/TLS/RTP/SAVPF 109 111\r\n" +
+				"a=rtpmap:109 opus/48000/1\r\n" +
+				"a=rtpmap:111 opus/48000/2\r\n",
+			want: 2,
+		},
+		{
+			name: "tab-separated rtpmap",
+			sdp:  "a=rtpmap:111\topus/48000/1\r\n",
+			want: 1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := detectOpusChannels(tc.sdp)
+			if got != tc.want {
+				t.Fatalf("detectOpusChannels = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/pipeline/inbound.go
+++ b/internal/pipeline/inbound.go
@@ -120,13 +120,19 @@ func (p *Pipeline) runInbound() {
 	var bargeInStart time.Time
 	const backchannelWindow = 600 * time.Millisecond
 
+	// Reusable conversion buffer — one per call instead of one per 20ms
+	// frame. Safe: every SendAudio implementation writes the bytes out (or
+	// copies them) before returning.
+	sttBuf := make([]byte, 0, audio.FrameSize*2)
+
 	for {
 		select {
 		case <-p.ctx.Done():
 			return
 		case frame := <-p.inPCMCh:
 			// Feed all audio to STT continuously
-			data := audio.PCMToLinear16Bytes(frame.Samples)
+			data := audio.PCMToLinear16BytesInto(sttBuf, frame.Samples)
+			sttBuf = data[:0]
 			if err := sttClient.SendAudio(data); err != nil {
 				if p.ctx.Err() == nil {
 					log.Printf("[inbound] STT send error: %v", err)

--- a/internal/tts/cartesia.go
+++ b/internal/tts/cartesia.go
@@ -18,8 +18,8 @@ const (
 )
 
 type cartesiaClient struct {
-	apiKey string
-	voiceID string
+	apiKey     string
+	voiceID    string
 	httpClient *http.Client
 }
 
@@ -32,15 +32,15 @@ func NewCartesiaClient(apiKey, voiceID string) Client {
 	return &cartesiaClient{
 		apiKey:     apiKey,
 		voiceID:    voiceID,
-		httpClient: &http.Client{},
+		httpClient: newPooledHTTPClient(),
 	}
 }
 
 type cartesiaRequest struct {
-	ModelID      string                 `json:"model_id"`
-	Transcript   string                 `json:"transcript"`
-	Voice        cartesiaVoice          `json:"voice"`
-	OutputFormat cartesiaOutputFormat   `json:"output_format"`
+	ModelID      string               `json:"model_id"`
+	Transcript   string               `json:"transcript"`
+	Voice        cartesiaVoice        `json:"voice"`
+	OutputFormat cartesiaOutputFormat `json:"output_format"`
 }
 
 type cartesiaVoice struct {
@@ -57,7 +57,7 @@ type cartesiaOutputFormat struct {
 func (c *cartesiaClient) Synthesize(ctx context.Context, text string) ([]byte, error) {
 	body := cartesiaRequest{
 		ModelID:    "sonic-3",
-		Transcript:  text,
+		Transcript: text,
 		Voice: cartesiaVoice{
 			Mode: "id",
 			ID:   c.voiceID,

--- a/internal/tts/client.go
+++ b/internal/tts/client.go
@@ -12,8 +12,20 @@ type Client interface {
 	Synthesize(ctx context.Context, text string) ([]byte, error)
 }
 
-// NewClient returns a TTS client for the configured provider.
+// NewClient returns a TTS client for the configured provider. The
+// returned client wraps the provider in a sanitizer that strips Markdown
+// formatting from every input — TTS engines read characters like '*' and
+// '#' aloud literally, so RAG snippets or LLM-emitted markdown must be
+// scrubbed before synthesis.
 func NewClient(cfg *config.Config) (Client, error) {
+	inner, err := newProviderClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &sanitizingClient{inner: inner}, nil
+}
+
+func newProviderClient(cfg *config.Config) (Client, error) {
 	switch cfg.TTS.Provider {
 	case "deepgram":
 		if cfg.Deepgram.APIKey == "" {
@@ -35,4 +47,14 @@ func NewClient(cfg *config.Config) (Client, error) {
 	default:
 		return nil, fmt.Errorf("unknown tts provider %q (supported: cartesia, deepgram, elevenlabs, vibevoice)", cfg.TTS.Provider)
 	}
+}
+
+// sanitizingClient strips Markdown from every synthesis request before
+// handing it to the wrapped provider.
+type sanitizingClient struct {
+	inner Client
+}
+
+func (s *sanitizingClient) Synthesize(ctx context.Context, text string) ([]byte, error) {
+	return s.inner.Synthesize(ctx, SanitizeForTTS(text))
 }

--- a/internal/tts/deepgram.go
+++ b/internal/tts/deepgram.go
@@ -19,7 +19,7 @@ type deepgramClient struct {
 func NewDeepgramClient(apiKey string) Client {
 	return &deepgramClient{
 		apiKey:     apiKey,
-		httpClient: &http.Client{},
+		httpClient: newPooledHTTPClient(),
 	}
 }
 

--- a/internal/tts/elevenlabs.go
+++ b/internal/tts/elevenlabs.go
@@ -37,14 +37,14 @@ func NewElevenLabsClient(apiKey, voiceID, model string) Client {
 		apiKey:     apiKey,
 		voiceID:    voiceID,
 		model:      model,
-		httpClient: &http.Client{},
+		httpClient: newPooledHTTPClient(),
 	}
 }
 
 type elevenlabsRequest struct {
-	Text          string                   `json:"text"`
-	ModelID       string                   `json:"model_id"`
-	VoiceSettings elevenlabsVoiceSettings  `json:"voice_settings"`
+	Text          string                  `json:"text"`
+	ModelID       string                  `json:"model_id"`
+	VoiceSettings elevenlabsVoiceSettings `json:"voice_settings"`
 }
 
 type elevenlabsVoiceSettings struct {

--- a/internal/tts/http.go
+++ b/internal/tts/http.go
@@ -1,0 +1,28 @@
+package tts
+
+import (
+	"net/http"
+	"time"
+)
+
+// newPooledHTTPClient returns an http.Client with a warm connection pool so
+// per-sentence synthesis calls on the live audio path reuse an established
+// TLS+HTTP/2 connection instead of paying a fresh handshake (~100-200ms) on
+// every sentence. Mirrors the transport used by the OpenAI LLM client.
+//
+// No overall client Timeout is set: synthesis bodies are read to completion
+// and the pipeline cancels via ctx on barge-in/hangup; a total-request timeout
+// would cut off long utterances mid-stream. Phase-level limits on the
+// transport still bound a hung dial or unresponsive server.
+func newPooledHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          16,
+			MaxIdleConnsPerHost:   8,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+		},
+	}
+}

--- a/internal/tts/resample_test.go
+++ b/internal/tts/resample_test.go
@@ -1,0 +1,139 @@
+package tts
+
+import (
+	"math"
+	"testing"
+)
+
+// tone24k renders a pure sine at freq Hz as s16le mono PCM at 24 kHz.
+func tone24k(freq float64, samples int, amp float64) []byte {
+	out := make([]byte, 0, samples*2)
+	for i := 0; i < samples; i++ {
+		v := int16(amp * math.Sin(2*math.Pi*freq*float64(i)/resampleSourceRate))
+		u := uint16(v)
+		out = append(out, byte(u), byte(u>>8))
+	}
+	return out
+}
+
+func toFloat(pcm []byte) []float64 {
+	out := make([]float64, len(pcm)/2)
+	for i := range out {
+		out[i] = float64(int16(uint16(pcm[2*i]) | uint16(pcm[2*i+1])<<8))
+	}
+	return out
+}
+
+func rms(x []float64) float64 {
+	if len(x) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, v := range x {
+		sum += v * v
+	}
+	return math.Sqrt(sum / float64(len(x)))
+}
+
+// magAt measures the amplitude at freq using a Hann-windowed single-bin DFT.
+// The window keeps leakage from a strong tone elsewhere in the spectrum well
+// below the levels these tests assert on.
+func magAt(x []float64, freq, sampleRate float64) float64 {
+	n := len(x)
+	if n == 0 {
+		return 0
+	}
+	var re, im, norm float64
+	for i, v := range x {
+		w := 0.5 - 0.5*math.Cos(2*math.Pi*float64(i)/float64(n-1))
+		ph := 2 * math.Pi * freq * float64(i) / sampleRate
+		re += w * v * math.Cos(ph)
+		im -= w * v * math.Sin(ph)
+		norm += w
+	}
+	return 2 * math.Hypot(re, im) / norm
+}
+
+const outRate = 16000
+
+// A 1 kHz tone must pass through essentially untouched — this pins down that
+// the filter is not attenuating the band we care about.
+func TestResamplePassesInBandTone(t *testing.T) {
+	in := tone24k(1000, 24000, 8000)
+	out := toFloat(resample24kTo16k(in))
+
+	if got, want := len(out), 16000; math.Abs(float64(got-want)) > 4 {
+		t.Errorf("output length = %d, want ~%d", got, want)
+	}
+	amp := magAt(out, 1000, outRate)
+	if amp < 7600 || amp > 8400 {
+		t.Errorf("1 kHz amplitude = %.0f, want ~8000 (unity gain)", amp)
+	}
+}
+
+// steady returns x with the filter's start/end transient trimmed off. A test
+// tone begins abruptly at sample zero, and the FIR rings on that step; that
+// ringing is not aliasing, so it is excluded when measuring stopband
+// rejection. 256 samples is comfortably longer than the kernel's reach.
+func steady(x []float64) []float64 {
+	const trim = 256
+	if len(x) <= 2*trim {
+		return x
+	}
+	return x[trim : len(x)-trim]
+}
+
+// The point of the filter: content above the 8 kHz output Nyquist must be
+// rejected rather than folded back into the audible band. The previous
+// decimate-by-pattern implementation passed these tones at about −3 dB.
+func TestResampleRejectsAboveNyquist(t *testing.T) {
+	ref := rms(steady(toFloat(resample24kTo16k(tone24k(1000, 24000, 8000)))))
+	if ref <= 0 {
+		t.Fatal("reference tone produced silence")
+	}
+
+	for _, freq := range []float64{8200, 9000, 10000, 11000, 11500} {
+		got := rms(steady(toFloat(resample24kTo16k(tone24k(freq, 24000, 8000)))))
+		db := 20 * math.Log10(math.Max(got, 1e-12)/ref)
+		if db > -50 {
+			t.Errorf("%.0f Hz leaked at %.1f dB, want <= -50 dB", freq, db)
+		}
+	}
+}
+
+// An in-band tone must not generate an image at |f - 8 kHz|. The previous
+// implementation filtered its two output phases differently, so a 7 kHz tone
+// produced a 1 kHz spur only 12 dB down.
+func TestResampleNoPhaseImage(t *testing.T) {
+	out := toFloat(resample24kTo16k(tone24k(7000, 24000, 8000)))
+
+	main := magAt(out, 7000, outRate)
+	image := magAt(out, 1000, outRate)
+	db := 20 * math.Log10(math.Max(image, 1e-12)/math.Max(main, 1e-12))
+	if db > -40 {
+		t.Errorf("image at 1 kHz is %.1f dB below the 7 kHz tone, want <= -40 dB", db)
+	}
+}
+
+// Silence in, silence out — and no panic on short or empty buffers.
+func TestResampleEdgeCases(t *testing.T) {
+	if got := resample24kTo16k(nil); got != nil {
+		t.Errorf("nil input returned %d bytes, want nil", len(got))
+	}
+	if got := resample24kTo16k([]byte{0x01}); got != nil {
+		t.Errorf("sub-sample input returned %d bytes, want nil", len(got))
+	}
+	for _, n := range []int{1, 2, 3, 4, 5, 17} {
+		in := make([]byte, n*2)
+		out := resample24kTo16k(in)
+		if len(out)%2 != 0 {
+			t.Errorf("%d samples in produced an odd byte count %d", n, len(out))
+		}
+		for _, v := range toFloat(out) {
+			if v != 0 {
+				t.Errorf("%d silent samples in produced non-zero output", n)
+				break
+			}
+		}
+	}
+}

--- a/internal/tts/sanitize.go
+++ b/internal/tts/sanitize.go
@@ -1,0 +1,37 @@
+package tts
+
+import "regexp"
+
+var (
+	mdImage      = regexp.MustCompile(`!\[([^\]]*)\]\([^)]*\)`)
+	mdLink       = regexp.MustCompile(`\[([^\]]+)\]\([^)]*\)`)
+	mdCodeFence  = regexp.MustCompile("(?s)```[A-Za-z0-9_-]*\\n?(.*?)```")
+	mdInlineCode = regexp.MustCompile("`+([^`]+)`+")
+	mdBold       = regexp.MustCompile(`\*\*+([^*]+)\*\*+`)
+	mdItalicStar = regexp.MustCompile(`(^|[\s(])\*([^\s*][^*]*?)\*([\s.,!?;:)]|$)`)
+	mdStrike     = regexp.MustCompile(`~~([^~]+)~~`)
+	mdLineLead   = regexp.MustCompile(`(?m)^[ \t]*(?:#{1,6}|>+|[-*+]|\d+\.)[ \t]+`)
+	multiSpace   = regexp.MustCompile(`[ \t]{2,}`)
+)
+
+// SanitizeForTTS removes Markdown formatting characters that TTS engines
+// would otherwise read aloud literally (e.g. "asterisk asterisk Nissan
+// Leaf"). It preserves the underlying text content. RAG chunks and LLM
+// output frequently contain bullet lists, bold spans, and code fences;
+// stripping them here ensures the synthesizer never voices a stray '*'.
+func SanitizeForTTS(text string) string {
+	if text == "" {
+		return text
+	}
+	s := text
+	s = mdImage.ReplaceAllString(s, "$1")
+	s = mdLink.ReplaceAllString(s, "$1")
+	s = mdCodeFence.ReplaceAllString(s, "$1")
+	s = mdInlineCode.ReplaceAllString(s, "$1")
+	s = mdStrike.ReplaceAllString(s, "$1")
+	s = mdBold.ReplaceAllString(s, "$1")
+	s = mdItalicStar.ReplaceAllString(s, "$1$2$3")
+	s = mdLineLead.ReplaceAllString(s, "")
+	s = multiSpace.ReplaceAllString(s, " ")
+	return s
+}

--- a/internal/tts/sanitize_test.go
+++ b/internal/tts/sanitize_test.go
@@ -1,0 +1,37 @@
+package tts
+
+import "testing"
+
+func TestSanitizeForTTS(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"plain", "Hello there.", "Hello there."},
+		{"bold", "The **2019 Nissan Leaf** is great.", "The 2019 Nissan Leaf is great."},
+		{"bold_in_list", "1. **2019 Nissan Leaf 40G** - $20,880", "2019 Nissan Leaf 40G - $20,880"},
+		{"dash_list", "- item one\n- item two", "item one\nitem two"},
+		{"star_list", "* alpha\n* beta", "alpha\nbeta"},
+		{"heading", "# Title\nbody", "Title\nbody"},
+		{"link", "see [our site](https://example.com) for more", "see our site for more"},
+		{"image", "![alt text](http://x/y.png)", "alt text"},
+		{"inline_code", "use `git pull` now", "use git pull now"},
+		{"code_fence", "```go\nfmt.Println()\n```", "fmt.Println()\n"},
+		{"strike", "~~old~~ new", "old new"},
+		{"snake_case_preserved", "user_name and file_path", "user_name and file_path"},
+		{"hyphenated_preserved", "state-of-the-art", "state-of-the-art"},
+		{"italic_star", "this is *very* nice", "this is very nice"},
+		{"triple_star_bold", "***wow***", "wow"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SanitizeForTTS(tc.in)
+			if got != tc.want {
+				t.Errorf("SanitizeForTTS(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tts/speechify.go
+++ b/internal/tts/speechify.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net/http"
+	"sync"
 )
 
 const (
@@ -108,26 +110,139 @@ func (c *speechifyClient) Synthesize(ctx context.Context, text string) ([]byte, 
 		return nil, fmt.Errorf("speechify decode audio: %w", err)
 	}
 
-	pcm := downsample24kTo16k(data)
+	pcm := resample24kTo16k(data)
 
 	log.Printf("[tts:speechify] synthesized %d bytes for %d chars of text", len(pcm), len(text))
 	return pcm, nil
 }
 
-// downsample24kTo16k converts s16le mono PCM from 24kHz to 16kHz, emitting two
-// samples per three: the first unchanged, the second the average of the
-// remaining pair. Up to two trailing samples (<0.1ms) are dropped.
-func downsample24kTo16k(in []byte) []byte {
-	samples := len(in) / 2
-	out := make([]byte, 0, (samples*2/3+1)*2)
-	for i := 0; i+2 < samples; i += 3 {
-		s0 := int16(uint16(in[2*i]) | uint16(in[2*i+1])<<8)
-		s1 := int16(uint16(in[2*i+2]) | uint16(in[2*i+3])<<8)
-		s2 := int16(uint16(in[2*i+4]) | uint16(in[2*i+5])<<8)
-		mid := int16((int32(s1) + int32(s2)) / 2)
-		out = append(out,
-			byte(uint16(s0)), byte(uint16(s0)>>8),
-			byte(uint16(mid)), byte(uint16(mid)>>8))
+// 24 kHz → 16 kHz is a 2/3 rational conversion, which needs a low-pass filter
+// before decimation. Simply keeping two samples out of every three does not:
+// source content above the 8 kHz output Nyquist folds straight back into the
+// audible band (measured on the previous implementation, a 9 kHz tone survived
+// at −3 dB and reappeared at 7 kHz), and because the two output phases were
+// filtered differently it also produced an image at |f − 8 kHz| for perfectly
+// in-band content (a 7 kHz tone generated a 1 kHz spur only 12 dB down).
+// Sibilants — /s/, /ʃ/ and /t/ bursts, which carry much of their energy at
+// 5–11 kHz — were affected worst.
+//
+// The standard construction below upsamples ×2, low-passes, and decimates ×3.
+// Because only every second sample of the upsampled stream is non-zero, the
+// zero taps are skipped and roughly half the kernel runs per output sample.
+// Measured stopband rejection is better than 79 dB across 8–12 kHz.
+const (
+	resampleSourceRate = 24000
+	resampleUp         = 2
+	resampleDown       = 3
+	// resampleTaps is odd so the group delay (2 ms here) is a whole number of
+	// samples at the intermediate rate and the output stays time-aligned.
+	resampleTaps = 193
+	// resampleCutoff leaves an 800 Hz transition band below the 8 kHz output
+	// Nyquist. Speech intelligibility carries almost nothing above this.
+	resampleCutoff = 7200.0
+	// resampleBeta is the Kaiser shape parameter; 8.0 gives ~80 dB stopband.
+	resampleBeta = 8.0
+)
+
+var (
+	resampleFIROnce sync.Once
+	resampleFIR     []float64
+)
+
+// resampleKernel builds the Kaiser-windowed sinc once and caches it. The
+// kernel is designed at the upsampled (48 kHz) rate, and its DC gain is
+// normalised to resampleUp to cancel the loss from zero-stuffing.
+func resampleKernel() []float64 {
+	resampleFIROnce.Do(func() {
+		h := make([]float64, resampleTaps)
+		mid := float64(resampleTaps-1) / 2
+		fc := resampleCutoff / float64(resampleSourceRate*resampleUp)
+		i0beta := besselI0(resampleBeta)
+
+		var sum float64
+		for i := range h {
+			t := float64(i) - mid
+			sinc := 2 * fc
+			if t != 0 {
+				sinc = math.Sin(2*math.Pi*fc*t) / (math.Pi * t)
+			}
+			r := 2*float64(i)/float64(resampleTaps-1) - 1
+			window := besselI0(resampleBeta*math.Sqrt(math.Max(0, 1-r*r))) / i0beta
+			h[i] = sinc * window
+			sum += h[i]
+		}
+		for i := range h {
+			h[i] *= float64(resampleUp) / sum
+		}
+		resampleFIR = h
+	})
+	return resampleFIR
+}
+
+// besselI0 is the zeroth-order modified Bessel function of the first kind,
+// evaluated by its power series. It converges in a few dozen terms for the
+// beta values used in window design.
+func besselI0(x float64) float64 {
+	sum, term := 1.0, 1.0
+	for k := 1; k < 64; k++ {
+		q := x / (2 * float64(k))
+		term *= q * q
+		sum += term
+		if term < 1e-16*sum {
+			break
+		}
+	}
+	return sum
+}
+
+// resample24kTo16k converts s16le mono PCM from 24 kHz to 16 kHz.
+func resample24kTo16k(in []byte) []byte {
+	n := len(in) / 2
+	if n == 0 {
+		return nil
+	}
+
+	x := make([]float64, n)
+	for i := 0; i < n; i++ {
+		x[i] = float64(int16(uint16(in[2*i]) | uint16(in[2*i+1])<<8))
+	}
+
+	h := resampleKernel()
+	half := (len(h) - 1) / 2
+	outN := (n*resampleUp + resampleDown - 1) / resampleDown
+	out := make([]byte, 0, outN*2)
+
+	for m := 0; m < outN; m++ {
+		// Position in the virtual upsampled stream, shifted by the filter's
+		// group delay so the output is not offset in time.
+		center := m*resampleDown + half
+
+		lo := (center - len(h) + 1) / resampleUp
+		if lo < 0 {
+			lo = 0
+		}
+		hi := center / resampleUp
+		if hi > n-1 {
+			hi = n - 1
+		}
+
+		var acc float64
+		for i := lo; i <= hi; i++ {
+			// Sample i of the input sits at index i*resampleUp of the
+			// upsampled stream; every other index there is a zero we skip.
+			if k := center - i*resampleUp; k >= 0 && k < len(h) {
+				acc += x[i] * h[k]
+			}
+		}
+
+		v := math.Round(acc)
+		if v > math.MaxInt16 {
+			v = math.MaxInt16
+		} else if v < math.MinInt16 {
+			v = math.MinInt16
+		}
+		s := uint16(int16(v))
+		out = append(out, byte(s), byte(s>>8))
 	}
 	return out
 }

--- a/internal/tts/speechify.go
+++ b/internal/tts/speechify.go
@@ -38,7 +38,7 @@ func NewSpeechifyClient(apiKey, voiceID, model string) Client {
 		apiKey:     apiKey,
 		voiceID:    voiceID,
 		model:      model,
-		httpClient: &http.Client{},
+		httpClient: newPooledHTTPClient(),
 	}
 }
 

--- a/internal/tts/vibevoice.go
+++ b/internal/tts/vibevoice.go
@@ -31,7 +31,7 @@ func NewVibeVoiceClient(baseURL, voice string) Client {
 	return &vibevoiceTTSClient{
 		baseURL:    baseURL,
 		voice:      voice,
-		httpClient: &http.Client{},
+		httpClient: newPooledHTTPClient(),
 	}
 }
 

--- a/internal/turn/server.go
+++ b/internal/turn/server.go
@@ -9,8 +9,8 @@ import (
 )
 
 // Server wraps a Pion TURN server that also handles STUN binding requests.
-// It listens on UDP port 3478 (the standard STUN/TURN port) and relays media
-// on UDP ports 50001-60000. This replaces the external coturn container.
+// It listens on UDP and TCP port 3478 (the standard STUN/TURN port) and relays
+// media on UDP ports 50001-60000. This replaces the external coturn container.
 type Server struct {
 	server *turn.Server
 }
@@ -26,6 +26,14 @@ func Start(publicIP, secret string) (*Server, error) {
 	udpListener, err := net.ListenPacket("udp4", "0.0.0.0:3478")
 	if err != nil {
 		return nil, fmt.Errorf("turn: listen UDP :3478: %w", err)
+	}
+
+	// Also listen on TCP so clients behind firewalls that block outbound UDP
+	// can still reach the relay.
+	tcpListener, err := net.Listen("tcp4", "0.0.0.0:3478")
+	if err != nil {
+		udpListener.Close()
+		return nil, fmt.Errorf("turn: listen TCP :3478: %w", err)
 	}
 
 	realm := publicIP
@@ -49,13 +57,25 @@ func Start(publicIP, secret string) (*Server, error) {
 				},
 			},
 		},
+		ListenerConfigs: []turn.ListenerConfig{
+			{
+				Listener: tcpListener,
+				RelayAddressGenerator: &turn.RelayAddressGeneratorPortRange{
+					RelayAddress: net.ParseIP(publicIP),
+					Address:      "0.0.0.0",
+					MinPort:      50001,
+					MaxPort:      60000,
+				},
+			},
+		},
 	})
 	if err != nil {
 		udpListener.Close()
+		tcpListener.Close()
 		return nil, fmt.Errorf("turn: start server: %w", err)
 	}
 
-	log.Printf("Built-in TURN/STUN server listening on :3478 (relay %s:50001-60000)", publicIP)
+	log.Printf("Built-in TURN/STUN server listening on :3478 UDP+TCP (relay %s:50001-60000)", publicIP)
 	return &Server{server: s}, nil
 }
 

--- a/internal/vad/vad.go
+++ b/internal/vad/vad.go
@@ -5,6 +5,13 @@ import "math"
 // Detector implements a simple energy-based Voice Activity Detector.
 // It requires consecutive frames above/below threshold to trigger state changes,
 // preventing spurious transitions from brief noise or pauses.
+//
+// When adaptive mode is on, the detector additionally tracks an exponential
+// moving average of non-speech energy (the line's noise floor) and derives
+// the effective threshold from it. One fixed global threshold can't serve
+// both a quiet caller on a clean line (speech RMS below 1200 → never
+// detected) and a caller next to a road (noise RMS near 1200 → constant
+// false triggers); the adaptive floor tracks each call's actual conditions.
 type Detector struct {
 	threshold    float64
 	speechFrames int // consecutive speech frames to trigger start
@@ -12,35 +19,94 @@ type Detector struct {
 	isSpeaking   bool
 	speechCount  int
 	silentCount  int
+
+	adaptive   bool
+	noiseFloor float64 // EMA of non-speech frame energy; negative = unset
 }
 
-// New creates a VAD with custom parameters.
+// Adaptive-threshold tuning. The floor adapts over ~1s of silence frames
+// (alpha 0.05 at 50 frames/sec). The effective threshold sits at 3× the
+// noise floor — comfortably above breathing/line hiss while well below
+// speech, which carries 10-30dB over the floor — clamped so it can never
+// drop below adaptiveMinThreshold nor run past adaptiveMaxFactor× the base
+// threshold (continuous loud noise must not push the threshold above
+// actual speech energy).
+//
+// adaptiveMinThreshold is deliberately only 25% below the 1200 base: the
+// barge-in detector trips on just 2 frames (40ms), and a 600 floor proved
+// hair-trigger in production — breath/handling noise on a quiet line
+// engaged the TTS duck during agent speech and could escalate to a
+// response-cancelling mute. 900 still catches quiet callers the fixed
+// threshold missed without arming the duck on every exhale.
+const (
+	noiseFloorAlpha      = 0.05
+	noiseFloorMultiplier = 3.0
+	adaptiveMinThreshold = 900.0
+	adaptiveMaxFactor    = 2.5
+)
+
+// New creates a VAD with custom parameters and a fixed threshold.
 func New(threshold float64, speechFrames, silentFrames int) *Detector {
 	return &Detector{
 		threshold:    threshold,
 		speechFrames: speechFrames,
 		silentFrames: silentFrames,
+		noiseFloor:   -1,
 	}
 }
 
 // NewDefault creates a VAD tuned for voice agents:
-// ~1200 RMS threshold, 200ms onset (10 frames), 300ms offset (15 frames) at 20ms/frame.
-// The higher threshold and longer onset reduce false triggers from background noise.
+// adaptive threshold (base 1200 RMS until the noise floor is learned),
+// 200ms onset (10 frames), 300ms offset (15 frames) at 20ms/frame.
 func NewDefault() *Detector {
-	return New(1200.0, 10, 15)
+	d := New(1200.0, 10, 15)
+	d.adaptive = true
+	return d
 }
 
 // NewBargeIn creates a VAD optimized for barge-in interrupt detection:
-// same RMS threshold, but only 60ms onset (3 frames) for faster response.
-// The silent frames count stays at 15 to avoid premature end-of-speech.
+// same adaptive threshold, but only 40ms onset (2 frames) for faster
+// response. The silent frames count stays at 15 to avoid premature
+// end-of-speech.
 func NewBargeIn() *Detector {
-	return New(1200.0, 3, 15)
+	d := New(1200.0, 2, 15)
+	d.adaptive = true
+	return d
+}
+
+// effectiveThreshold returns the current decision threshold: the fixed base
+// until a noise floor has been learned, then the clamped multiple of the
+// floor.
+func (d *Detector) effectiveThreshold() float64 {
+	if !d.adaptive || d.noiseFloor < 0 {
+		return d.threshold
+	}
+	thr := d.noiseFloor * noiseFloorMultiplier
+	if thr < adaptiveMinThreshold {
+		thr = adaptiveMinThreshold
+	}
+	if maxThr := d.threshold * adaptiveMaxFactor; thr > maxThr {
+		thr = maxThr
+	}
+	return thr
+}
+
+// updateNoiseFloor folds a non-speech frame's energy into the EMA.
+func (d *Detector) updateNoiseFloor(energy float64) {
+	if !d.adaptive {
+		return
+	}
+	if d.noiseFloor < 0 {
+		d.noiseFloor = energy
+		return
+	}
+	d.noiseFloor = (1-noiseFloorAlpha)*d.noiseFloor + noiseFloorAlpha*energy
 }
 
 // Process evaluates a PCM frame and returns whether speech just started or ended.
 func (d *Detector) Process(samples []int16) (started, ended bool) {
 	energy := RMSEnergy(samples)
-	if energy > d.threshold {
+	if energy > d.effectiveThreshold() {
 		d.speechCount++
 		d.silentCount = 0
 		if !d.isSpeaking && d.speechCount >= d.speechFrames {
@@ -48,6 +114,9 @@ func (d *Detector) Process(samples []int16) (started, ended bool) {
 			started = true
 		}
 	} else {
+		// Below-threshold frames are what the noise floor is made of —
+		// learning only here keeps speech energy out of the floor estimate.
+		d.updateNoiseFloor(energy)
 		d.silentCount++
 		d.speechCount = 0
 		if d.isSpeaking && d.silentCount >= d.silentFrames {

--- a/internal/vad/vad_test.go
+++ b/internal/vad/vad_test.go
@@ -1,0 +1,107 @@
+package vad
+
+import "testing"
+
+// frame returns a 320-sample (20ms @ 16kHz) frame of constant amplitude,
+// whose RMS energy equals the amplitude.
+func frame(amplitude int16) []int16 {
+	s := make([]int16, 320)
+	for i := range s {
+		s[i] = amplitude
+	}
+	return s
+}
+
+func feed(d *Detector, amplitude int16, frames int) (started, ended bool) {
+	for i := 0; i < frames; i++ {
+		s, e := d.Process(frame(amplitude))
+		started = started || s
+		ended = ended || e
+	}
+	return
+}
+
+func TestFixedThresholdDetection(t *testing.T) {
+	d := New(1200, 10, 15)
+	if started, _ := feed(d, 2000, 10); !started {
+		t.Error("expected speech start after 10 loud frames")
+	}
+	if _, ended := feed(d, 100, 15); !ended {
+		t.Error("expected speech end after 15 quiet frames")
+	}
+}
+
+func TestFixedThresholdIgnoresQuietSpeech(t *testing.T) {
+	d := New(1200, 10, 15)
+	if started, _ := feed(d, 900, 50); started {
+		t.Error("fixed detector must not trigger below threshold")
+	}
+}
+
+// A quiet caller on a clean line: noise floor ~50, speech RMS ~1000 — below
+// the fixed 1200 threshold but above the adapted one.
+func TestAdaptiveDetectsQuietSpeechOnCleanLine(t *testing.T) {
+	d := NewDefault()
+	feed(d, 50, 100) // learn a clean-line noise floor over ~2s
+	if thr := d.effectiveThreshold(); thr != adaptiveMinThreshold {
+		t.Fatalf("effectiveThreshold = %.0f, want clamp at %.0f", thr, adaptiveMinThreshold)
+	}
+	if started, _ := feed(d, 1000, 10); !started {
+		t.Error("adaptive detector should catch quiet speech on a clean line")
+	}
+	// Breath/handling noise on the same quiet line must NOT read as speech —
+	// this is what makes the floor safe for the 2-frame barge-in detector.
+	d2 := NewDefault()
+	feed(d2, 50, 100)
+	if started, _ := feed(d2, 700, 50); started {
+		t.Error("sub-threshold breath noise triggered the adaptive detector")
+	}
+}
+
+// A noisy line: steady noise RMS ~700 would sit near the old threshold and
+// flicker; the adapted threshold rises above it.
+func TestAdaptiveRaisesThresholdOnNoisyLine(t *testing.T) {
+	d := NewDefault()
+	feed(d, 700, 200) // steady road noise, never crosses 1200 base
+	thr := d.effectiveThreshold()
+	if thr <= 1200 {
+		t.Fatalf("effectiveThreshold = %.0f, want above the 1200 base on a noisy line", thr)
+	}
+	// The same noise must not now read as speech.
+	if started, _ := feed(d, 700, 50); started {
+		t.Error("steady noise triggered speech after adaptation")
+	}
+	// Real speech well above the noise still triggers.
+	if started, _ := feed(d, 4000, 10); !started {
+		t.Error("loud speech failed to trigger on noisy line")
+	}
+}
+
+// The threshold must never run away past the cap even under absurd noise.
+func TestAdaptiveThresholdCapped(t *testing.T) {
+	d := NewDefault()
+	feed(d, 1100, 500) // continuous near-threshold noise
+	maxThr := 1200 * adaptiveMaxFactor
+	if thr := d.effectiveThreshold(); thr > maxThr {
+		t.Errorf("effectiveThreshold = %.0f, want <= %.0f", thr, maxThr)
+	}
+}
+
+// Before any noise floor is learned the base threshold applies unchanged.
+func TestAdaptiveUsesBaseThresholdInitially(t *testing.T) {
+	d := NewDefault()
+	if thr := d.effectiveThreshold(); thr != 1200 {
+		t.Errorf("initial effectiveThreshold = %.0f, want 1200", thr)
+	}
+}
+
+// Speech frames must not contaminate the noise floor estimate.
+func TestSpeechDoesNotRaiseNoiseFloor(t *testing.T) {
+	d := NewDefault()
+	feed(d, 100, 100) // clean floor
+	floorBefore := d.noiseFloor
+	feed(d, 5000, 100) // sustained speech
+	if d.noiseFloor != floorBefore {
+		t.Errorf("noise floor moved during speech: %.1f → %.1f", floorBefore, d.noiseFloor)
+	}
+}


### PR DESCRIPTION
This pull request introduces several important improvements across audio processing, LLM sentence splitting, peer connection handling, and deployment workflow. The main themes are performance optimizations (buffer reuse, connection pooling), improved protocol compatibility (Opus channel negotiation), and more robust handling of edge cases (audio and sentence boundaries). It also changes deployment to be release-driven instead of push-driven.

**Audio Processing Optimizations and Robustness:**

* [`internal/audio/opus.go`](diffhunk://#diff-469d977544c060ce1bd8e8169518110a93810f7c4a41ecb5120e939c68797c9bR23-R58): Refactored `OpusDecoder` and `OpusEncoder` to reuse internal buffers, significantly reducing per-frame memory allocations and garbage collection overhead. Added detailed comments on concurrency safety and buffer usage. [[1]](diffhunk://#diff-469d977544c060ce1bd8e8169518110a93810f7c4a41ecb5120e939c68797c9bR23-R58) [[2]](diffhunk://#diff-469d977544c060ce1bd8e8169518110a93810f7c4a41ecb5120e939c68797c9bL55-R82)
* [`internal/audio/rtp.go`](diffhunk://#diff-fa93bc1aef1daca6a4bf1aa8c1ee4d5154beea47951638e654dc6aa9afd5202fR5-R39): Added `PCMToLinear16BytesInto`, an allocation-free variant for PCM encoding, and improved `Linear16BytesToPCM` to log and gracefully handle odd-length (corrupt) frames instead of panicking.
* [`internal/audio/rtp_test.go`](diffhunk://#diff-c2294c4b1150cc02e4a14aadf47279a97b4f2dd6c4842511c790cbe59295c335R1-R58): Added tests to verify round-trip encoding/decoding, buffer reuse, and handling of odd-length frames.

**Peer Connection and Opus Channel Negotiation:**

* [`internal/peer/peer.go`](diffhunk://#diff-3263003f3ae07445bf00c6213d7181fe0279a53570e350f32e2449240ebc93c9R80-R106): Now registers both mono and stereo Opus codecs to support both browser and SDK clients. The outbound audio track is created after inspecting the offer, ensuring channel count matches the client. Added SDP parsing helpers and extensive logging for debugging. Also improved network interface filtering for cross-platform compatibility. [[1]](diffhunk://#diff-3263003f3ae07445bf00c6213d7181fe0279a53570e350f32e2449240ebc93c9R80-R106) [[2]](diffhunk://#diff-3263003f3ae07445bf00c6213d7181fe0279a53570e350f32e2449240ebc93c9L108-R136) [[3]](diffhunk://#diff-3263003f3ae07445bf00c6213d7181fe0279a53570e350f32e2449240ebc93c9L146-R175) [[4]](diffhunk://#diff-3263003f3ae07445bf00c6213d7181fe0279a53570e350f32e2449240ebc93c9R256-R281) [[5]](diffhunk://#diff-3263003f3ae07445bf00c6213d7181fe0279a53570e350f32e2449240ebc93c9R290-R295) [[6]](diffhunk://#diff-3263003f3ae07445bf00c6213d7181fe0279a53570e350f32e2449240ebc93c9L269-R367)

**LLM Sentence Splitting and Connection Pooling:**

* [`internal/llm/openai.go`](diffhunk://#diff-b784602960fcf6fb9fb45f82224c87527cf99d94d1276502b1520a04c898eda2R9-R12): The OpenAI client now uses a custom HTTP connection pool for lower-latency streaming and primes the pool on startup. The sentence boundary detector was fixed to avoid splitting inside email addresses, domains, or decimals, improving TTS readback accuracy. [[1]](diffhunk://#diff-b784602960fcf6fb9fb45f82224c87527cf99d94d1276502b1520a04c898eda2R9-R12) [[2]](diffhunk://#diff-b784602960fcf6fb9fb45f82224c87527cf99d94d1276502b1520a04c898eda2L27-R61) [[3]](diffhunk://#diff-b784602960fcf6fb9fb45f82224c87527cf99d94d1276502b1520a04c898eda2R327-R359)
* [`internal/llm/sentence_split_test.go`](diffhunk://#diff-795820b80d31e708871cfa732bf7857e50ae69c2aa8436088a3de8b596ad7f58R1-R35): Added comprehensive tests for sentence boundary detection, including edge cases like email addresses and decimals.

**Deployment Workflow Changes:**

* [`.github/workflows/deploy-ec2.yml`](diffhunk://#diff-3126cbbfdefb2851895ea8a2b674eba99fc264a3c221b8c8a3588205be7e1b1fL3-R4): Deployment is now triggered by publishing a GitHub release or manually, not by pushing to main. Docker image tagging is improved for clarity, and the workflow is streamlined. [[1]](diffhunk://#diff-3126cbbfdefb2851895ea8a2b674eba99fc264a3c221b8c8a3588205be7e1b1fL3-R4) [[2]](diffhunk://#diff-3126cbbfdefb2851895ea8a2b674eba99fc264a3c221b8c8a3588205be7e1b1fL15-R17) [[3]](diffhunk://#diff-3126cbbfdefb2851895ea8a2b674eba99fc264a3c221b8c8a3588205be7e1b1fR46-R63)This pull request introduces several performance optimizations, bug fixes, and feature improvements across the audio, LLM, and peer connection subsystems. The most significant changes include reducing audio pipeline allocations, fixing sentence boundary detection for TTS, improving peer connection compatibility with different clients, and enhancing deployment workflow triggers.

**Audio pipeline optimizations:**

* Significantly reduces per-frame allocations in `OpusDecoder` and `OpusEncoder` by reusing internal buffers, cutting GC churn and improving performance. The decoder now uses a scratch buffer for worst-case decode size, and the encoder reuses its output buffer; both are safe for their respective call patterns. [[1]](diffhunk://#diff-469d977544c060ce1bd8e8169518110a93810f7c4a41ecb5120e939c68797c9bR23-R58) [[2]](diffhunk://#diff-469d977544c060ce1bd8e8169518110a93810f7c4a41ecb5120e939c68797c9bL55-R82)
* Adds allocation-free PCM encoding with `PCMToLinear16BytesInto` in `internal/audio/rtp.go`, allowing hot paths to reuse buffers and avoid unnecessary allocations. Includes tests for round-trip correctness and buffer reuse. [[1]](diffhunk://#diff-fa93bc1aef1daca6a4bf1aa8c1ee4d5154beea47951638e654dc6aa9afd5202fR5-R39) [[2]](diffhunk://#diff-c2294c4b1150cc02e4a14aadf47279a97b4f2dd6c4842511c790cbe59295c335R1-R58)

**LLM/TTS improvements:**

* Fixes sentence splitting in streaming LLM completions: `findSentenceEnd` now avoids splitting inside emails, domains, or decimals, ensuring TTS reads addresses and numbers correctly (e.g., "gmail.com" is not split at the dot). Includes comprehensive tests. [[1]](diffhunk://#diff-b784602960fcf6fb9fb45f82224c87527cf99d94d1276502b1520a04c898eda2R327-R359) [[2]](diffhunk://#diff-795820b80d31e708871cfa732bf7857e50ae69c2aa8436088a3de8b596ad7f58R1-R35)
* Improves OpenAI client connection reuse by configuring a warm HTTP/2 connection pool and priming it in the background, reducing latency for subsequent requests.

**Peer connection and WebRTC compatibility:**

* Registers both mono (`opus/48000/1`) and stereo (`opus/48000/2`) Opus codecs in the media engine, ensuring compatibility with both browser-based and SDK clients. The outbound audio track is now created after inspecting the offer, matching the client's channel layout. [[1]](diffhunk://#diff-3263003f3ae07445bf00c6213d7181fe0279a53570e350f32e2449240ebc93c9R80-R106) [[2]](diffhunk://#diff-3263003f3ae07445bf00c6213d7181fe0279a53570e350f32e2449240ebc93c9L146-R175) [[3]](diffhunk://#diff-3263003f3ae07445bf00c6213d7181fe0279a53570e350f32e2449240ebc93c9R256-R281)
* Refines network interface filtering to support both Linux and macOS interface naming conventions, and delays outbound track creation to the offer handler for correct channel negotiation. [[1]](diffhunk://#diff-3263003f3ae07445bf00c6213d7181fe0279a53570e350f32e2449240ebc93c9L108-R136) [[2]](diffhunk://#diff-3263003f3ae07445bf00c6213d7181fe0279a53570e350f32e2449240ebc93c9L146-R175) [[3]](diffhunk://#diff-3263003f3ae07445bf00c6213d7181fe0279a53570e350f32e2449240ebc93c9L172)
* Adds detailed SDP offer/answer and transceiver direction logging to aid debugging and deployment. [[1]](diffhunk://#diff-3263003f3ae07445bf00c6213d7181fe0279a53570e350f32e2449240ebc93c9R256-R281) [[2]](diffhunk://#diff-3263003f3ae07445bf00c6213d7181fe0279a53570e350f32e2449240ebc93c9R290-R295) [[3]](diffhunk://#diff-3263003f3ae07445bf00c6213d7181fe0279a53570e350f32e2449240ebc93c9L269-R367)

**Deployment workflow update:**

* Changes the `deploy-ec2.yml` workflow to trigger only on GitHub release publication or manual dispatch, not on every push to main. Docker images are now tagged with the release name for easier version tracking. [[1]](diffhunk://#diff-3126cbbfdefb2851895ea8a2b674eba99fc264a3c221b8c8a3588205be7e1b1fL3-R4) [[2]](diffhunk://#diff-3126cbbfdefb2851895ea8a2b674eba99fc264a3c221b8c8a3588205be7e1b1fL15-R17) [[3]](diffhunk://#diff-3126cbbfdefb2851895ea8a2b674eba99fc264a3c221b8c8a3588205be7e1b1fR46-R63)

These changes collectively improve system performance, reliability, and maintainability, especially for high-throughput audio and real-time LLM applications.