### PR TITLE
Llm stt robustness

### DIFF
--- a/.github/workflows/stars-history.yml
+++ b/.github/workflows/stars-history.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: narayann7/star-history-action@v1.0.4
+      # Pinned to an immutable commit SHA rather than the v1.0.4 tag: this is a
+      # third-party action running with contents:write, and a tag can be
+      # repointed at any commit by its author. Keep the trailing comment so
+      # Dependabot still offers version bumps.
+      - uses: narayann7/star-history-action@c2061675dacbf6f35d116e556015b8905843387f # v1.0.4
         with:
           repos: ${{ github.repository }}

--- a/.github/workflows/stars-history.yml
+++ b/.github/workflows/stars-history.yml
@@ -1,0 +1,26 @@
+name: Star History
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  watch:
+    types: [started]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: star-history
+  cancel-in-progress: true
+
+jobs:
+  star-history:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: narayann7/star-history-action@v1.0.4
+        with:
+          repos: ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ A generic HTTP / OpenAI-compatible agent endpoint that requires no Go code is on
 
 | AI integration | Providers |
 |----------------|-----------|
-| Streaming STT | Deepgram, OpenAI, VibeVoice (local) |
+| Streaming STT | Deepgram, AssemblyAI, OpenAI, VibeVoice (local) |
 | LLM | OpenAI, Ollama (local or self-hosted) |
 | Streaming TTS | Cartesia, Deepgram, ElevenLabs, Speechify, VibeVoice (local) |
 | Retrieval | pgvector, Supabase |
@@ -469,7 +469,7 @@ The CLI reads your server's `config.toml` for provider credentials, so nothing i
 
 | Role | Providers | Required credentials |
 |------|-----------|----------------------|
-| STT | `deepgram`, `openai`, `vibevoice` | Deepgram API key, OpenAI API key, or a local VibeVoice ASR server |
+| STT | `deepgram`, `assemblyai`, `openai`, `vibevoice` | Deepgram API key, AssemblyAI API key, OpenAI API key, or a local VibeVoice ASR server |
 | LLM | `openai`, `ollama` | OpenAI API key, or an Ollama instance you control |
 | TTS | `cartesia`, `deepgram`, `elevenlabs`, `speechify`, `vibevoice` | Matching provider API key, or a local VibeVoice TTS server |
 | RAG (optional) | `pgvector`, `supabase` | Postgres connection string or Supabase URL + key, plus an OpenAI key for embeddings |
@@ -706,6 +706,11 @@ Not built yet — listed here so the capability tables above stay honest:
 - **Persistent memory** across sessions.
 - **Broader examples** proving the positioning: realtime translator, AI-hosted voice room, browser copilot, embedded device, SIP application, and a raw audio-processing app with no LLM at all.
 - **Embedded client hardening.** The ESP32-S3 firmware in [`esp32/`](../esp32/) connects over WHIP but is not production-ready.
+
+## Star history
+
+<!-- star-history:start -->
+<!-- star-history:end -->
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ A generic HTTP / OpenAI-compatible agent endpoint that requires no Go code is on
 
 **Clients**
 
-- TypeScript (`@streamcore/js-sdk`), React Native / Expo (`@streamcore/react-native-sdk`), Python (`streamcoreai-sdk`), Go (`github.com/streamcoreai/go-sdk`), Rust
+- TypeScript (`@streamcore/js-sdk`), Python (`streamcore`), Go (`github.com/streamcoreai/go-sdk`), Rust
+- React Native / Expo (`@streamcore/react-native-sdk`) — built, not yet published to npm
 
 ## Supported endpoints and integrations
 
@@ -135,8 +136,8 @@ A generic HTTP / OpenAI-compatible agent endpoint that requires no Go code is on
 | Mobile | Available | React Native / Expo SDK (`react-native-webrtc` peer dependency) |
 | Backend service / worker | Available | Go, Python, or Rust SDK |
 | CLI and TUI | Available | Go and Rust examples |
-| Telephony (SIP) | Available | [`sip-server/`](../sip-server/) bridges PCMU/RTP ↔ Opus/WHIP, inbound and outbound |
-| Embedded device | Experimental | ESP32-S3 firmware in [`esp32/`](../esp32/) speaking WHIP directly |
+| Telephony (SIP) | Available | [`sip-server`](https://github.com/streamcoreai/sip-server) bridges PCMU/RTP ↔ Opus/WHIP, inbound and outbound |
+| Embedded device | Experimental | ESP32-S3 firmware in [`esp32`](https://github.com/streamcoreai/esp32) speaking WHIP directly |
 
 | AI integration | Providers |
 |----------------|-----------|
@@ -445,9 +446,10 @@ table = "documents"
 
 **Ingesting documents**
 
-The server handles query-time retrieval only. Populate your vector store with [`streamcore-cli`](../streamcore-cli/):
+The server handles query-time retrieval only. Populate your vector store with [`streamcore-cli`](https://github.com/streamcoreai/streamcore-cli):
 
 ```bash
+git clone https://github.com/streamcoreai/streamcore-cli
 cd streamcore-cli && go build -o streamcore-cli .
 
 # Supports .txt, .md, .csv, .pdf, .docx, .xlsx
@@ -679,8 +681,8 @@ Notes:
 Client SDKs:
 
 - TypeScript: `@streamcore/js-sdk`
-- React Native / Expo: `@streamcore/react-native-sdk`
-- Python: `streamcoreai-sdk`
+- React Native / Expo: `@streamcore/react-native-sdk` (not yet published to npm)
+- Python: `streamcore`
 - Go: `github.com/streamcoreai/go-sdk`
 - [Rust](https://github.com/streamcoreai/rust-sdk)
 
@@ -705,7 +707,7 @@ Not built yet — listed here so the capability tables above stay honest:
 - **HTTP agent endpoint.** A configurable OpenAI-compatible or webhook-style agent backend, so bring-your-own-agent needs no Go code.
 - **Persistent memory** across sessions.
 - **Broader examples** proving the positioning: realtime translator, AI-hosted voice room, browser copilot, embedded device, SIP application, and a raw audio-processing app with no LLM at all.
-- **Embedded client hardening.** The ESP32-S3 firmware in [`esp32/`](../esp32/) connects over WHIP but is not production-ready.
+- **Embedded client hardening.** The ESP32-S3 firmware in [`esp32`](https://github.com/streamcoreai/esp32) connects over WHIP but is not production-ready.
 
 ## Star history
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -19,7 +19,7 @@ debug = false           # Emit timing events over the DataChannel
 # Provider selection
 
 [stt]
-provider = "deepgram"   # Supported: deepgram, openai, vibevoice
+provider = "deepgram"   # Supported: deepgram, openai, assemblyai, vibevoice
 
 [llm]
 provider = "openai"     # Supported: openai, ollama
@@ -32,6 +32,18 @@ provider = "cartesia"   # Supported: cartesia, deepgram, elevenlabs, speechify, 
 [deepgram]
 api_key = ""            # Required for Deepgram STT, and for Deepgram TTS if selected
 model = "nova-3"        # STT model
+language = ""           # Optional BCP-47 tag (en-US, es-MX). Non-en/es routes to the multilingual model
+endpointing = "300"     # Silence (ms) before a transcript is finalised. Raise it if callers get cut off mid-sentence
+utterance_end_ms = "1000"  # Silence (ms) before an UtteranceEnd event; flushes a turn when no speech_final arrives (min 1000)
+keyterms = []           # Nova-3 only: bias the decoder toward domain words ("Tauranga", product names)
+
+[assemblyai]
+api_key = ""            # Required if stt.provider = "assemblyai"
+model = "u3-rt-pro"     # Universal-Streaming model; "u3-rt" is the cheaper baseline
+language = ""           # Optional BCP-47 tag; region is stripped (en-NZ -> en). Empty auto-detects
+# format_turns = true   # Auto-punctuate and capitalise the final turn
+# end_of_turn_silence_ms = 0   # Override how long the model waits before ending a turn
+keyterms = []           # Bias the decoder toward domain words
 
 [openai]
 api_key = ""            # Required for LLM, and for OpenAI STT if selected
@@ -46,6 +58,9 @@ system_prompt = "You are a helpful AI voice assistant. Keep your responses conci
 [cartesia]
 api_key = ""            # Required if tts.provider = "cartesia"
 voice_id = ""           # Optional; defaults to Cartesia Katie
+ws_url = ""             # Optional; defaults to wss://api.cartesia.ai/tts/websocket
+max_concurrency = 3     # Simultaneous generations before requests queue locally instead of hitting 429s.
+                        # Set to your plan's TTS concurrency limit; negative disables the limiter
 
 [elevenlabs]
 api_key = ""            # Required if tts.provider = "elevenlabs"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	TTS        TTSConfig        `toml:"tts"`
 	RAG        RAGConfig        `toml:"rag"`
 	Deepgram   DeepgramConfig   `toml:"deepgram"`
+	AssemblyAI AssemblyAIConfig `toml:"assemblyai"`
 	OpenAI     OpenAIConfig     `toml:"openai"`
 	Ollama     OllamaConfig     `toml:"ollama"`
 	VibeVoice  VibeVoiceConfig  `toml:"vibevoice"`
@@ -63,6 +64,43 @@ type TTSConfig struct {
 type DeepgramConfig struct {
 	APIKey string `toml:"api_key"`
 	Model  string `toml:"model"`
+	// Language is a BCP-47 tag (e.g. "en-US", "es-MX"). It is mapped to the
+	// language code the Nova-3 model expects; anything outside en/es becomes
+	// "multi". Empty defaults to English.
+	Language string `toml:"language"`
+	// Endpointing is how long (ms, as a string) Deepgram waits for silence
+	// before finalising a transcript. Lower is snappier but fragments natural
+	// mid-sentence pauses ("I want to… um… order a pizza").
+	Endpointing string `toml:"endpointing"`
+	// UtteranceEndMs asks Deepgram to emit an UtteranceEnd event after this
+	// much silence, which the callback uses to flush buffered chunks when no
+	// speech_final arrives. Deepgram requires >= 1000 and interim results.
+	UtteranceEndMs string `toml:"utterance_end_ms"`
+	// Keyterms bias the Nova-3 decoder toward domain vocabulary that is
+	// phonetically ambiguous against common English (product names, place
+	// names). Ignored by other models.
+	Keyterms []string `toml:"keyterms"`
+}
+
+type AssemblyAIConfig struct {
+	APIKey string `toml:"api_key"`
+	// Model selects the Universal-Streaming speech model. Common values:
+	//   - "u3-rt-pro" (Universal-3 Pro, strongest entity capture)
+	//   - "u3-rt"     (Universal-3 baseline, cheaper)
+	Model string `toml:"model"`
+	// Language is a BCP-47 tag; the region is stripped before it is sent as
+	// AssemblyAI's `language_code` (which expects ISO 639-1). Empty lets the
+	// model auto-detect.
+	Language string `toml:"language"`
+	// FormatTurns enables auto-formatted text (capitalisation, punctuation)
+	// on the final turn. Nil means enabled.
+	FormatTurns *bool `toml:"format_turns"`
+	// EndOfTurnSilenceMs tunes how long the model waits before declaring the
+	// turn over. Zero leaves the provider default.
+	EndOfTurnSilenceMs int `toml:"end_of_turn_silence_ms"`
+	// Keyterms are passed as repeated keyterm_prompt parameters to bias the
+	// decoder, mirroring the Deepgram option.
+	Keyterms []string `toml:"keyterms"`
 }
 
 type OpenAIConfig struct {
@@ -80,6 +118,15 @@ type OllamaConfig struct {
 type CartesiaConfig struct {
 	APIKey  string `toml:"api_key"`
 	VoiceID string `toml:"voice_id"`
+	// WSURL overrides the Cartesia WebSocket endpoint. Empty (the default)
+	// talks to wss://api.cartesia.ai/tts/websocket.
+	WSURL string `toml:"ws_url"`
+	// MaxConcurrency caps simultaneous in-flight generations. Cartesia counts
+	// concurrency by active generation context — not by call or connection —
+	// and returns 429 past the account limit, so set this to your plan's TTS
+	// concurrency limit and extra requests queue locally instead of failing.
+	// 0 (unset) defaults to 3; a negative value disables the limiter.
+	MaxConcurrency int `toml:"max_concurrency"`
 }
 
 type ElevenLabsConfig struct {
@@ -136,6 +183,18 @@ func Load(path string) (*Config, error) {
 	setDefault(&cfg.Server.Port, "8080")
 	setDefault(&cfg.STT.Provider, "deepgram")
 	setDefault(&cfg.Deepgram.Model, "nova-3")
+	// 300ms keeps the historical snappy endpointing. utterance_end_ms has no
+	// prior value; 1000 is Deepgram's minimum and switches on the UtteranceEnd
+	// flush that recovers a turn when no speech_final arrives.
+	setDefault(&cfg.Deepgram.Endpointing, "300")
+	setDefault(&cfg.Deepgram.UtteranceEndMs, "1000")
+	setDefault(&cfg.AssemblyAI.Model, "u3-rt-pro")
+	// Cartesia counts concurrency by active generation context; 3 comfortably
+	// serves many concurrent calls because agent speech is bursty and
+	// half-duplex. Negative disables the limiter.
+	if cfg.Cartesia.MaxConcurrency == 0 {
+		cfg.Cartesia.MaxConcurrency = 3
+	}
 	setDefault(&cfg.LLM.Provider, "openai")
 	setDefault(&cfg.TTS.Provider, "cartesia")
 	setDefault(&cfg.OpenAI.Model, "gpt-4o-mini")

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -121,6 +121,13 @@ func (c *openaiClient) AppendSystemPrompt(text string) {
 // continues until the LLM produces a text response.
 func (c *openaiClient) Chat(ctx context.Context, userText string, onChunk func(string), onSentence func(string)) (string, error) {
 	c.mu.Lock()
+	// Reconcile history before adding the new user message. If a previous
+	// Chat call was interrupted mid-tool-execution (barge-in or new turn),
+	// the history may contain an assistant message with tool_calls but no
+	// corresponding tool result messages. OpenAI rejects this. Patch any
+	// dangling tool_call_ids with error placeholders so the conversation
+	// stays valid.
+	c.reconcileHistory()
 	c.history = append(c.history, openai.ChatCompletionMessage{
 		Role:    openai.ChatMessageRoleUser,
 		Content: userText,
@@ -128,7 +135,17 @@ func (c *openaiClient) Chat(ctx context.Context, userText string, onChunk func(s
 	c.mu.Unlock()
 
 	// Tool-call loop: LLM may request tools multiple times before answering.
-	const maxToolRounds = 10
+	// Capped conservatively — most legitimate flows complete in <= 2 rounds.
+	// Higher caps just let broken prompts rack up latency.
+	const maxToolRounds = 4
+
+	// Track (name|args) signatures across rounds so we can break out of
+	// pathological loops where the LLM keeps calling the same tool with the
+	// same arguments after it errored (seen when the user requests a
+	// capability that isn't enabled — the model desperately retries unrelated
+	// tools instead of giving up).
+	seenCalls := make(map[string]int)
+
 	for round := 0; ; round++ {
 		result, toolCalls, err := c.streamCompletion(ctx, onChunk, onSentence)
 		if err != nil {
@@ -142,7 +159,8 @@ func (c *openaiClient) Chat(ctx context.Context, userText string, onChunk func(s
 
 		if round >= maxToolRounds {
 			log.Printf("[llm] exceeded %d tool-call rounds, stopping", maxToolRounds)
-			return result, nil
+			return c.forceTextResponse(ctx, onChunk, onSentence,
+				"You've used your tool-call budget for this turn. Reply to the user in plain text now without calling any more tools.")
 		}
 
 		// Execute tool calls and feed results back.
@@ -155,15 +173,35 @@ func (c *openaiClient) Chat(ctx context.Context, userText string, onChunk func(s
 			return result, nil
 		}
 
+		repeatedAll := true
 		for _, tc := range toolCalls {
+			sig := tc.Name + "|" + string(tc.Arguments)
+			prev := seenCalls[sig]
+
 			log.Printf("[llm] tool call: %s(%s)", tc.Name, truncate(string(tc.Arguments), 100))
 
-			output, err := handler(ctx, tc)
-			if err != nil {
-				output = fmt.Sprintf("Error: %v", err)
+			var output string
+			if prev >= 1 {
+				// Model asked for the exact same call again — short-circuit
+				// with a terse note rather than re-running the tool.
+				output = fmt.Sprintf(
+					"The tool %s was already called with these arguments in this turn and returned the same result. Do not call it again; answer the user directly.",
+					tc.Name,
+				)
+				log.Printf("[llm] skipping duplicate tool call: %s", tc.Name)
+			} else {
+				repeatedAll = false
+				out, err := handler(ctx, tc)
+				if err != nil {
+					output = fmt.Sprintf("Error: %v", err)
+				} else {
+					output = out
+					// Only mark as seen on success so the LLM can retry
+					// after transient errors (e.g. broken pipe).
+					seenCalls[sig] = prev + 1
+				}
+				log.Printf("[llm] tool result: %s", truncate(output, 100))
 			}
-
-			log.Printf("[llm] tool result: %s", truncate(output, 100))
 
 			c.mu.Lock()
 			c.history = append(c.history, openai.ChatCompletionMessage{
@@ -173,7 +211,109 @@ func (c *openaiClient) Chat(ctx context.Context, userText string, onChunk func(s
 			})
 			c.mu.Unlock()
 		}
+
+		// Every tool call this round was a duplicate of a previous call.
+		// The model is stuck in a loop — force a text response instead of
+		// letting it burn another round.
+		if repeatedAll {
+			log.Printf("[llm] all tool calls in round %d were duplicates, forcing text response", round)
+			return c.forceTextResponse(ctx, onChunk, onSentence,
+				"Stop calling tools. Reply to the user in plain text explaining what you can and cannot help with based on the tools available in this session.")
+		}
 	}
+}
+
+// reconcileHistory patches any assistant tool_calls that never received a
+// matching tool result — the state left behind when a turn is cancelled
+// mid-execution by a barge-in. OpenAI rejects such a history outright, so a
+// single interrupted tool call would otherwise break every later turn in the
+// call.
+func (c *openaiClient) reconcileHistory() {
+	// Pass 1: collect every tool_call_id an assistant asked for, plus every
+	// tool result already present.
+	type pendingRef struct {
+		assistantIdx int
+		callID       string
+	}
+	var pending []pendingRef
+	answered := make(map[string]bool)
+
+	for i, msg := range c.history {
+		if msg.Role == openai.ChatMessageRoleAssistant {
+			for _, tc := range msg.ToolCalls {
+				pending = append(pending, pendingRef{assistantIdx: i, callID: tc.ID})
+			}
+		}
+		if msg.Role == openai.ChatMessageRoleTool {
+			answered[msg.ToolCallID] = true
+		}
+	}
+	if len(pending) == 0 {
+		return
+	}
+
+	// Pass 2: build a placeholder result for each unanswered call, tagged
+	// with the assistant message it must follow.
+	type patch struct {
+		insertAfter int
+		msg         openai.ChatCompletionMessage
+	}
+	var patches []patch
+	for _, p := range pending {
+		if answered[p.callID] {
+			continue
+		}
+		log.Printf("[llm] reconciling dangling tool_call_id=%s (cancelled mid-execution)", p.callID)
+		patches = append(patches, patch{
+			insertAfter: p.assistantIdx,
+			msg: openai.ChatCompletionMessage{
+				Role:       openai.ChatMessageRoleTool,
+				Content:    "Tool execution was cancelled.",
+				ToolCallID: p.callID,
+			},
+		})
+		// Defensive: mark answered so a duplicate ID can't be patched twice.
+		answered[p.callID] = true
+	}
+	if len(patches) == 0 {
+		return
+	}
+
+	// Pass 3: splice from the back so earlier indices stay valid.
+	for i, j := 0, len(patches)-1; i < j; i, j = i+1, j-1 {
+		patches[i], patches[j] = patches[j], patches[i]
+	}
+	for _, p := range patches {
+		insertAt := p.insertAfter + 1
+		c.history = append(
+			c.history[:insertAt],
+			append([]openai.ChatCompletionMessage{p.msg}, c.history[insertAt:]...)...,
+		)
+	}
+}
+
+// forceTextResponse nudges the model into a text reply when the tool-call loop
+// would otherwise spin. We inject a strongly-worded system message and make a
+// follow-up streaming request; tool use is still technically available but the
+// instruction plus the preceding duplicate results usually suffice.
+func (c *openaiClient) forceTextResponse(ctx context.Context, onChunk, onSentence func(string), instruction string) (string, error) {
+	c.mu.Lock()
+	c.history = append(c.history, openai.ChatCompletionMessage{
+		Role:    openai.ChatMessageRoleSystem,
+		Content: instruction,
+	})
+	c.mu.Unlock()
+
+	result, toolCalls, err := c.streamCompletion(ctx, onChunk, onSentence)
+	if err != nil {
+		return result, err
+	}
+	if len(toolCalls) > 0 {
+		// The model still insisted on tool calls. Drop them silently and
+		// return whatever text we captured; avoids another round.
+		log.Printf("[llm] force-text fallback still requested %d tool calls, ignoring", len(toolCalls))
+	}
+	return result, nil
 }
 
 // streamCompletion runs one streaming request and returns either a text response
@@ -223,7 +363,7 @@ func (c *openaiClient) streamCompletion(ctx context.Context, onChunk func(string
 
 		// Handle tool call deltas
 		for _, tc := range delta.ToolCalls {
-			idx := *tc.Index
+			idx := toolCallDeltaIndex(tc)
 			existing, ok := toolCallMap[idx]
 			if !ok {
 				existing = &ToolCall{}
@@ -322,6 +462,18 @@ func (c *openaiClient) streamCompletion(ctx context.Context, onChunk func(string
 
 	log.Printf("[llm] response: %s", truncate(fullResponse.String(), 80))
 	return fullResponse.String(), nil, nil
+}
+
+// toolCallDeltaIndex returns the stream tool-call index, defaulting to 0 when
+// the provider omits it. The go-openai SDK types Index as *int and documents
+// it as non-nil only in streaming chunks, but OpenAI-compatible backends and
+// proxies don't always populate it — dereferencing a nil pointer here would
+// panic and kill the call's goroutine mid-turn, so guard it.
+func toolCallDeltaIndex(tc openai.ToolCall) int {
+	if tc.Index == nil {
+		return 0
+	}
+	return *tc.Index
 }
 
 // findSentenceEnd returns the index of the latest sentence-terminating

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -1,0 +1,130 @@
+package llm
+
+import (
+	"testing"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+// TestToolCallDeltaIndex guards the streaming tool-call index against a nil
+// Index pointer, which OpenAI-compatible backends/proxies can send and which
+// would otherwise panic the call's goroutine mid-turn.
+func TestToolCallDeltaIndex(t *testing.T) {
+	if got := toolCallDeltaIndex(openai.ToolCall{}); got != 0 {
+		t.Errorf("nil Index = %d, want 0", got)
+	}
+	for _, want := range []int{0, 1, 5} {
+		idx := want
+		if got := toolCallDeltaIndex(openai.ToolCall{Index: &idx}); got != want {
+			t.Errorf("Index=%d => %d, want %d", want, got, want)
+		}
+	}
+}
+
+func assistantWithCalls(ids ...string) openai.ChatCompletionMessage {
+	msg := openai.ChatCompletionMessage{Role: openai.ChatMessageRoleAssistant}
+	for _, id := range ids {
+		msg.ToolCalls = append(msg.ToolCalls, openai.ToolCall{ID: id})
+	}
+	return msg
+}
+
+func toolResult(id string) openai.ChatCompletionMessage {
+	return openai.ChatCompletionMessage{
+		Role:       openai.ChatMessageRoleTool,
+		Content:    "ok",
+		ToolCallID: id,
+	}
+}
+
+// checkWellFormed asserts the invariant OpenAI enforces: every assistant
+// tool_call id is answered by a tool message that appears after it.
+func checkWellFormed(t *testing.T, h []openai.ChatCompletionMessage) {
+	t.Helper()
+	answeredAt := make(map[string]int)
+	for i, msg := range h {
+		if msg.Role == openai.ChatMessageRoleTool {
+			answeredAt[msg.ToolCallID] = i
+		}
+	}
+	for i, msg := range h {
+		if msg.Role != openai.ChatMessageRoleAssistant {
+			continue
+		}
+		for _, tc := range msg.ToolCalls {
+			at, ok := answeredAt[tc.ID]
+			if !ok {
+				t.Errorf("tool_call %q has no result", tc.ID)
+			} else if at <= i {
+				t.Errorf("tool_call %q answered at %d, before its assistant message at %d", tc.ID, at, i)
+			}
+		}
+	}
+}
+
+// A turn cancelled mid-tool-execution leaves an assistant tool_calls message
+// with no matching result. OpenAI rejects that outright, so every later turn
+// in the call would fail until the history is patched.
+func TestReconcileHistoryPatchesDanglingCalls(t *testing.T) {
+	cases := []struct {
+		name    string
+		history []openai.ChatCompletionMessage
+		want    int // expected length after reconciliation
+	}{
+		{
+			name: "already complete — untouched",
+			history: []openai.ChatCompletionMessage{
+				{Role: openai.ChatMessageRoleSystem},
+				assistantWithCalls("a"),
+				toolResult("a"),
+			},
+			want: 3,
+		},
+		{
+			name: "single dangling call",
+			history: []openai.ChatCompletionMessage{
+				{Role: openai.ChatMessageRoleSystem},
+				assistantWithCalls("a"),
+			},
+			want: 3,
+		},
+		{
+			name: "partially answered multi-call",
+			history: []openai.ChatCompletionMessage{
+				{Role: openai.ChatMessageRoleSystem},
+				assistantWithCalls("a", "b"),
+				toolResult("a"),
+			},
+			want: 4,
+		},
+		{
+			name: "dangling call in an earlier round, later rounds intact",
+			history: []openai.ChatCompletionMessage{
+				{Role: openai.ChatMessageRoleSystem},
+				assistantWithCalls("a"),
+				{Role: openai.ChatMessageRoleUser, Content: "next turn"},
+				assistantWithCalls("b"),
+				toolResult("b"),
+			},
+			want: 6,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &openaiClient{history: tc.history}
+			c.reconcileHistory()
+
+			if len(c.history) != tc.want {
+				t.Fatalf("history length = %d, want %d", len(c.history), tc.want)
+			}
+			checkWellFormed(t, c.history)
+
+			// Reconciliation must be idempotent — a second pass adds nothing.
+			c.reconcileHistory()
+			if len(c.history) != tc.want {
+				t.Errorf("second pass changed length to %d, want %d", len(c.history), tc.want)
+			}
+		})
+	}
+}

--- a/internal/pipeline/agent.go
+++ b/internal/pipeline/agent.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/streamcoreai/server/internal/audio"
+	"github.com/streamcoreai/server/internal/tts"
 )
 
 // runAgent is the central orchestrator goroutine. It receives transcript
@@ -138,12 +139,15 @@ func (p *Pipeline) respond(userText string, turnStart time.Time) {
 					Ms:    time.Since(turnStart).Milliseconds(),
 				})
 			}
-			// Accumulate response text for interruption context
+			// Accumulate response text for interruption context. Delivery tags
+			// are stripped: this text is quoted back to the LLM verbatim when
+			// the user barges in, and feeding it "[warm] ..." would teach the
+			// model that tags are part of normal prose.
+			acc := chunk
 			if prev, _ := p.lastAgentText.Load().(string); prev != "" {
-				p.lastAgentText.Store(prev + chunk)
-			} else {
-				p.lastAgentText.Store(chunk)
+				acc = prev + chunk
 			}
+			p.lastAgentText.Store(tts.StripVoiceTags(acc))
 			p.sendEvent(responseMsg{
 				Type: "response",
 				Text: chunk,
@@ -168,65 +172,111 @@ func (p *Pipeline) respond(userText string, turnStart time.Time) {
 // synthesizeSentences reads sentences from the channel, calls TTS for each,
 // and pushes the resulting PCM frames into outPCMCh for the sender goroutine.
 func (p *Pipeline) synthesizeSentences(ctx context.Context, sentences <-chan string, turnStart time.Time) {
-	firstSentence := true
 	emittedTTSTiming := false
 	emittedSpeaking := false
+
+	// leftover holds samples that did not fill a complete frame. Streaming
+	// chunks arrive on arbitrary byte boundaries, so the remainder carries
+	// into the next chunk rather than being padded with silence mid-utterance,
+	// which would insert an audible click every chunk.
+	var leftover []int16
+	talkspurtSent := false
+
+	emitFrame := func(frame PCMFrame) bool {
+		select {
+		case p.outPCMCh <- frame:
+			if !emittedTTSTiming && p.cfg.Pipeline.Debug && !turnStart.IsZero() {
+				emittedTTSTiming = true
+				p.sendEvent(timingMsg{
+					Type:  "timing",
+					Stage: "tts_first_byte",
+					Ms:    time.Since(turnStart).Milliseconds(),
+				})
+			}
+			// Send "speaking" state when the first audio frame is actually
+			// produced, not when respond() begins. This keeps the "thinking"
+			// state visible while the LLM and TTS are working.
+			if !emittedSpeaking {
+				emittedSpeaking = true
+				p.speaking.Store(true)
+				p.sendEvent(stateMsg{Type: "state", State: "speaking"})
+			}
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
 
 	for sentence := range sentences {
 		if ctx.Err() != nil {
 			return
 		}
 
-		pcmBytes, err := p.ttsClient.Synthesize(ctx, sentence)
+		// The LLM may prefix a sentence with a delivery tag ([warm], [calm], …)
+		// per the voice-output rules. The tag is stripped here — the caller
+		// never hears it — and mapped to provider voice controls when the
+		// configured TTS supports them.
+		controls, clean := tts.ParseVoiceTag(sentence)
+
+		// Stream so audio starts playing as soon as the first PCM chunk
+		// arrives, instead of waiting for the whole sentence to synthesize.
+		var stream <-chan tts.StreamChunk
+		var err error
+		if cs, ok := p.ttsClient.(tts.ControllableStreamer); ok && !controls.IsZero() {
+			stream, err = cs.SynthesizeStreamWithControls(ctx, clean, controls)
+		} else {
+			stream, err = p.ttsClient.SynthesizeStream(ctx, clean)
+		}
 		if err != nil {
 			if ctx.Err() == nil {
-				log.Printf("[agent] TTS error: %v", err)
+				log.Printf("[agent] TTS stream error: %v", err)
 			}
 			return
 		}
 
-		pcm := audio.Linear16BytesToPCM(pcmBytes)
-
-		for i := 0; i < len(pcm); i += audio.FrameSize {
-			end := i + audio.FrameSize
-			var samples []int16
-			if end > len(pcm) {
-				// Pad last frame with silence
-				samples = make([]int16, audio.FrameSize)
-				copy(samples, pcm[i:])
-			} else {
-				samples = pcm[i:end]
-			}
-
-			frame := PCMFrame{
-				Samples:      samples,
-				NewTalkspurt: (i == 0 && firstSentence),
-			}
-
-			select {
-			case p.outPCMCh <- frame:
-				if !emittedTTSTiming && p.cfg.Pipeline.Debug && !turnStart.IsZero() {
-					emittedTTSTiming = true
-					p.sendEvent(timingMsg{
-						Type:  "timing",
-						Stage: "tts_first_byte",
-						Ms:    time.Since(turnStart).Milliseconds(),
-					})
+		for chunk := range stream {
+			if chunk.Err != nil {
+				if ctx.Err() == nil {
+					log.Printf("[agent] TTS error: %v", chunk.Err)
 				}
-				// Send "speaking" state when the first audio frame is
-				// actually produced, not when respond() begins. This
-				// keeps the "thinking" state visible while the LLM and
-				// TTS are working.
-				if !emittedSpeaking {
-					emittedSpeaking = true
-					p.speaking.Store(true)
-					p.sendEvent(stateMsg{Type: "state", State: "speaking"})
-				}
-			case <-ctx.Done():
 				return
 			}
+			if ctx.Err() != nil {
+				return
+			}
+
+			samples := append(leftover, audio.Linear16BytesToPCM(chunk.PCM)...)
+			leftover = nil
+
+			// Emit complete frames only; the partial tail waits for the next
+			// chunk, or is flushed once every sentence is done.
+			i := 0
+			for ; i+audio.FrameSize <= len(samples); i += audio.FrameSize {
+				frame := PCMFrame{
+					Samples:      make([]int16, audio.FrameSize),
+					NewTalkspurt: !talkspurtSent,
+				}
+				copy(frame.Samples, samples[i:i+audio.FrameSize])
+				talkspurtSent = true
+				if !emitFrame(frame) {
+					return
+				}
+			}
+			if i < len(samples) {
+				leftover = append([]int16{}, samples[i:]...)
+			}
 		}
-		firstSentence = false
+	}
+
+	// Flush the final partial frame, padded with silence. Only the very end of
+	// the turn gets padding, so the click lands where the agent stops talking.
+	if len(leftover) > 0 {
+		frame := PCMFrame{
+			Samples:      make([]int16, audio.FrameSize),
+			NewTalkspurt: !talkspurtSent,
+		}
+		copy(frame.Samples, leftover)
+		emitFrame(frame)
 	}
 }
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -203,6 +203,17 @@ func New(
 		}
 	}
 
+	// Teach the model the optional delivery tags. Without this rule the tag
+	// vocabulary is never emitted and ParseVoiceTag simply never fires, so
+	// voice controls stay at provider defaults.
+	llmClient.AppendSystemPrompt(
+		"\n\nOPTIONAL tone control: you may start a sentence with exactly one tag from " +
+			"[warm] [empathetic] [calm] [excited] to shape how it is spoken — e.g. " +
+			"\"[empathetic] I'm really sorry to hear that.\" Use it sparingly, only when the " +
+			"moment calls for it (apologies, bad news, congratulations). The tag is never " +
+			"spoken aloud. Never invent other tags.",
+	)
+
 	// Initialize atomic values with empty strings for type consistency.
 	p.lastAgentText.Store("")
 	p.interruptedText.Store("")

--- a/internal/stt/assemblyai.go
+++ b/internal/stt/assemblyai.go
@@ -1,0 +1,322 @@
+package stt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/streamcoreai/server/internal/config"
+)
+
+// AssemblyAI Universal-Streaming v3 protocol notes
+// -----------------------------------------------
+//   Endpoint:  wss://streaming.assemblyai.com/v3/ws
+//   Auth:      Authorization: <API_KEY>   (no "Bearer" prefix)
+//   Audio:     raw 16-bit signed little-endian PCM at 16kHz mono, sent as
+//              binary WebSocket frames.
+//   Messages:  JSON text frames. Discriminator is the "type" field.
+//              - "Begin"        — session started
+//              - "Turn"         — partial or final transcript for the current
+//                                  turn; `end_of_turn=true` marks the final
+//              - "Termination"  — session ended
+//   Shutdown:  send {"type":"Terminate"} as a text frame, then close the conn.
+//
+// The client below mirrors the shape of NewDeepgramClient: it returns a value
+// that satisfies the stt.Client interface (SendAudio + Close) and forwards
+// transcript events through the provided onResult callback.
+
+const (
+	assemblyAIStreamURL  = "wss://streaming.assemblyai.com/v3/ws"
+	assemblyAISampleRate = 16000
+
+	// Websocket write deadline guards against a hung remote — if a single
+	// audio frame takes longer than this to flush, something is wrong and
+	// we'd rather error than wedge the audio pipeline.
+	assemblyAIWriteTimeout = 5 * time.Second
+)
+
+type assemblyAIClient struct {
+	conn     *websocket.Conn
+	onResult func(TranscriptResult)
+	ctx      context.Context
+	cancel   context.CancelFunc
+
+	writeMu sync.Mutex // gorilla/websocket requires single concurrent writer
+	closed  atomic.Bool
+	readWG  sync.WaitGroup
+
+	// lastFinal/lastFinalAt deduplicate identical finals emitted within a
+	// short window, matching deepgram.go's recentFinalSuppressWindow guard.
+	mu                sync.Mutex
+	lastEmittedText   string
+	lastEmittedFinal  string
+	lastFinalAt       time.Time
+	suppressDuplicate time.Duration
+}
+
+func NewAssemblyAIClient(ctx context.Context, cfg config.AssemblyAIConfig, onResult func(TranscriptResult)) (*assemblyAIClient, error) {
+	if cfg.APIKey == "" {
+		return nil, fmt.Errorf("assemblyai: api_key is required")
+	}
+
+	sttCtx, cancel := context.WithCancel(ctx)
+
+	endpoint := buildAssemblyAIURL(cfg)
+	header := http.Header{}
+	header.Set("Authorization", cfg.APIKey)
+
+	dialer := websocket.Dialer{
+		HandshakeTimeout: 10 * time.Second,
+	}
+
+	conn, _, err := dialer.DialContext(sttCtx, endpoint, header)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("assemblyai: dial: %w", err)
+	}
+
+	c := &assemblyAIClient{
+		conn:              conn,
+		onResult:          onResult,
+		ctx:               sttCtx,
+		cancel:            cancel,
+		suppressDuplicate: 5 * time.Second,
+	}
+
+	c.readWG.Add(1)
+	go c.readLoop()
+
+	log.Printf("[stt:assemblyai] connected (model=%s)", cfg.Model)
+	if len(cfg.Keyterms) > 0 {
+		log.Printf("[stt:assemblyai] keyterms loaded: count=%d", len(cfg.Keyterms))
+	}
+	return c, nil
+}
+
+// assemblyAILanguageCode maps a tenant BCP-47 locale (e.g. "en-IN", "es-US")
+// to AssemblyAI's `language_code` query parameter, which expects ISO 639-1
+// (e.g. "en", "es"). Empty input returns empty so we omit the parameter and
+// let the model auto-detect.
+func assemblyAILanguageCode(locale string) string {
+	base := strings.ToLower(strings.TrimSpace(locale))
+	if idx := strings.Index(base, "-"); idx > 0 {
+		base = base[:idx]
+	}
+	return base
+}
+
+// buildAssemblyAIURL composes the wss endpoint with query parameters.
+// Kept as a free function so it's trivial to unit-test if needed.
+func buildAssemblyAIURL(cfg config.AssemblyAIConfig) string {
+	q := url.Values{}
+	q.Set("sample_rate", strconv.Itoa(assemblyAISampleRate))
+	q.Set("encoding", "pcm_s16le")
+	if cfg.Model != "" {
+		q.Set("speech_model", cfg.Model)
+	}
+	if code := assemblyAILanguageCode(cfg.Language); code != "" {
+		q.Set("language_code", code)
+	}
+	formatTurns := true
+	if cfg.FormatTurns != nil {
+		formatTurns = *cfg.FormatTurns
+	}
+	if formatTurns {
+		q.Set("format_turns", "true")
+	} else {
+		q.Set("format_turns", "false")
+	}
+	if cfg.EndOfTurnSilenceMs > 0 {
+		q.Set("end_of_turn_confidence_threshold_silence_duration_ms", strconv.Itoa(cfg.EndOfTurnSilenceMs))
+	}
+	if len(cfg.Keyterms) > 0 {
+		// AssemblyAI accepts repeated keyterm_prompt params.
+		for _, kw := range cfg.Keyterms {
+			if strings.TrimSpace(kw) != "" {
+				q.Add("keyterm_prompt", kw)
+			}
+		}
+	}
+	return assemblyAIStreamURL + "?" + q.Encode()
+}
+
+// SendAudio forwards raw linear16 PCM bytes to AssemblyAI as a binary frame.
+// Returns an error if the connection is closed or the write times out.
+func (c *assemblyAIClient) SendAudio(data []byte) error {
+	if c.closed.Load() {
+		return fmt.Errorf("assemblyai: client closed")
+	}
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	if err := c.conn.SetWriteDeadline(time.Now().Add(assemblyAIWriteTimeout)); err != nil {
+		return fmt.Errorf("assemblyai: set write deadline: %w", err)
+	}
+	if err := c.conn.WriteMessage(websocket.BinaryMessage, data); err != nil {
+		return fmt.Errorf("assemblyai: write audio: %w", err)
+	}
+	return nil
+}
+
+// Close gracefully shuts down the AssemblyAI session: sends Terminate, closes
+// the socket, cancels the context, and waits for the read loop to exit.
+func (c *assemblyAIClient) Close() {
+	if !c.closed.CompareAndSwap(false, true) {
+		return
+	}
+
+	c.writeMu.Lock()
+	_ = c.conn.SetWriteDeadline(time.Now().Add(assemblyAIWriteTimeout))
+	_ = c.conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"Terminate"}`))
+	c.writeMu.Unlock()
+
+	_ = c.conn.Close()
+	c.cancel()
+	c.readWG.Wait()
+	log.Println("[stt:assemblyai] closed")
+}
+
+// assemblyAITurnMsg is the subset of the v3 Turn message we care about.
+// Unknown fields are silently ignored by encoding/json.
+type assemblyAITurnMsg struct {
+	Type            string           `json:"type"`
+	TurnOrder       int              `json:"turn_order"`
+	Transcript      string           `json:"transcript"`
+	EndOfTurn       bool             `json:"end_of_turn"`
+	TurnIsFormatted bool             `json:"turn_is_formatted"`
+	EndOfTurnConf   float64          `json:"end_of_turn_confidence"`
+	Words           []assemblyAIWord `json:"words"`
+}
+
+// assemblyAIWord is one element of the v3 Turn `words` array. We only consume
+// the confidence; the text/timestamps are already reflected in `transcript`.
+type assemblyAIWord struct {
+	Confidence float64 `json:"confidence"`
+}
+
+// transcriptConfidence returns the mean per-word confidence for the turn, or
+// 0 if no per-word confidences are available. AssemblyAI's v3 Turn message
+// does not carry an aggregate transcript confidence, so we synthesise one
+// from the word array (analogous to Deepgram's Alternative.Confidence).
+func (t assemblyAITurnMsg) transcriptConfidence() float64 {
+	if len(t.Words) == 0 {
+		return 0
+	}
+	var sum float64
+	var n int
+	for _, w := range t.Words {
+		if w.Confidence > 0 {
+			sum += w.Confidence
+			n++
+		}
+	}
+	if n == 0 {
+		return 0
+	}
+	return sum / float64(n)
+}
+
+type assemblyAIErrorMsg struct {
+	Type    string `json:"type"`
+	Error   string `json:"error"`
+	Message string `json:"message"`
+}
+
+func (c *assemblyAIClient) readLoop() {
+	defer c.readWG.Done()
+	for {
+		if c.ctx.Err() != nil {
+			return
+		}
+
+		msgType, payload, err := c.conn.ReadMessage()
+		if err != nil {
+			if !c.closed.Load() {
+				log.Printf("[stt:assemblyai] read error: %v", err)
+			}
+			return
+		}
+		if msgType != websocket.TextMessage {
+			continue
+		}
+
+		// Peek at the discriminator without unmarshalling the full payload twice.
+		var head struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(payload, &head); err != nil {
+			log.Printf("[stt:assemblyai] bad json: %v", err)
+			continue
+		}
+
+		switch head.Type {
+		case "Begin":
+			log.Println("[stt:assemblyai] session started")
+		case "Turn":
+			var turn assemblyAITurnMsg
+			if err := json.Unmarshal(payload, &turn); err != nil {
+				log.Printf("[stt:assemblyai] bad turn payload: %v", err)
+				continue
+			}
+			c.handleTurn(turn)
+		case "Termination":
+			log.Println("[stt:assemblyai] session terminated by server")
+			return
+		case "Error":
+			var e assemblyAIErrorMsg
+			_ = json.Unmarshal(payload, &e)
+			log.Printf("[stt:assemblyai] error message: error=%q message=%q", e.Error, e.Message)
+		default:
+			// Unknown event — log once at trace level. Don't spam.
+			log.Printf("[stt:assemblyai] unhandled event type=%q", head.Type)
+		}
+	}
+}
+
+func (c *assemblyAIClient) handleTurn(t assemblyAITurnMsg) {
+	text := strings.TrimSpace(t.Transcript)
+	if text == "" {
+		return
+	}
+
+	confidence := t.transcriptConfidence()
+
+	if t.EndOfTurn {
+		// AssemblyAI emits the same end-of-turn twice when format_turns=true:
+		// once unformatted, once formatted. Prefer the formatted version when
+		// present. Either way, suppress duplicates of the same final within
+		// the recent-final window.
+		c.mu.Lock()
+		if sameTranscript(text, c.lastEmittedFinal) && time.Since(c.lastFinalAt) < c.suppressDuplicate {
+			c.mu.Unlock()
+			return
+		}
+		c.lastEmittedFinal = text
+		c.lastFinalAt = time.Now()
+		c.lastEmittedText = ""
+		c.mu.Unlock()
+		log.Printf("[stt:assemblyai] final: %q (formatted=%v eot_conf=%.2f conf=%.2f)", text, t.TurnIsFormatted, t.EndOfTurnConf, confidence)
+		c.onResult(TranscriptResult{Text: text, IsFinal: true, Confidence: confidence})
+		return
+	}
+
+	// Partial — drop dupes so barge-in/UI logic doesn't see repeats.
+	c.mu.Lock()
+	if sameTranscript(text, c.lastEmittedText) {
+		c.mu.Unlock()
+		return
+	}
+	c.lastEmittedText = text
+	c.mu.Unlock()
+	log.Printf("[stt:assemblyai] partial: %q (conf=%.2f)", text, confidence)
+	c.onResult(TranscriptResult{Text: text, IsFinal: false, Confidence: confidence})
+}

--- a/internal/stt/assemblyai_test.go
+++ b/internal/stt/assemblyai_test.go
@@ -1,0 +1,224 @@
+package stt
+
+import (
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/streamcoreai/server/internal/config"
+)
+
+func TestAssemblyAILanguageCode(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"en", "en"},
+		{"en-US", "en"},
+		{"en-IN", "en"},
+		{"  es-MX  ", "es"},
+		{"zh-CN", "zh"},
+	}
+	for _, tc := range tests {
+		if got := assemblyAILanguageCode(tc.in); got != tc.want {
+			t.Errorf("assemblyAILanguageCode(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestBuildAssemblyAIURL_Defaults(t *testing.T) {
+	raw := buildAssemblyAIURL(config.AssemblyAIConfig{})
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if u.Scheme != "wss" || u.Host != "streaming.assemblyai.com" || u.Path != "/v3/ws" {
+		t.Fatalf("unexpected base url: %s", raw)
+	}
+	q := u.Query()
+	if q.Get("sample_rate") != "16000" {
+		t.Errorf("sample_rate not set to 16000: got %q", q.Get("sample_rate"))
+	}
+	if q.Get("encoding") != "pcm_s16le" {
+		t.Errorf("encoding not pcm_s16le: got %q", q.Get("encoding"))
+	}
+	if q.Get("format_turns") != "true" {
+		t.Errorf("format_turns should default true: got %q", q.Get("format_turns"))
+	}
+	if q.Get("speech_model") != "" {
+		t.Errorf("speech_model should be omitted when empty: got %q", q.Get("speech_model"))
+	}
+}
+
+func TestBuildAssemblyAIURL_AllOptions(t *testing.T) {
+	off := false
+	cfg := config.AssemblyAIConfig{
+		Model:              "u3-rt-pro",
+		Language:           "en-IN",
+		FormatTurns:        &off,
+		EndOfTurnSilenceMs: 500,
+		Keyterms:           []string{"Rediffmail", "Krishnamurthy", ""},
+	}
+	raw := buildAssemblyAIURL(cfg)
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	q := u.Query()
+	if q.Get("speech_model") != "u3-rt-pro" {
+		t.Errorf("speech_model = %q", q.Get("speech_model"))
+	}
+	if q.Get("language_code") != "en" {
+		t.Errorf("language_code = %q want en", q.Get("language_code"))
+	}
+	if q.Get("format_turns") != "false" {
+		t.Errorf("format_turns = %q want false", q.Get("format_turns"))
+	}
+	if q.Get("end_of_turn_confidence_threshold_silence_duration_ms") != "500" {
+		t.Errorf("silence duration = %q", q.Get("end_of_turn_confidence_threshold_silence_duration_ms"))
+	}
+	terms := q["keyterm_prompt"]
+	if len(terms) != 2 || terms[0] != "Rediffmail" || terms[1] != "Krishnamurthy" {
+		t.Errorf("keyterm_prompt = %v want [Rediffmail Krishnamurthy]", terms)
+	}
+}
+
+func TestAssemblyAIHandleTurn_SuppressesDuplicateFinals(t *testing.T) {
+	var calls atomic.Int32
+	var lastIsFinal atomic.Bool
+	c := &assemblyAIClient{
+		onResult: func(r TranscriptResult) {
+			calls.Add(1)
+			lastIsFinal.Store(r.IsFinal)
+		},
+		suppressDuplicate: 5 * time.Second,
+	}
+
+	// First final
+	c.handleTurn(assemblyAITurnMsg{Type: "Turn", Transcript: "hello world", EndOfTurn: true})
+	if calls.Load() != 1 || !lastIsFinal.Load() {
+		t.Fatalf("first final: got calls=%d final=%v", calls.Load(), lastIsFinal.Load())
+	}
+	// Same text repeated within the window — should be suppressed.
+	c.handleTurn(assemblyAITurnMsg{Type: "Turn", Transcript: "hello world", EndOfTurn: true})
+	if calls.Load() != 1 {
+		t.Fatalf("duplicate final should be suppressed: calls=%d", calls.Load())
+	}
+	// Different text passes through.
+	c.handleTurn(assemblyAITurnMsg{Type: "Turn", Transcript: "different", EndOfTurn: true})
+	if calls.Load() != 2 {
+		t.Fatalf("new final should fire: calls=%d", calls.Load())
+	}
+}
+
+func TestAssemblyAIHandleTurn_PartialsDedupe(t *testing.T) {
+	var calls atomic.Int32
+	var lastText atomic.Value
+	lastText.Store("")
+	c := &assemblyAIClient{
+		onResult: func(r TranscriptResult) {
+			calls.Add(1)
+			lastText.Store(r.Text)
+		},
+		suppressDuplicate: 5 * time.Second,
+	}
+
+	c.handleTurn(assemblyAITurnMsg{Transcript: "hi there", EndOfTurn: false})
+	c.handleTurn(assemblyAITurnMsg{Transcript: "hi there", EndOfTurn: false}) // dup
+	c.handleTurn(assemblyAITurnMsg{Transcript: "hi there ho", EndOfTurn: false})
+	if calls.Load() != 2 {
+		t.Fatalf("expected 2 partials, got %d", calls.Load())
+	}
+	if got := lastText.Load().(string); !strings.HasPrefix(got, "hi there ho") {
+		t.Fatalf("last partial = %q", got)
+	}
+}
+
+func TestAssemblyAIHandleTurn_EmptyTranscriptIgnored(t *testing.T) {
+	var calls atomic.Int32
+	c := &assemblyAIClient{
+		onResult:          func(r TranscriptResult) { calls.Add(1) },
+		suppressDuplicate: 5 * time.Second,
+	}
+	c.handleTurn(assemblyAITurnMsg{Transcript: "   ", EndOfTurn: true})
+	c.handleTurn(assemblyAITurnMsg{Transcript: "", EndOfTurn: false})
+	if calls.Load() != 0 {
+		t.Fatalf("empty transcripts should not fire: calls=%d", calls.Load())
+	}
+}
+
+func TestAssemblyAIHandleTurn_PropagatesFinalConfidence(t *testing.T) {
+	var got TranscriptResult
+	var calls atomic.Int32
+	c := &assemblyAIClient{
+		onResult: func(r TranscriptResult) {
+			calls.Add(1)
+			got = r
+		},
+		suppressDuplicate: 5 * time.Second,
+	}
+	c.handleTurn(assemblyAITurnMsg{
+		Transcript: "hello world",
+		EndOfTurn:  true,
+		Words: []assemblyAIWord{
+			{Confidence: 0.9},
+			{Confidence: 0.8},
+		},
+	})
+	if calls.Load() != 1 || !got.IsFinal {
+		t.Fatalf("expected one final, got calls=%d result=%+v", calls.Load(), got)
+	}
+	want := 0.85
+	if got.Confidence < want-1e-9 || got.Confidence > want+1e-9 {
+		t.Fatalf("final confidence = %v, want %v (mean of word confidences)", got.Confidence, want)
+	}
+}
+
+func TestAssemblyAIHandleTurn_PropagatesPartialConfidence(t *testing.T) {
+	var got TranscriptResult
+	c := &assemblyAIClient{
+		onResult:          func(r TranscriptResult) { got = r },
+		suppressDuplicate: 5 * time.Second,
+	}
+	c.handleTurn(assemblyAITurnMsg{
+		Transcript: "hi there",
+		EndOfTurn:  false,
+		Words: []assemblyAIWord{
+			{Confidence: 0.6},
+			{Confidence: 0.4},
+		},
+	})
+	if got.IsFinal {
+		t.Fatalf("expected partial, got final: %+v", got)
+	}
+	want := 0.5
+	if got.Confidence < want-1e-9 || got.Confidence > want+1e-9 {
+		t.Fatalf("partial confidence = %v, want %v", got.Confidence, want)
+	}
+}
+
+func TestAssemblyAIHandleTurn_MissingConfidenceFallsBackToZero(t *testing.T) {
+	var got TranscriptResult
+	var calls atomic.Int32
+	c := &assemblyAIClient{
+		onResult: func(r TranscriptResult) {
+			calls.Add(1)
+			got = r
+		},
+		suppressDuplicate: 5 * time.Second,
+	}
+	// No words array — emulates a provider message without per-word confidences.
+	c.handleTurn(assemblyAITurnMsg{Transcript: "hello", EndOfTurn: true})
+	if calls.Load() != 1 || !got.IsFinal {
+		t.Fatalf("expected one final, got calls=%d result=%+v", calls.Load(), got)
+	}
+	if got.Text != "hello" {
+		t.Fatalf("text = %q, want %q", got.Text, "hello")
+	}
+	if got.Confidence != 0 {
+		t.Fatalf("missing-confidence final = %v, want 0", got.Confidence)
+	}
+}

--- a/internal/stt/deepgram.go
+++ b/internal/stt/deepgram.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/streamcoreai/server/internal/config"
 
@@ -13,9 +16,33 @@ import (
 	msginterfaces "github.com/deepgram/deepgram-go-sdk/v3/pkg/api/listen/v1/websocket/interfaces"
 )
 
+// recentFinalSuppressWindow is how long an identical final transcript is
+// suppressed after being emitted. Deepgram can re-deliver the same text via
+// both speech_final and UtteranceEnd; emitting twice would make the agent
+// answer the same sentence twice.
+const recentFinalSuppressWindow = 5 * time.Second
+
 // deepgramCallback implements the Deepgram SDK's LiveMessageCallback interface.
+//
+// Deepgram delivers an utterance as a series of chunks: interim results, then
+// one or more is_final chunks, and finally (usually) one carrying
+// speech_final. Emitting each is_final chunk separately splits a single
+// sentence into several turns, and consecutive chunks routinely overlap by a
+// few words. This callback accumulates the chunks, merges the overlaps, and
+// emits exactly one final per utterance.
 type deepgramCallback struct {
 	onResult func(TranscriptResult)
+	mu       sync.Mutex
+	// finalized accumulates is_final chunks for the current utterance.
+	finalized          string
+	lastEmittedPartial string
+	lastFinal          string
+	lastFinalAt        time.Time
+	speechActive       bool
+	// lastChunkConfidence remembers the confidence from the most recent
+	// message of this utterance, so the UtteranceEnd flush path — which has
+	// no message of its own — can still report one.
+	lastChunkConfidence float64
 }
 
 func (cb *deepgramCallback) Open(or *msginterfaces.OpenResponse) error {
@@ -28,16 +55,78 @@ func (cb *deepgramCallback) Message(mr *msginterfaces.MessageResponse) error {
 		return nil
 	}
 
-	text := mr.Channel.Alternatives[0].Transcript
+	alt := mr.Channel.Alternatives[0]
+	text := strings.TrimSpace(alt.Transcript)
 	if text == "" {
 		return nil
 	}
+	confidence := alt.Confidence
 
-	cb.onResult(TranscriptResult{
-		Text:    text,
-		IsFinal: mr.IsFinal || mr.SpeechFinal,
-	})
+	var emit *TranscriptResult
+
+	cb.mu.Lock()
+	cb.lastChunkConfidence = confidence
+	if mr.IsFinal {
+		cb.finalized = mergeTranscriptChunks(cb.finalized, text)
+		if mr.SpeechFinal {
+			combined := strings.TrimSpace(cb.finalized)
+			if combined == "" {
+				combined = text
+			}
+			if !cb.shouldSuppressRecentFinalLocked(combined) {
+				emit = &TranscriptResult{Text: combined, IsFinal: true, Confidence: confidence}
+			}
+			cb.resetUtteranceLocked(combined)
+		} else {
+			// Emit progress so barge-in and the text UI still see current words.
+			emit = cb.partialResultLocked(cb.finalized, confidence)
+		}
+	} else {
+		combined := text
+		if cb.finalized != "" {
+			combined = strings.TrimSpace(cb.finalized + " " + text)
+		}
+		emit = cb.partialResultLocked(combined, confidence)
+	}
+	cb.mu.Unlock()
+
+	if emit != nil {
+		if emit.IsFinal {
+			log.Printf("[stt] final: %q (conf=%.2f)", emit.Text, emit.Confidence)
+		}
+		cb.onResult(*emit)
+	}
 	return nil
+}
+
+// partialResultLocked builds an interim result, dropping repeats and anything
+// that merely restates a final we just emitted.
+func (cb *deepgramCallback) partialResultLocked(text string, confidence float64) *TranscriptResult {
+	text = strings.TrimSpace(text)
+	if text == "" ||
+		sameTranscript(text, cb.lastEmittedPartial) ||
+		cb.shouldSuppressRecentFinalLocked(text) {
+		return nil
+	}
+	cb.lastEmittedPartial = text
+	return &TranscriptResult{Text: text, IsFinal: false, Confidence: confidence}
+}
+
+// resetUtteranceLocked clears per-utterance accumulation and records the final
+// text so an immediate repeat can be suppressed.
+func (cb *deepgramCallback) resetUtteranceLocked(finalText string) {
+	cb.finalized = ""
+	cb.lastEmittedPartial = ""
+	cb.speechActive = false
+	cb.lastChunkConfidence = 0
+	if strings.TrimSpace(finalText) != "" {
+		cb.lastFinal = finalText
+		cb.lastFinalAt = time.Now()
+	}
+}
+
+func (cb *deepgramCallback) shouldSuppressRecentFinalLocked(text string) bool {
+	return sameTranscript(text, cb.lastFinal) && time.Since(cb.lastFinalAt) < recentFinalSuppressWindow
 }
 
 func (cb *deepgramCallback) Metadata(md *msginterfaces.MetadataResponse) error {
@@ -45,10 +134,34 @@ func (cb *deepgramCallback) Metadata(md *msginterfaces.MetadataResponse) error {
 }
 
 func (cb *deepgramCallback) SpeechStarted(ssr *msginterfaces.SpeechStartedResponse) error {
+	var logStarted bool
+	cb.mu.Lock()
+	if !cb.speechActive {
+		cb.speechActive = true
+		logStarted = true
+	}
+	cb.mu.Unlock()
+	if logStarted {
+		log.Println("[stt] Deepgram speech started")
+	}
 	return nil
 }
 
+// UtteranceEnd is the fallback path: if Deepgram closes the utterance without
+// ever sending a speech_final message, the buffered chunks would otherwise sit
+// in `finalized` forever and the caller's turn would be silently dropped.
 func (cb *deepgramCallback) UtteranceEnd(ur *msginterfaces.UtteranceEndResponse) error {
+	cb.mu.Lock()
+	combined := strings.TrimSpace(cb.finalized)
+	emit := combined != "" && !cb.shouldSuppressRecentFinalLocked(combined)
+	confidence := cb.lastChunkConfidence
+	cb.resetUtteranceLocked(combined)
+	cb.mu.Unlock()
+
+	if emit {
+		log.Printf("[stt] utterance end flush: %q (conf=%.2f)", combined, confidence)
+		cb.onResult(TranscriptResult{Text: combined, IsFinal: true, Confidence: confidence})
+	}
 	return nil
 }
 
@@ -77,13 +190,24 @@ func NewDeepgramClient(ctx context.Context, cfg config.DeepgramConfig, onResult 
 
 	tOptions := &clientinterfaces.LiveTranscriptionOptions{
 		Model:          cfg.Model,
+		Language:       nova3Language(cfg.Language),
 		Encoding:       "linear16",
 		SampleRate:     16000,
 		Channels:       1,
 		Punctuate:      true,
 		InterimResults: true,
-		Endpointing:    "300",
+		Endpointing:    cfg.Endpointing,
+		// UtteranceEndMs drives the UtteranceEnd event the callback uses to
+		// flush buffered chunks when speech_final never arrives.
+		UtteranceEndMs: cfg.UtteranceEndMs,
 		VadEvents:      true,
+		// Keyterms bias the decoder toward domain vocabulary that is
+		// phonetically ambiguous against common English. Nova-3 only; the SDK
+		// silently drops them on other models.
+		Keyterm: cfg.Keyterms,
+	}
+	if len(cfg.Keyterms) > 0 {
+		log.Printf("[stt] deepgram keyterms loaded: count=%d", len(cfg.Keyterms))
 	}
 
 	cb := &deepgramCallback{onResult: onResult}
@@ -101,6 +225,24 @@ func NewDeepgramClient(ctx context.Context, cfg config.DeepgramConfig, onResult 
 
 	log.Println("[stt] connected to Deepgram")
 	return &deepgramClient{ws: ws, cancel: cancel}, nil
+}
+
+// nova3Language maps a BCP-47 locale to the language code Nova-3 accepts.
+// English and Spanish have dedicated models; everything else routes to the
+// multilingual model rather than failing.
+func nova3Language(locale string) string {
+	base := strings.ToLower(strings.TrimSpace(locale))
+	if idx := strings.Index(base, "-"); idx > 0 {
+		base = base[:idx]
+	}
+	switch base {
+	case "", "en":
+		return "en"
+	case "es":
+		return "es"
+	default:
+		return "multi"
+	}
 }
 
 // SendAudio sends raw linear16 PCM bytes to Deepgram.

--- a/internal/stt/deepgram_test.go
+++ b/internal/stt/deepgram_test.go
@@ -1,0 +1,195 @@
+package stt
+
+import (
+	"testing"
+
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v3/pkg/api/listen/v1/websocket/interfaces"
+)
+
+func TestNova3LanguageStripsLocale(t *testing.T) {
+	cases := map[string]string{
+		"":      "en",
+		"en":    "en",
+		"en-US": "en",
+		"en-IN": "en",
+		"en-NZ": "en",
+		"en-GB": "en",
+		"en-ZA": "en",
+		"es":    "es",
+		"es-ES": "es",
+		"zh-CN": "multi",
+		"ja-JP": "multi",
+		"ko-KR": "multi",
+		"hi-IN": "multi",
+		"mi-NZ": "multi",
+	}
+	for in, want := range cases {
+		if got := nova3Language(in); got != want {
+			t.Errorf("nova3Language(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestDeepgramCallbackDedupesRepeatedPartials(t *testing.T) {
+	var got []TranscriptResult
+	cb := &deepgramCallback{
+		onResult: func(result TranscriptResult) {
+			got = append(got, result)
+		},
+	}
+	defer cb.Close(nil)
+
+	if err := cb.Message(deepgramMessage("hello there", false, false)); err != nil {
+		t.Fatal(err)
+	}
+	if err := cb.Message(deepgramMessage("hello there", false, false)); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("got %d results, want 1", len(got))
+	}
+	if got[0].Text != "hello there" || got[0].IsFinal {
+		t.Fatalf("got %+v, want one non-final hello there", got[0])
+	}
+}
+
+func TestDeepgramCallbackUtteranceEndDoesNotPromotePartial(t *testing.T) {
+	var got []TranscriptResult
+	cb := &deepgramCallback{
+		onResult: func(result TranscriptResult) {
+			got = append(got, result)
+		},
+	}
+	defer cb.Close(nil)
+
+	if err := cb.Message(deepgramMessage("change the email address", false, false)); err != nil {
+		t.Fatal(err)
+	}
+	if err := cb.UtteranceEnd(&msginterfaces.UtteranceEndResponse{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("got %d results, want only the partial", len(got))
+	}
+	if got[0].Text != "change the email address" || got[0].IsFinal {
+		t.Fatalf("got %+v, want non-final transcript", got[0])
+	}
+}
+
+func TestDeepgramCallbackSpeechStartedDoesNotClearFinalizedChunk(t *testing.T) {
+	var got []TranscriptResult
+	cb := &deepgramCallback{
+		onResult: func(result TranscriptResult) {
+			got = append(got, result)
+		},
+	}
+	defer cb.Close(nil)
+
+	if err := cb.Message(deepgramMessage("first finalized chunk", true, false)); err != nil {
+		t.Fatal(err)
+	}
+	if err := cb.SpeechStarted(&msginterfaces.SpeechStartedResponse{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := cb.UtteranceEnd(&msginterfaces.UtteranceEndResponse{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("got %d results, want partial and final", len(got))
+	}
+	if got[1].Text != "first finalized chunk" || !got[1].IsFinal {
+		t.Fatalf("got final %+v, want preserved finalized chunk", got[1])
+	}
+}
+
+func TestMergeTranscriptChunksDedupesOrdinaryOverlap(t *testing.T) {
+	got := mergeTranscriptChunks("I would like a booking", "booking for tomorrow")
+	want := "I would like a booking for tomorrow"
+	if got != want {
+		t.Fatalf("mergeTranscriptChunks ordinary overlap = %q, want %q", got, want)
+	}
+}
+
+func TestMergeTranscriptChunksPreservesRepeatedSpokenPhoneDigit(t *testing.T) {
+	got := mergeTranscriptChunks("o two one", "one two three four five six seven")
+	want := "o two one one two three four five six seven"
+	if got != want {
+		t.Fatalf("mergeTranscriptChunks repeated spoken digit = %q, want %q", got, want)
+	}
+}
+
+func deepgramMessage(text string, isFinal, speechFinal bool) *msginterfaces.MessageResponse {
+	return deepgramMessageWithConfidence(text, isFinal, speechFinal, 0)
+}
+
+func deepgramMessageWithConfidence(text string, isFinal, speechFinal bool, confidence float64) *msginterfaces.MessageResponse {
+	return &msginterfaces.MessageResponse{
+		Channel: msginterfaces.Channel{
+			Alternatives: []msginterfaces.Alternative{
+				{Transcript: text, Confidence: confidence},
+			},
+		},
+		IsFinal:     isFinal,
+		SpeechFinal: speechFinal,
+	}
+}
+
+func TestDeepgramCallbackPropagatesFinalConfidence(t *testing.T) {
+	var got []TranscriptResult
+	cb := &deepgramCallback{
+		onResult: func(r TranscriptResult) { got = append(got, r) },
+	}
+	defer cb.Close(nil)
+
+	if err := cb.Message(deepgramMessageWithConfidence("hello world", true, true, 0.93)); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || !got[0].IsFinal {
+		t.Fatalf("got %+v, want one final", got)
+	}
+	if got[0].Confidence != 0.93 {
+		t.Fatalf("final confidence = %v, want 0.93", got[0].Confidence)
+	}
+}
+
+func TestDeepgramCallbackPropagatesPartialConfidence(t *testing.T) {
+	var got []TranscriptResult
+	cb := &deepgramCallback{
+		onResult: func(r TranscriptResult) { got = append(got, r) },
+	}
+	defer cb.Close(nil)
+
+	if err := cb.Message(deepgramMessageWithConfidence("hello there", false, false, 0.71)); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].IsFinal {
+		t.Fatalf("got %+v, want one partial", got)
+	}
+	if got[0].Confidence != 0.71 {
+		t.Fatalf("partial confidence = %v, want 0.71", got[0].Confidence)
+	}
+}
+
+func TestDeepgramCallbackMissingConfidenceFallsBackToZero(t *testing.T) {
+	var got []TranscriptResult
+	cb := &deepgramCallback{
+		onResult: func(r TranscriptResult) { got = append(got, r) },
+	}
+	defer cb.Close(nil)
+
+	if err := cb.Message(deepgramMessage("hello world", true, true)); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || !got[0].IsFinal {
+		t.Fatalf("got %+v, want one final", got)
+	}
+	if got[0].Confidence != 0 {
+		t.Fatalf("missing-confidence final = %v, want 0", got[0].Confidence)
+	}
+	if got[0].Text != "hello world" {
+		t.Fatalf("text = %q, want preserved transcript", got[0].Text)
+	}
+}

--- a/internal/stt/stt.go
+++ b/internal/stt/stt.go
@@ -10,6 +10,11 @@ import (
 type TranscriptResult struct {
 	Text    string
 	IsFinal bool
+	// Confidence is the provider-reported confidence for the transcript in the
+	// range [0, 1]. Zero means the provider did not report a value (or the
+	// reported value was genuinely zero); callers must treat it as "unknown"
+	// rather than "low confidence".
+	Confidence float64
 }
 
 // Client is the interface that all STT providers must implement.
@@ -31,9 +36,14 @@ func NewClient(ctx context.Context, cfg *config.Config, onResult func(Transcript
 			return nil, fmt.Errorf("stt provider %q requires [openai] api_key to be set", cfg.STT.Provider)
 		}
 		return NewOpenAIClient(ctx, cfg.OpenAI.APIKey, onResult)
+	case "assemblyai":
+		if cfg.AssemblyAI.APIKey == "" {
+			return nil, fmt.Errorf("stt provider %q requires [assemblyai] api_key to be set", cfg.STT.Provider)
+		}
+		return NewAssemblyAIClient(ctx, cfg.AssemblyAI, onResult)
 	case "vibevoice":
 		return NewVibeVoiceClient(ctx, cfg.VibeVoice.ASRURL, onResult)
 	default:
-		return nil, fmt.Errorf("unknown stt provider %q (supported: deepgram, openai, vibevoice)", cfg.STT.Provider)
+		return nil, fmt.Errorf("unknown stt provider %q (supported: deepgram, openai, assemblyai, vibevoice)", cfg.STT.Provider)
 	}
 }

--- a/internal/stt/transcript.go
+++ b/internal/stt/transcript.go
@@ -1,0 +1,98 @@
+package stt
+
+import "strings"
+
+// normalizeTranscript lowercases and collapses whitespace so two transcripts
+// that differ only in spacing or case compare equal.
+func normalizeTranscript(s string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(s))), " ")
+}
+
+// sameTranscript reports whether two transcripts are the same modulo case and
+// whitespace.
+func sameTranscript(a, b string) bool {
+	return normalizeTranscript(a) == normalizeTranscript(b)
+}
+
+// mergeTranscriptChunks joins two consecutive final chunks from a streaming
+// STT provider, removing the overlap they usually share. Providers commonly
+// re-send the tail of the previous chunk at the head of the next one, so a
+// naive concatenation yields "book a table book a table for two".
+//
+// The longest suffix of base that matches a prefix of next is treated as the
+// overlap and dropped from next.
+func mergeTranscriptChunks(base, next string) string {
+	base = strings.TrimSpace(base)
+	next = strings.TrimSpace(next)
+	if base == "" {
+		return next
+	}
+	if next == "" {
+		return base
+	}
+
+	baseWords := strings.Fields(base)
+	nextWords := strings.Fields(next)
+	if len(baseWords) == 0 {
+		return next
+	}
+	if len(nextWords) == 0 {
+		return base
+	}
+
+	maxOverlap := min(len(baseWords), len(nextWords))
+	overlap := 0
+	for k := maxOverlap; k >= 1; k-- {
+		match := true
+		for i := 0; i < k; i++ {
+			if !strings.EqualFold(baseWords[len(baseWords)-k+i], nextWords[i]) {
+				match = false
+				break
+			}
+		}
+		if match {
+			overlap = k
+			break
+		}
+	}
+
+	if preservesRepeatedSpokenDigitBoundary(baseWords, nextWords, overlap) {
+		overlap = 0
+	}
+
+	if overlap == len(nextWords) {
+		return strings.Join(baseWords, " ")
+	}
+	if overlap == len(baseWords) && len(nextWords) >= len(baseWords) {
+		return strings.Join(nextWords, " ")
+	}
+
+	merged := append(append([]string{}, baseWords...), nextWords[overlap:]...)
+	return strings.Join(merged, " ")
+}
+
+// preservesRepeatedSpokenDigitBoundary guards the one case where a genuine
+// repetition must not be collapsed: a caller dictating digits. In "four five
+// five / five six seven" the shared "five" is real speech, not provider
+// overlap, and dropping it corrupts the phone number. Only a single-word
+// overlap between digit tokens on both sides qualifies.
+func preservesRepeatedSpokenDigitBoundary(baseWords, nextWords []string, overlap int) bool {
+	if overlap != 1 || len(baseWords) < 2 || len(nextWords) < 2 {
+		return false
+	}
+	word := strings.ToLower(baseWords[len(baseWords)-1])
+	if word != strings.ToLower(nextWords[0]) || !isSpokenDigitToken(word) {
+		return false
+	}
+	return isSpokenDigitToken(baseWords[len(baseWords)-2]) && isSpokenDigitToken(nextWords[1])
+}
+
+func isSpokenDigitToken(word string) bool {
+	switch strings.ToLower(strings.TrimSpace(word)) {
+	case "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+		"zero", "oh", "o", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/tts/cartesia.go
+++ b/internal/tts/cartesia.go
@@ -14,7 +14,8 @@ const (
 	cartesiaAPIURL     = "https://api.cartesia.ai/tts/bytes"
 	cartesiaAPIVersion = "2025-04-16"
 	// Katie - stable voice for voice agents (Cartesia docs)
-	defaultCartesiaVoiceID = "f786b574-daa5-4673-aa0c-cbe3e8534c02"
+	defaultCartesiaVoiceID  = "f786b574-daa5-4673-aa0c-cbe3e8534c02"
+	cartesiaStreamChunkSize = 3200
 )
 
 type cartesiaClient struct {
@@ -54,7 +55,7 @@ type cartesiaOutputFormat struct {
 	SampleRate int    `json:"sample_rate"`
 }
 
-func (c *cartesiaClient) Synthesize(ctx context.Context, text string) ([]byte, error) {
+func (c *cartesiaClient) buildRequest(ctx context.Context, text string) (*http.Request, error) {
 	body := cartesiaRequest{
 		ModelID:    "sonic-3",
 		Transcript: text,
@@ -82,6 +83,14 @@ func (c *cartesiaClient) Synthesize(ctx context.Context, text string) ([]byte, e
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Cartesia-Version", cartesiaAPIVersion)
+	return req, nil
+}
+
+func (c *cartesiaClient) Synthesize(ctx context.Context, text string) ([]byte, error) {
+	req, err := c.buildRequest(ctx, text)
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -101,4 +110,78 @@ func (c *cartesiaClient) Synthesize(ctx context.Context, text string) ([]byte, e
 
 	log.Printf("[tts:cartesia] synthesized %d bytes for %d chars of text", len(data), len(text))
 	return data, nil
+}
+
+func (c *cartesiaClient) SynthesizeStream(ctx context.Context, text string) (<-chan StreamChunk, error) {
+	req, err := c.buildRequest(ctx, text)
+	if err != nil {
+		ch := make(chan StreamChunk, 1)
+		ch <- StreamChunk{Err: err}
+		close(ch)
+		return ch, nil
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		ch := make(chan StreamChunk, 1)
+		ch <- StreamChunk{Err: fmt.Errorf("cartesia request: %w", err)}
+		close(ch)
+		return ch, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		ch := make(chan StreamChunk, 1)
+		ch <- StreamChunk{Err: fmt.Errorf("cartesia error %d: %s", resp.StatusCode, string(respBody))}
+		close(ch)
+		return ch, nil
+	}
+
+	ch := make(chan StreamChunk, 16)
+
+	go func() {
+		defer close(ch)
+		defer resp.Body.Close()
+
+		buf := make([]byte, cartesiaStreamChunkSize)
+		totalBytes := 0
+
+		for {
+			// Read a full chunk. The HTTP response body streams PCM bytes
+			// as the server generates them, so the first chunk typically
+			// arrives well before the full audio is ready.
+			n, err := io.ReadFull(resp.Body, buf)
+			if n > 0 {
+				totalBytes += n
+				// Copy the slice so we can reuse buf on the next read.
+				chunk := make([]byte, n)
+				copy(chunk, buf[:n])
+
+				select {
+				case ch <- StreamChunk{PCM: chunk}:
+				case <-ctx.Done():
+					return
+				}
+			}
+			if err != nil {
+				if err == io.EOF || err == io.ErrUnexpectedEOF {
+					// Normal end of stream — io.ErrUnexpectedEOF means
+					// the last read was shorter than buf size, which is
+					// expected for the final chunk.
+					break
+				}
+				// Real error — send it downstream.
+				select {
+				case ch <- StreamChunk{Err: fmt.Errorf("cartesia read: %w", err)}:
+				case <-ctx.Done():
+				}
+				return
+			}
+		}
+
+		log.Printf("[tts:cartesia] streamed %d bytes for %d chars of text", totalBytes, len(text))
+	}()
+
+	return ch, nil
 }

--- a/internal/tts/cartesia_ws.go
+++ b/internal/tts/cartesia_ws.go
@@ -1,0 +1,478 @@
+package tts
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	cartesiaDefaultWSURL = "wss://api.cartesia.ai/tts/websocket"
+	cartesiaWSVersion    = "2025-04-16"
+	// cartesiaWSPendingBuf is the per-context response channel buffer.
+	// 64 slots is enough for even very long sentences while keeping
+	// memory modest (64 × pointer size).
+	cartesiaWSPendingBuf = 64
+)
+
+// cartesiaWSClient implements the Client interface using Cartesia's WebSocket
+// TTS API. It maintains a single persistent connection, eliminating per-request
+// TLS handshake overhead (~65-195 ms per sentence). The connection is
+// established lazily on first use and auto-reconnects on failure.
+type cartesiaWSClient struct {
+	apiKey  string
+	voiceID string
+	wsURL   string
+
+	// connMu protects conn and connected. It is also held during writes
+	// to serialise WebSocket write operations (gorilla/websocket requires
+	// at most one concurrent writer).
+	connMu    sync.Mutex
+	conn      *websocket.Conn
+	connected bool
+
+	// pendingMu protects the pending map which routes incoming WebSocket
+	// messages to the correct SynthesizeStream caller via context_id.
+	pendingMu sync.Mutex
+	pending   map[string]chan *wsResponse
+
+	// closeCh is closed when Close() is called, signalling the readLoop
+	// and bridge goroutines to exit.
+	closeCh   chan struct{}
+	closeOnce sync.Once
+}
+
+// wsResponse represents a message received from the Cartesia WebSocket API.
+type wsResponse struct {
+	Type       string `json:"type"`
+	Data       string `json:"data"`
+	Done       bool   `json:"done"`
+	ContextID  string `json:"context_id"`
+	StatusCode int    `json:"status_code"`
+
+	// Error fields (present when type == "error")
+	Title     string `json:"title"`
+	Message   string `json:"message"`
+	ErrorCode string `json:"error_code"`
+}
+
+// wsGenerationRequest is the JSON payload sent to request speech synthesis.
+type wsGenerationRequest struct {
+	ModelID          string              `json:"model_id"`
+	Transcript       string              `json:"transcript"`
+	Voice            wsVoiceSpecifier    `json:"voice"`
+	OutputFormat     wsOutputFormat      `json:"output_format"`
+	GenerationConfig *wsGenerationConfig `json:"generation_config,omitempty"`
+	ContextID        string              `json:"context_id"`
+	Continue         bool                `json:"continue"`
+}
+
+// wsGenerationConfig controls sonic-3 audio attributes. Speed is explicitly
+// pinned to 1.0 to prevent the model from varying playback speed across
+// requests.
+type wsGenerationConfig struct {
+	Speed float64 `json:"speed"`
+}
+
+type wsVoiceSpecifier struct {
+	Mode string `json:"mode"`
+	ID   string `json:"id"`
+}
+
+type wsOutputFormat struct {
+	Container  string `json:"container"`
+	Encoding   string `json:"encoding"`
+	SampleRate int    `json:"sample_rate"`
+}
+
+// NewCartesiaWSClient creates a Cartesia TTS client backed by the WebSocket
+// API. The connection is established lazily on first synthesis request.
+// voiceID defaults to Katie if empty. wsURL overrides the WebSocket
+// endpoint (intended for local dev — see config.CartesiaConfig.WSURL).
+// Empty wsURL means production wss://api.cartesia.ai/tts/websocket.
+func NewCartesiaWSClient(apiKey, voiceID, wsURL string) Client {
+	if voiceID == "" {
+		voiceID = defaultCartesiaVoiceID
+	}
+	endpoint := cartesiaDefaultWSURL
+	if wsURL != "" {
+		endpoint = wsURL
+		log.Printf("[tts:cartesia-ws] ws URL override active: %s", endpoint)
+	}
+	return &cartesiaWSClient{
+		apiKey:  apiKey,
+		voiceID: voiceID,
+		wsURL:   endpoint,
+		pending: make(map[string]chan *wsResponse),
+		closeCh: make(chan struct{}),
+	}
+}
+
+// Close shuts down the WebSocket connection and stops the read loop.
+// It is safe to call multiple times. The Client interface does not require
+// Close, but callers can use it via type assertion for explicit cleanup.
+func (c *cartesiaWSClient) Close() {
+	c.closeOnce.Do(func() {
+		close(c.closeCh)
+
+		// Unblock any bridge goroutines waiting for responses.
+		c.notifyAllError(fmt.Errorf("cartesia ws: client closed"))
+
+		c.connMu.Lock()
+		defer c.connMu.Unlock()
+
+		if c.conn != nil {
+			// Best-effort close frame.
+			_ = c.conn.WriteMessage(
+				websocket.CloseMessage,
+				websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+			)
+			c.conn.Close()
+			c.conn = nil
+			c.connected = false
+		}
+
+		log.Println("[tts:cartesia-ws] closed")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Connection management
+// ---------------------------------------------------------------------------
+
+// ensureConnected dials the Cartesia WebSocket if no connection is active.
+// It is safe to call concurrently; the mutex serialises dial attempts.
+func (c *cartesiaWSClient) ensureConnected(ctx context.Context) error {
+	c.connMu.Lock()
+	defer c.connMu.Unlock()
+
+	if c.connected && c.conn != nil {
+		return nil
+	}
+
+	header := http.Header{}
+	header.Set("Authorization", "Bearer "+c.apiKey)
+	header.Set("Cartesia-Version", cartesiaWSVersion)
+
+	dialer := websocket.Dialer{
+		HandshakeTimeout: 10 * time.Second,
+	}
+
+	conn, _, err := dialer.DialContext(ctx, c.wsURL, header)
+	if err != nil {
+		return fmt.Errorf("cartesia ws dial: %w", err)
+	}
+
+	c.conn = conn
+	c.connected = true
+
+	go c.readLoop(conn)
+
+	log.Printf("[tts:cartesia-ws] connected to %s", c.wsURL)
+	return nil
+}
+
+// readLoop reads messages from the WebSocket and dispatches them to the
+// correct pending context channel. It runs in its own goroutine and exits
+// when the connection drops or Close() is called.
+//
+// The caller's conn is captured so that the deferred cleanup only resets
+// c.conn when it still points to *our* connection (not a newer one created
+// by a subsequent reconnect).
+func (c *cartesiaWSClient) readLoop(conn *websocket.Conn) {
+	defer func() {
+		// Only clear the shared pointer if it still refers to our connection.
+		c.connMu.Lock()
+		if c.conn == conn {
+			c.conn = nil
+			c.connected = false
+		}
+		c.connMu.Unlock()
+		conn.Close()
+	}()
+
+	for {
+		// Exit early if the client is shutting down.
+		select {
+		case <-c.closeCh:
+			return
+		default:
+		}
+
+		_, message, err := conn.ReadMessage()
+		if err != nil {
+			if !isNormalClose(err) {
+				log.Printf("[tts:cartesia-ws] read error: %v", err)
+			}
+			// Notify every pending caller so their bridge goroutines unblock.
+			c.notifyAllError(fmt.Errorf("cartesia ws: connection lost: %w", err))
+			return
+		}
+
+		var resp wsResponse
+		if err := json.Unmarshal(message, &resp); err != nil {
+			log.Printf("[tts:cartesia-ws] parse error: %v", err)
+			continue
+		}
+
+		ch := c.getPending(resp.ContextID)
+		if ch == nil {
+			// No pending caller for this context_id (already cleaned up).
+			continue
+		}
+
+		// Forward the response. Use a timeout so a stuck consumer cannot
+		// block the readLoop indefinitely.
+		select {
+		case ch <- &resp:
+		case <-time.After(3 * time.Second):
+			log.Printf("[tts:cartesia-ws] timeout dispatching to context %s", resp.ContextID)
+		case <-c.closeCh:
+			return
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Client interface
+// ---------------------------------------------------------------------------
+
+// SynthesizeStream produces PCM audio incrementally via a channel. It sends a
+// generation request over the persistent WebSocket and returns a channel that
+// yields PCM chunks as Cartesia generates them.
+//
+// If ctx is cancelled (e.g. barge-in), a cancel message is sent to Cartesia so
+// it stops generating on the server side.
+func (c *cartesiaWSClient) SynthesizeStream(ctx context.Context, text string) (<-chan StreamChunk, error) {
+	return c.SynthesizeStreamWithControls(ctx, text, VoiceControls{})
+}
+
+// SynthesizeStreamWithControls is SynthesizeStream with per-utterance voice
+// controls applied. Cartesia exposes a playback-speed multiplier on the
+// generation config; tone presets map onto it (warm/empathetic slightly
+// slower, excited slightly faster). Speed is clamped to a conversational
+// band so a bad tag can never produce comedy audio.
+func (c *cartesiaWSClient) SynthesizeStreamWithControls(ctx context.Context, text string, vc VoiceControls) (<-chan StreamChunk, error) {
+	if err := c.ensureConnected(ctx); err != nil {
+		return nil, fmt.Errorf("cartesia ws connect: %w", err)
+	}
+
+	speed := vc.Speed
+	if speed == 0 {
+		speed = 1.0
+	}
+	if speed < 0.8 {
+		speed = 0.8
+	}
+	if speed > 1.2 {
+		speed = 1.2
+	}
+
+	contextID := uuid.New().String()
+	respCh := make(chan *wsResponse, cartesiaWSPendingBuf)
+	c.registerPending(contextID, respCh)
+
+	req := wsGenerationRequest{
+		ModelID:    "sonic-3",
+		Transcript: text,
+		Voice: wsVoiceSpecifier{
+			Mode: "id",
+			ID:   c.voiceID,
+		},
+		OutputFormat: wsOutputFormat{
+			Container:  "raw",
+			Encoding:   "pcm_s16le",
+			SampleRate: 16000,
+		},
+		GenerationConfig: &wsGenerationConfig{Speed: speed},
+		ContextID:        contextID,
+		Continue:         false,
+	}
+
+	if err := c.writeJSON(req); err != nil {
+		c.unregisterPending(contextID)
+		return nil, fmt.Errorf("cartesia ws send: %w", err)
+	}
+
+	outCh := make(chan StreamChunk, 16)
+
+	// Bridge goroutine: convert wsResponse messages into StreamChunk values
+	// for the pipeline consumer.
+	go func() {
+		defer close(outCh)
+		defer c.unregisterPending(contextID)
+
+		totalBytes := 0
+		for {
+			select {
+			case resp, ok := <-respCh:
+				if !ok || resp == nil {
+					return
+				}
+
+				if resp.Type == "error" {
+					msg := resp.Message
+					if msg == "" {
+						msg = resp.Title
+					}
+					outCh <- StreamChunk{Err: fmt.Errorf("cartesia ws [%s]: %s", resp.ErrorCode, msg)}
+					return
+				}
+
+				if resp.Type == "chunk" && resp.Data != "" {
+					pcm, err := base64.StdEncoding.DecodeString(resp.Data)
+					if err != nil {
+						outCh <- StreamChunk{Err: fmt.Errorf("cartesia ws base64 decode: %w", err)}
+						return
+					}
+					if len(pcm) > 0 {
+						totalBytes += len(pcm)
+						outCh <- StreamChunk{PCM: pcm}
+					}
+				}
+
+				if resp.Done {
+					// Log total bytes, expected duration, and actual chunk
+					// count for diagnosing speed/sample-rate issues. At
+					// 16kHz mono 16-bit: 32000 bytes/sec → 32 bytes/ms.
+					durationMs := float64(totalBytes) / 32.0
+					log.Printf("[tts:cartesia-ws] streamed %d bytes (%.0f ms expected) for %d chars of text",
+						totalBytes, durationMs, len(text))
+					return
+				}
+
+			case <-ctx.Done():
+				// Pipeline cancelled (e.g. barge-in). Tell Cartesia to
+				// stop generating for this context.
+				c.sendCancel(contextID)
+				return
+			}
+		}
+	}()
+
+	return outCh, nil
+}
+
+// Synthesize produces the full audio for text in one shot by collecting all
+// chunks from SynthesizeStream.
+func (c *cartesiaWSClient) Synthesize(ctx context.Context, text string) ([]byte, error) {
+	stream, err := c.SynthesizeStream(ctx, text)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf []byte
+	for chunk := range stream {
+		if chunk.Err != nil {
+			return nil, chunk.Err
+		}
+		buf = append(buf, chunk.PCM...)
+	}
+
+	log.Printf("[tts:cartesia-ws] synthesized %d bytes for %d chars of text", len(buf), len(text))
+	return buf, nil
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket helpers
+// ---------------------------------------------------------------------------
+
+// writeJSON marshals v and writes it as a text message. connMu must NOT be
+// held by the caller; this method acquires it to serialise writes.
+func (c *cartesiaWSClient) writeJSON(v interface{}) error {
+	c.connMu.Lock()
+	defer c.connMu.Unlock()
+
+	if c.conn == nil {
+		return fmt.Errorf("cartesia ws: not connected")
+	}
+
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("cartesia ws marshal: %w", err)
+	}
+
+	if err := c.conn.WriteMessage(websocket.TextMessage, data); err != nil {
+		// Connection is likely broken; clean up so the next call reconnects.
+		c.connected = false
+		c.conn.Close()
+		c.conn = nil
+		return fmt.Errorf("cartesia ws write: %w", err)
+	}
+
+	return nil
+}
+
+// sendCancel sends a best-effort cancel request for the given context ID.
+func (c *cartesiaWSClient) sendCancel(contextID string) {
+	msg := struct {
+		ContextID string `json:"context_id"`
+		Cancel    bool   `json:"cancel"`
+	}{
+		ContextID: contextID,
+		Cancel:    true,
+	}
+	if err := c.writeJSON(msg); err != nil {
+		log.Printf("[tts:cartesia-ws] cancel send failed: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pending context management
+// ---------------------------------------------------------------------------
+
+func (c *cartesiaWSClient) registerPending(id string, ch chan *wsResponse) {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+	c.pending[id] = ch
+}
+
+func (c *cartesiaWSClient) unregisterPending(id string) {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+	delete(c.pending, id)
+}
+
+func (c *cartesiaWSClient) getPending(id string) chan *wsResponse {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+	return c.pending[id]
+}
+
+// notifyAllError sends an error response to every pending context and clears
+// the map. Used when the WebSocket connection is lost or the client is closed.
+func (c *cartesiaWSClient) notifyAllError(err error) {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+
+	for id, ch := range c.pending {
+		select {
+		case ch <- &wsResponse{
+			Type:      "error",
+			Done:      true,
+			ContextID: id,
+			Title:     "Connection error",
+			Message:   err.Error(),
+		}:
+		default:
+			// Channel full — bridge goroutine is behind or gone.
+		}
+		delete(c.pending, id)
+	}
+}
+
+// isNormalClose returns true if the error is a normal WebSocket close.
+func isNormalClose(err error) bool {
+	return websocket.IsCloseError(err,
+		websocket.CloseNormalClosure,
+		websocket.CloseGoingAway,
+	)
+}

--- a/internal/tts/client.go
+++ b/internal/tts/client.go
@@ -7,9 +7,26 @@ import (
 	"github.com/streamcoreai/server/internal/config"
 )
 
+// StreamChunk represents a chunk of synthesized PCM audio streamed from the
+// TTS provider. The channel closes when synthesis is complete. If Err is
+// non-nil the synthesis failed and no further chunks will arrive.
+type StreamChunk struct {
+	PCM []byte
+	Err error
+}
+
 // Client synthesizes text to PCM audio (linear16, 16kHz mono).
 type Client interface {
+	// Synthesize produces the full audio for text in one shot.
 	Synthesize(ctx context.Context, text string) ([]byte, error)
+
+	// SynthesizeStream produces audio incrementally via a channel, so playback
+	// can begin before the full utterance is ready. The channel is always
+	// closed by the producer (even on error). Cancel ctx to abort early.
+	//
+	// Providers that return audio in a single envelope (a JSON body, say)
+	// satisfy this by emitting one chunk — callers need not care which.
+	SynthesizeStream(ctx context.Context, text string) (<-chan StreamChunk, error)
 }
 
 // NewClient returns a TTS client for the configured provider. The
@@ -36,7 +53,15 @@ func newProviderClient(cfg *config.Config) (Client, error) {
 		if cfg.Cartesia.APIKey == "" {
 			return nil, ErrMissingAPIKey{Provider: "cartesia", Field: "[cartesia] api_key"}
 		}
-		return NewCartesiaClient(cfg.Cartesia.APIKey, cfg.Cartesia.VoiceID), nil
+		client := NewCartesiaWSClient(cfg.Cartesia.APIKey, cfg.Cartesia.VoiceID, cfg.Cartesia.WSURL)
+		// Gate generations to the account's TTS concurrency limit so extra
+		// requests queue locally instead of getting 429s. A negative limit
+		// disables gating; the limiter is shared process-wide (one ceiling
+		// per Cartesia key).
+		if cfg.Cartesia.MaxConcurrency > 0 {
+			client = newLimitedClient(client, sharedConcurrencyLimiter(cfg.Cartesia.MaxConcurrency))
+		}
+		return client, nil
 	case "elevenlabs":
 		if cfg.ElevenLabs.APIKey == "" {
 			return nil, ErrMissingAPIKey{Provider: "elevenlabs", Field: "[elevenlabs] api_key"}
@@ -62,4 +87,18 @@ type sanitizingClient struct {
 
 func (s *sanitizingClient) Synthesize(ctx context.Context, text string) ([]byte, error) {
 	return s.inner.Synthesize(ctx, SanitizeForTTS(text))
+}
+
+func (s *sanitizingClient) SynthesizeStream(ctx context.Context, text string) (<-chan StreamChunk, error) {
+	return s.inner.SynthesizeStream(ctx, SanitizeForTTS(text))
+}
+
+// SynthesizeStreamWithControls forwards per-utterance voice controls to the
+// wrapped provider when it supports them, degrading to a plain stream when it
+// doesn't — callers never need to know which provider is configured.
+func (s *sanitizingClient) SynthesizeStreamWithControls(ctx context.Context, text string, vc VoiceControls) (<-chan StreamChunk, error) {
+	if cs, ok := s.inner.(ControllableStreamer); ok {
+		return cs.SynthesizeStreamWithControls(ctx, SanitizeForTTS(text), vc)
+	}
+	return s.inner.SynthesizeStream(ctx, SanitizeForTTS(text))
 }

--- a/internal/tts/controls.go
+++ b/internal/tts/controls.go
@@ -1,0 +1,80 @@
+package tts
+
+import (
+	"context"
+	"strings"
+)
+
+// VoiceControls carries per-utterance delivery hints from the conversation
+// layer to the TTS provider — the difference between a flat robotic
+// "sorry, I didn't catch that" and a warm, slightly slower one. Zero value
+// means "provider defaults".
+type VoiceControls struct {
+	// Speed is a playback-rate multiplier (1.0 = normal). Zero = unset.
+	// Providers clamp to their own safe range.
+	Speed float64
+	// Tone is the normalized tag the LLM emitted ("warm", "empathetic",
+	// …). Providers with richer expressiveness settings may map it beyond
+	// speed (e.g. ElevenLabs stability).
+	Tone string
+}
+
+// IsZero reports whether no controls were requested.
+func (vc VoiceControls) IsZero() bool {
+	return vc.Speed == 0 && vc.Tone == ""
+}
+
+// ControllableStreamer is the optional capability interface for providers
+// (and wrappers) that accept per-utterance voice controls. Callers
+// type-assert and fall back to plain SynthesizeStream when unsupported, so
+// adding a provider never requires touching every Client implementation.
+type ControllableStreamer interface {
+	SynthesizeStreamWithControls(ctx context.Context, text string, vc VoiceControls) (<-chan StreamChunk, error)
+}
+
+// voiceTags is the inline-tag vocabulary the LLM may emit at the start of a
+// sentence (taught in the voice-output system prompt). Tags map to delivery
+// presets; unknown bracketed text is left untouched so legitimate brackets
+// can't be eaten.
+var voiceTags = map[string]VoiceControls{
+	"warm":       {Speed: 0.95, Tone: "warm"},
+	"empathetic": {Speed: 0.9, Tone: "empathetic"},
+	"calm":       {Speed: 0.9, Tone: "calm"},
+	"slow":       {Speed: 0.85, Tone: "slow"},
+	"excited":    {Speed: 1.1, Tone: "excited"},
+	"fast":       {Speed: 1.1, Tone: "fast"},
+}
+
+// ParseVoiceTag strips one leading [tag] from a sentence and returns the
+// matching controls plus the clean sentence. Sentences without a known
+// leading tag come back unchanged with zero controls.
+func ParseVoiceTag(sentence string) (VoiceControls, string) {
+	trimmed := strings.TrimSpace(sentence)
+	if !strings.HasPrefix(trimmed, "[") {
+		return VoiceControls{}, sentence
+	}
+	end := strings.Index(trimmed, "]")
+	if end <= 1 || end > 16 {
+		return VoiceControls{}, sentence
+	}
+	tag := strings.ToLower(strings.TrimSpace(trimmed[1:end]))
+	vc, ok := voiceTags[tag]
+	if !ok {
+		return VoiceControls{}, sentence
+	}
+	return vc, strings.TrimSpace(trimmed[end+1:])
+}
+
+// StripVoiceTags removes every known [tag] occurrence from text — used when
+// recording transcripts so delivery hints never pollute what reviews and
+// the LLM history treat as spoken words.
+func StripVoiceTags(text string) string {
+	if !strings.Contains(text, "[") {
+		return text
+	}
+	for tag := range voiceTags {
+		text = strings.ReplaceAll(text, "["+tag+"]", "")
+		text = strings.ReplaceAll(text, "["+strings.ToUpper(tag[:1])+tag[1:]+"]", "")
+	}
+	return strings.TrimSpace(strings.Join(strings.Fields(text), " "))
+}

--- a/internal/tts/controls_test.go
+++ b/internal/tts/controls_test.go
@@ -1,0 +1,55 @@
+package tts
+
+import "testing"
+
+func TestParseVoiceTag(t *testing.T) {
+	cases := []struct {
+		in        string
+		wantTone  string
+		wantClean string
+	}{
+		{"[warm] Thanks so much for calling.", "warm", "Thanks so much for calling."},
+		{"[empathetic] I'm really sorry to hear that.", "empathetic", "I'm really sorry to hear that."},
+		{"[Excited] That's wonderful news!", "excited", "That's wonderful news!"},
+		{"Plain sentence with no tag.", "", "Plain sentence with no tag."},
+		// Unknown bracket content must pass through untouched.
+		{"[Context: something] stays.", "", "[Context: something] stays."},
+		{"[12:30] is your booking time.", "", "[12:30] is your booking time."},
+		{"", "", ""},
+	}
+	for _, c := range cases {
+		vc, clean := ParseVoiceTag(c.in)
+		if vc.Tone != c.wantTone || clean != c.wantClean {
+			t.Errorf("ParseVoiceTag(%q) = (%q, %q), want (%q, %q)", c.in, vc.Tone, clean, c.wantTone, c.wantClean)
+		}
+		if c.wantTone != "" && vc.Speed == 0 {
+			t.Errorf("ParseVoiceTag(%q) returned zero speed for known tag", c.in)
+		}
+	}
+}
+
+func TestStripVoiceTags(t *testing.T) {
+	in := "[warm] Thanks for calling. [excited] We got you booked!"
+	want := "Thanks for calling. We got you booked!"
+	if got := StripVoiceTags(in); got != want {
+		t.Errorf("StripVoiceTags = %q, want %q", got, want)
+	}
+	// Unknown brackets survive.
+	keep := "Your appointment [tentative] is at three."
+	if got := StripVoiceTags(keep); got != keep {
+		t.Errorf("StripVoiceTags removed unknown bracket: %q", got)
+	}
+}
+
+// All wrappers must expose the controls capability so a pipeline
+// type-assertion reaches the provider through sanitizer + limiter layers.
+func TestWrappersForwardControlsCapability(t *testing.T) {
+	var c Client = &sanitizingClient{inner: &deepgramClient{}}
+	if _, ok := c.(ControllableStreamer); !ok {
+		t.Error("sanitizingClient must implement ControllableStreamer")
+	}
+	var l Client = &limitedClient{inner: &deepgramClient{}, limiter: newConcurrencyLimiter(1)}
+	if _, ok := l.(ControllableStreamer); !ok {
+		t.Error("limitedClient must implement ControllableStreamer")
+	}
+}

--- a/internal/tts/deepgram.go
+++ b/internal/tts/deepgram.go
@@ -23,7 +23,7 @@ func NewDeepgramClient(apiKey string) Client {
 	}
 }
 
-func (c *deepgramClient) Synthesize(ctx context.Context, text string) ([]byte, error) {
+func (c *deepgramClient) buildRequest(ctx context.Context, text string) (*http.Request, error) {
 	params := url.Values{}
 	params.Set("model", "aura-asteria-en")
 	params.Set("encoding", "linear16")
@@ -39,6 +39,33 @@ func (c *deepgramClient) Synthesize(ctx context.Context, text string) ([]byte, e
 
 	req.Header.Set("Authorization", fmt.Sprintf("Token %s", c.apiKey))
 	req.Header.Set("Content-Type", "text/plain")
+	return req, nil
+}
+
+// SynthesizeStream reads the response body as it arrives. Deepgram returns
+// raw headerless PCM, so bytes are playable the moment they land.
+func (c *deepgramClient) SynthesizeStream(ctx context.Context, text string) (<-chan StreamChunk, error) {
+	req, err := c.buildRequest(ctx, text)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("tts request: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, fmt.Errorf("tts error %d: %s", resp.StatusCode, string(body))
+	}
+	return streamHTTPResponse(ctx, resp), nil
+}
+
+func (c *deepgramClient) Synthesize(ctx context.Context, text string) ([]byte, error) {
+	req, err := c.buildRequest(ctx, text)
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/internal/tts/elevenlabs.go
+++ b/internal/tts/elevenlabs.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net/http"
 )
 
@@ -52,14 +53,24 @@ type elevenlabsVoiceSettings struct {
 	SimilarityBoost float64 `json:"similarity_boost"`
 }
 
-func (c *elevenlabsClient) Synthesize(ctx context.Context, text string) ([]byte, error) {
+// buildRequest composes the synthesis request. vc carries optional per-utterance
+// delivery hints; the zero value leaves the voice at its configured defaults.
+func (c *elevenlabsClient) buildRequest(ctx context.Context, text string, vc VoiceControls) (*http.Request, error) {
+	settings := elevenlabsVoiceSettings{
+		Stability:       0.5,
+		SimilarityBoost: 0.75,
+	}
+	// ElevenLabs has no speed parameter on this endpoint, so tone is mapped to
+	// stability instead: calmer tones get a steadier read, livelier ones more
+	// variation. Clamped to the API's valid range.
+	if vc.Speed > 0 {
+		settings.Stability = math.Min(0.9, math.Max(0.15, 0.5+(1.0-vc.Speed)))
+	}
+
 	body := elevenlabsRequest{
-		Text:    text,
-		ModelID: c.model,
-		VoiceSettings: elevenlabsVoiceSettings{
-			Stability:       0.5,
-			SimilarityBoost: 0.75,
-		},
+		Text:          text,
+		ModelID:       c.model,
+		VoiceSettings: settings,
 	}
 
 	jsonBody, err := json.Marshal(body)
@@ -76,6 +87,35 @@ func (c *elevenlabsClient) Synthesize(ctx context.Context, text string) ([]byte,
 
 	req.Header.Set("xi-api-key", c.apiKey)
 	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+func (c *elevenlabsClient) SynthesizeStream(ctx context.Context, text string) (<-chan StreamChunk, error) {
+	return c.SynthesizeStreamWithControls(ctx, text, VoiceControls{})
+}
+
+func (c *elevenlabsClient) SynthesizeStreamWithControls(ctx context.Context, text string, vc VoiceControls) (<-chan StreamChunk, error) {
+	req, err := c.buildRequest(ctx, text, vc)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("elevenlabs request: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, fmt.Errorf("elevenlabs error %d: %s", resp.StatusCode, string(respBody))
+	}
+	return streamHTTPResponse(ctx, resp), nil
+}
+
+func (c *elevenlabsClient) Synthesize(ctx context.Context, text string) ([]byte, error) {
+	req, err := c.buildRequest(ctx, text, VoiceControls{})
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/internal/tts/http.go
+++ b/internal/tts/http.go
@@ -1,6 +1,9 @@
 package tts
 
 import (
+	"context"
+	"fmt"
+	"io"
 	"net/http"
 	"time"
 )
@@ -25,4 +28,80 @@ func newPooledHTTPClient() *http.Client {
 			ResponseHeaderTimeout: 30 * time.Second,
 		},
 	}
+}
+
+// pumpPCMStream incrementally reads raw linear16 PCM from body and emits it
+// on ch as it arrives, so playback can start before the provider finishes
+// synthesizing. Emitted chunks are always even-length (int16-aligned); a
+// trailing odd byte is carried into the next read. Returns on EOF, read
+// error (reported on ch), or ctx cancellation. The caller owns closing ch
+// and body.
+func pumpPCMStream(ctx context.Context, body io.Reader, ch chan<- StreamChunk) {
+	var carry byte
+	hasCarry := false
+	buf := make([]byte, 8192)
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		n, err := body.Read(buf)
+		if n > 0 {
+			chunk := make([]byte, 0, n+1)
+			if hasCarry {
+				chunk = append(chunk, carry)
+				hasCarry = false
+			}
+			chunk = append(chunk, buf[:n]...)
+			if len(chunk)%2 == 1 {
+				carry = chunk[len(chunk)-1]
+				hasCarry = true
+				chunk = chunk[:len(chunk)-1]
+			}
+			if len(chunk) > 0 {
+				select {
+				case ch <- StreamChunk{PCM: chunk}:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+		if err != nil {
+			if err != io.EOF && ctx.Err() == nil {
+				select {
+				case ch <- StreamChunk{Err: fmt.Errorf("tts stream read: %w", err)}:
+				case <-ctx.Done():
+				}
+			}
+			return
+		}
+	}
+}
+
+// streamHTTPResponse turns an in-flight HTTP response carrying raw linear16
+// PCM into a StreamChunk channel. It takes ownership of resp.Body.
+func streamHTTPResponse(ctx context.Context, resp *http.Response) <-chan StreamChunk {
+	ch := make(chan StreamChunk, 8)
+	go func() {
+		defer close(ch)
+		defer resp.Body.Close()
+		pumpPCMStream(ctx, resp.Body, ch)
+	}()
+	return ch
+}
+
+// streamWhole adapts a one-shot Synthesize into the streaming interface for
+// providers that return audio in a single envelope (a JSON body, say) and
+// therefore cannot emit partial audio.
+func streamWhole(ctx context.Context, synth func(context.Context, string) ([]byte, error), text string) (<-chan StreamChunk, error) {
+	ch := make(chan StreamChunk, 1)
+	go func() {
+		defer close(ch)
+		pcm, err := synth(ctx, text)
+		if err != nil {
+			ch <- StreamChunk{Err: err}
+			return
+		}
+		ch <- StreamChunk{PCM: pcm}
+	}()
+	return ch, nil
 }

--- a/internal/tts/limiter.go
+++ b/internal/tts/limiter.go
@@ -1,0 +1,188 @@
+package tts
+
+import (
+	"context"
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Cartesia counts TTS concurrency by the number of unique generation contexts
+// active at a given moment — not by phone call and not by open WebSocket
+// connection. Idle connections cost nothing, and the account is allowed up to
+// 10× the concurrency limit in parallel connections (see
+// docs.cartesia.ai/use-the-api/concurrency-limits-and-timeouts). Exceeding the
+// active-context limit returns HTTP 429.
+//
+// concurrencyLimiter is a process-wide counting semaphore that gates how many
+// SynthesizeStream / Synthesize calls may be generating simultaneously. When
+// all slots are taken, additional requests block (queue) until one frees,
+// instead of being rejected by Cartesia. Because agent speech is bursty and
+// half-duplex, a handful of slots comfortably serves many concurrent calls —
+// contention only occurs when more callers are literally being spoken to at
+// the exact same instant than the plan allows.
+type concurrencyLimiter struct {
+	slots   chan struct{}
+	limit   int
+	inUse   atomic.Int64
+	waiting atomic.Int64
+}
+
+func newConcurrencyLimiter(limit int) *concurrencyLimiter {
+	return &concurrencyLimiter{
+		slots: make(chan struct{}, limit),
+		limit: limit,
+	}
+}
+
+// acquire takes a generation slot, blocking until one is free or ctx is
+// cancelled. It returns ctx.Err() if the wait is abandoned (e.g. barge-in or
+// call hangup) before a slot becomes available.
+func (l *concurrencyLimiter) acquire(ctx context.Context) error {
+	// Fast path: a slot is immediately available.
+	select {
+	case l.slots <- struct{}{}:
+		l.inUse.Add(1)
+		return nil
+	default:
+	}
+
+	// Slow path: all slots busy — queue for one.
+	waiting := l.waiting.Add(1)
+	defer l.waiting.Add(-1)
+	start := time.Now()
+	log.Printf("[tts:limit] all %d generation slots in use, queuing request (in_use=%d waiting=%d)",
+		l.limit, l.inUse.Load(), waiting)
+
+	select {
+	case l.slots <- struct{}{}:
+		l.inUse.Add(1)
+		log.Printf("[tts:limit] slot acquired after %s queued (in_use=%d waiting=%d)",
+			time.Since(start).Round(time.Millisecond), l.inUse.Load(), l.waiting.Load()-1)
+		return nil
+	case <-ctx.Done():
+		log.Printf("[tts:limit] request abandoned after %s queued: %v",
+			time.Since(start).Round(time.Millisecond), ctx.Err())
+		return ctx.Err()
+	}
+}
+
+// release returns a slot to the pool. It must be called exactly once for every
+// successful acquire.
+func (l *concurrencyLimiter) release() {
+	<-l.slots
+	l.inUse.Add(-1)
+}
+
+// InUse reports how many generation slots are currently held. Exposed for
+// observability/health surfaces.
+func (l *concurrencyLimiter) InUse() int { return int(l.inUse.Load()) }
+
+// Waiting reports how many requests are currently queued for a slot.
+func (l *concurrencyLimiter) Waiting() int { return int(l.waiting.Load()) }
+
+// The limiter is process-global: every call builds its own tts.Client (and its
+// own Cartesia WebSocket), but the concurrency ceiling applies to the whole
+// account/API key, so all of them must share one semaphore.
+//
+// NOTE: this is in-process only. It is correct for a single voice-server task
+// (the current ECS topology, asg_desired_size = 1). If the service is scaled
+// to multiple instances sharing one Cartesia key, each instance would enforce
+// the limit independently and the account total could be exceeded — that would
+// need a distributed counter (e.g. Redis/Postgres) instead.
+var (
+	globalLimiterOnce sync.Once
+	globalLimiter     *concurrencyLimiter
+)
+
+// sharedConcurrencyLimiter returns the process-global limiter, creating it on
+// first use with the given limit. Subsequent calls return the same instance
+// and ignore their limit argument (config is constant for the process).
+func sharedConcurrencyLimiter(limit int) *concurrencyLimiter {
+	globalLimiterOnce.Do(func() {
+		globalLimiter = newConcurrencyLimiter(limit)
+		log.Printf("[tts:limit] cartesia generation concurrency limited to %d slots", limit)
+	})
+	return globalLimiter
+}
+
+// limitedClient wraps a TTS Client so every generation passes through a
+// concurrency limiter. It releases the slot when the synthesis stream
+// finishes, errors, or is cancelled.
+type limitedClient struct {
+	inner   Client
+	limiter *concurrencyLimiter
+}
+
+func newLimitedClient(inner Client, limiter *concurrencyLimiter) Client {
+	return &limitedClient{inner: inner, limiter: limiter}
+}
+
+func (c *limitedClient) Synthesize(ctx context.Context, text string) ([]byte, error) {
+	if err := c.limiter.acquire(ctx); err != nil {
+		return nil, err
+	}
+	defer c.limiter.release()
+	return c.inner.Synthesize(ctx, text)
+}
+
+func (c *limitedClient) SynthesizeStream(ctx context.Context, text string) (<-chan StreamChunk, error) {
+	return c.limitedStream(ctx, func() (<-chan StreamChunk, error) {
+		return c.inner.SynthesizeStream(ctx, text)
+	})
+}
+
+// SynthesizeStreamWithControls forwards voice controls through the limiter
+// to the wrapped provider, degrading to a plain stream when it doesn't
+// support them. Slot accounting is identical to SynthesizeStream.
+func (c *limitedClient) SynthesizeStreamWithControls(ctx context.Context, text string, vc VoiceControls) (<-chan StreamChunk, error) {
+	return c.limitedStream(ctx, func() (<-chan StreamChunk, error) {
+		if cs, ok := c.inner.(ControllableStreamer); ok {
+			return cs.SynthesizeStreamWithControls(ctx, text, vc)
+		}
+		return c.inner.SynthesizeStream(ctx, text)
+	})
+}
+
+// limitedStream runs start under a held limiter slot and relays the
+// resulting stream, releasing the slot when the stream closes.
+func (c *limitedClient) limitedStream(ctx context.Context, start func() (<-chan StreamChunk, error)) (<-chan StreamChunk, error) {
+	if err := c.limiter.acquire(ctx); err != nil {
+		return nil, err
+	}
+
+	stream, err := start()
+	if err != nil {
+		c.limiter.release()
+		return nil, err
+	}
+
+	// Relay the inner stream so the slot is held for exactly the lifetime of
+	// the generation and released the moment it closes (completion, error, or
+	// barge-in cancel). The relay also selects on ctx so a consumer that stops
+	// reading after cancellation can never wedge this goroutine — guaranteeing
+	// the slot is always returned.
+	out := make(chan StreamChunk, 16)
+	go func() {
+		defer close(out)
+		defer c.limiter.release()
+		for {
+			select {
+			case chunk, ok := <-stream:
+				if !ok {
+					return
+				}
+				select {
+				case out <- chunk:
+				case <-ctx.Done():
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return out, nil
+}

--- a/internal/tts/limiter_test.go
+++ b/internal/tts/limiter_test.go
@@ -1,0 +1,155 @@
+package tts
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeStreamClient is a controllable TTS Client for exercising the limiter
+// decorator. Each SynthesizeStream returns a channel the test closes via the
+// returned release func, letting tests hold a generation "open" for as long as
+// they want.
+type fakeStreamClient struct {
+	startErr error
+}
+
+func (f *fakeStreamClient) Synthesize(ctx context.Context, text string) ([]byte, error) {
+	return []byte(text), f.startErr
+}
+
+func (f *fakeStreamClient) SynthesizeStream(ctx context.Context, text string) (<-chan StreamChunk, error) {
+	if f.startErr != nil {
+		return nil, f.startErr
+	}
+	ch := make(chan StreamChunk, 1)
+	ch <- StreamChunk{PCM: []byte(text)}
+	// Caller closes via context cancel or by draining; for these tests we
+	// leave it open and let ctx drive completion where needed. To represent a
+	// finished generation we close immediately after the single chunk unless
+	// the test keeps ctx alive. Simplicity: close right away.
+	close(ch)
+	return ch, nil
+}
+
+func TestConcurrencyLimiterBlocksAtLimit(t *testing.T) {
+	lim := newConcurrencyLimiter(2)
+	ctx := context.Background()
+
+	if err := lim.acquire(ctx); err != nil {
+		t.Fatalf("acquire 1: %v", err)
+	}
+	if err := lim.acquire(ctx); err != nil {
+		t.Fatalf("acquire 2: %v", err)
+	}
+	if got := lim.InUse(); got != 2 {
+		t.Fatalf("InUse = %d, want 2", got)
+	}
+
+	// Third acquire must block until a slot frees.
+	acquired := make(chan struct{})
+	go func() {
+		_ = lim.acquire(ctx)
+		close(acquired)
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("third acquire returned while at limit; expected it to block")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if got := lim.Waiting(); got != 1 {
+		t.Fatalf("Waiting = %d, want 1", got)
+	}
+
+	lim.release()
+
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("third acquire did not unblock after release")
+	}
+}
+
+func TestConcurrencyLimiterContextCancelWhileQueued(t *testing.T) {
+	lim := newConcurrencyLimiter(1)
+	if err := lim.acquire(context.Background()); err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- lim.acquire(ctx) }()
+
+	// Let the goroutine reach the queued state, then cancel.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("queued acquire err = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancelled acquire did not return")
+	}
+
+	if got := lim.InUse(); got != 1 {
+		t.Fatalf("InUse = %d after cancel, want 1 (cancelled waiter must not take a slot)", got)
+	}
+}
+
+func TestLimitedClientReleasesWhenStreamCloses(t *testing.T) {
+	lim := newConcurrencyLimiter(1)
+	client := newLimitedClient(&fakeStreamClient{}, lim)
+	ctx := context.Background()
+
+	stream, err := client.SynthesizeStream(ctx, "hello")
+	if err != nil {
+		t.Fatalf("SynthesizeStream: %v", err)
+	}
+	// Drain the stream — once it closes, the slot must be released.
+	for range stream {
+	}
+
+	// Poll briefly: release happens in the relay goroutine after close.
+	deadline := time.After(time.Second)
+	for lim.InUse() != 0 {
+		select {
+		case <-deadline:
+			t.Fatalf("slot not released after stream drained; InUse = %d", lim.InUse())
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+
+	// A fresh acquire should now succeed immediately.
+	if err := lim.acquire(ctx); err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+}
+
+func TestLimitedClientReleasesOnStartError(t *testing.T) {
+	lim := newConcurrencyLimiter(1)
+	client := newLimitedClient(&fakeStreamClient{startErr: errors.New("boom")}, lim)
+
+	if _, err := client.SynthesizeStream(context.Background(), "x"); err == nil {
+		t.Fatal("expected error from failed start")
+	}
+	if got := lim.InUse(); got != 0 {
+		t.Fatalf("InUse = %d after start error, want 0 (slot must be released)", got)
+	}
+}
+
+func TestLimitedClientSynthesizeReleases(t *testing.T) {
+	lim := newConcurrencyLimiter(1)
+	client := newLimitedClient(&fakeStreamClient{}, lim)
+
+	if _, err := client.Synthesize(context.Background(), "hi"); err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	if got := lim.InUse(); got != 0 {
+		t.Fatalf("InUse = %d after Synthesize, want 0", got)
+	}
+}

--- a/internal/tts/speechify.go
+++ b/internal/tts/speechify.go
@@ -246,3 +246,10 @@ func resample24kTo16k(in []byte) []byte {
 	}
 	return out
 }
+
+// SynthesizeStream emits the whole utterance as one chunk. Speechify returns
+// base64 audio inside a JSON envelope, and the 24 kHz to 16 kHz resampler
+// needs a complete buffer, so there is nothing to stream incrementally.
+func (c *speechifyClient) SynthesizeStream(ctx context.Context, text string) (<-chan StreamChunk, error) {
+	return streamWhole(ctx, c.Synthesize, text)
+}

--- a/internal/tts/vibevoice.go
+++ b/internal/tts/vibevoice.go
@@ -78,3 +78,10 @@ func (c *vibevoiceTTSClient) Synthesize(ctx context.Context, text string) ([]byt
 	log.Printf("[tts:vibevoice] synthesized %d bytes for %d chars of text", len(data), len(text))
 	return data, nil
 }
+
+// SynthesizeStream emits the whole utterance as one chunk: the VibeVoice
+// server returns audio in a single JSON envelope, so there is nothing to
+// stream incrementally.
+func (c *vibevoiceTTSClient) SynthesizeStream(ctx context.Context, text string) (<-chan StreamChunk, error) {
+	return streamWhole(ctx, c.Synthesize, text)
+}


### PR DESCRIPTION
This pull request introduces several improvements and new features related to configuration, speech-to-text (STT) provider support, and LLM tool-call handling. The most significant changes include adding support for AssemblyAI as an STT provider, enhancing configuration options for Deepgram and Cartesia, and making the OpenAI LLM integration more robust against tool-call errors and loops.

**Provider and Configuration Enhancements:**

* Added support for AssemblyAI as a streaming STT provider, including new configuration options in both `config.toml.example` and the `Config` struct (`AssemblyAIConfig`). This includes model selection, language, formatting, silence detection, and keyterms. [[1]](diffhunk://#diff-514f3c6049dd26198894991be37accf7786d0b38e3a1fc21f201c14be271b642L22-R22) [[2]](diffhunk://#diff-514f3c6049dd26198894991be37accf7786d0b38e3a1fc21f201c14be271b642R35-R46) [[3]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR22) [[4]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR67-R103)
* Expanded Deepgram and Cartesia configuration options, such as language selection, endpointing, utterance end detection, keyterms for Deepgram, and WebSocket URL and concurrency limits for Cartesia. [[1]](diffhunk://#diff-514f3c6049dd26198894991be37accf7786d0b38e3a1fc21f201c14be271b642R35-R46) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR67-R103) [[3]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR121-R129)
* Updated default values and logic for new configuration fields in the `Load` function.
* Updated documentation (`README.md`) to reflect the addition of AssemblyAI and new configuration options for Deepgram and Cartesia, including provider tables and instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L143-R143) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L472-R472) [[3]](diffhunk://#diff-514f3c6049dd26198894991be37accf7786d0b38e3a1fc21f201c14be271b642L22-R22) [[4]](diffhunk://#diff-514f3c6049dd26198894991be37accf7786d0b38e3a1fc21f201c14be271b642R35-R46)

**LLM Tool-Call Handling Improvements:**

* Improved the OpenAI LLM client to:
  * Reconcile conversation history before each turn, patching any interrupted tool calls to prevent future errors. [[1]](diffhunk://#diff-b784602960fcf6fb9fb45f82224c87527cf99d94d1276502b1520a04c898eda2R124-R148) [[2]](diffhunk://#diff-b784602960fcf6fb9fb45f82224c87527cf99d94d1276502b1520a04c898eda2R214-R316)
  * Cap tool-call rounds per turn to 4 and force a text response if the cap is exceeded or if the model gets stuck in a loop of duplicate tool calls. [[1]](diffhunk://#diff-b784602960fcf6fb9fb45f82224c87527cf99d94d1276502b1520a04c898eda2R124-R148) [[2]](diffhunk://#diff-b784602960fcf6fb9fb45f82224c87527cf99d94d1276502b1520a04c898eda2L145-R163) [[3]](diffhunk://#diff-b784602960fcf6fb9fb45f82224c87527cf99d94d1276502b1520a04c898eda2R176-R204) [[4]](diffhunk://#diff-b784602960fcf6fb9fb45f82224c87527cf99d94d1276502b1520a04c898eda2R214-R316)
  * Add robust handling for missing tool-call indices in streaming responses, preventing panics from nil pointers. [[1]](diffhunk://#diff-b784602960fcf6fb9fb45f82224c87527cf99d94d1276502b1520a04c898eda2L226-R366) [[2]](diffhunk://#diff-b784602960fcf6fb9fb45f82224c87527cf99d94d1276502b1520a04c898eda2R467-R478)

**Testing and Workflow:**

* Added unit tests for the new `toolCallDeltaIndex` and `reconcileHistory` logic to ensure robust handling of edge cases and maintain OpenAI compatibility.
* Introduced a GitHub Actions workflow (`.github/workflows/stars-history.yml`) to track repository star history.
* Added a "Star history" section to the `README.md`.

These changes improve the flexibility, reliability, and maintainability of the codebase, especially around STT provider integration and LLM tool-call management.