### PR TITLE
server: upstream Tier 3 turn-quality work from helloDesk

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,29 @@ type PipelineConfig struct {
 	Greeting         string `toml:"greeting"`          // Text spoken by the agent when a user connects
 	GreetingOutgoing string `toml:"greeting_outgoing"` // Text spoken on outgoing SIP calls (falls back to greeting)
 	Debug            bool   `toml:"debug"`             // Emit per-turn timing events over the DataChannel
+
+	// UserSpeechQuietMs is how long the caller must be quiet before the agent
+	// starts speaking. It stops the agent talking over someone who is still
+	// mid-thought after the transcript went final.
+	UserSpeechQuietMs int `toml:"user_speech_quiet_ms"`
+
+	// TurnMergeMs is the debounce window for merging consecutive final
+	// transcripts into a single turn. A caller who pauses mid-sentence
+	// ("I want to... um... book a table") otherwise fires two turns and the
+	// agent answers the first half.
+	TurnMergeMs int `toml:"turn_merge_ms"`
+
+	// ReadbackBargeInGuardEnabled suppresses weak correction/backchannel
+	// barge-ins ("yeah", "mm-hm", "no that's wrong") while the agent is
+	// reading values back for confirmation. Only strong commands (stop,
+	// cancel, hang up) cut through. Default off, preserving existing
+	// barge-in behaviour.
+	ReadbackBargeInGuardEnabled bool `toml:"readback_bargein_guard_enabled"`
+
+	// RAGPrefetch starts retrieval speculatively during the turn-merge
+	// window so embedding and vector search overlap the debounce instead of
+	// adding to it.
+	RAGPrefetch bool `toml:"rag_prefetch"`
 }
 
 type ServerConfig struct {
@@ -205,6 +228,15 @@ func Load(path string) (*Config, error) {
 	setDefault(&cfg.VibeVoice.ASRURL, "ws://127.0.0.1:8200")
 	setDefault(&cfg.VibeVoice.TTSURL, "http://127.0.0.1:8300")
 	setDefault(&cfg.VibeVoice.Voice, "en-Emma_woman")
+
+	// Quiet grace and turn-merge debounce. Both default to conservative values
+	// that measurably reduce the agent talking over a caller mid-thought.
+	if cfg.Pipeline.UserSpeechQuietMs == 0 {
+		cfg.Pipeline.UserSpeechQuietMs = 600
+	}
+	if cfg.Pipeline.TurnMergeMs == 0 {
+		cfg.Pipeline.TurnMergeMs = 350
+	}
 
 	// Default barge-in to true if not explicitly set
 	if cfg.Pipeline.BargeIn == nil {

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -31,6 +31,9 @@ type ToolResult struct {
 // Client is the interface that all LLM providers must implement.
 type Client interface {
 	Chat(ctx context.Context, userText string, onChunk func(string), onSentence func(string)) (string, error)
+	// OneShot makes a single non-streaming call independent of conversation
+	// state. Used for focused transformations such as summarisation.
+	OneShot(ctx context.Context, system, user string) (string, error)
 	SetTools(tools []ToolDefinition)
 	SetToolHandler(handler func(ctx context.Context, call ToolCall) (string, error))
 	AppendSystemPrompt(text string)

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -296,3 +296,28 @@ func (c *ollamaClient) Reset() {
 		{Role: "system", Content: c.systemPrompt},
 	}
 }
+func (c *ollamaClient) OneShot(ctx context.Context, system, user string) (string, error) {
+	stream := false
+	req := &api.ChatRequest{
+		Model: c.model,
+		Messages: []api.Message{
+			{Role: "system", Content: system},
+			{Role: "user", Content: user},
+		},
+		Stream: &stream,
+		// Disable reasoning. Thinking models (qwen3, deepseek-r1, gpt-oss…)
+		// otherwise emit a long hidden reasoning preamble before any answer,
+		// which blows past the call deadline ("context deadline exceeded") and
+		// wastes tokens for a focused transform. Ignored by non-thinking models.
+		Think: &api.ThinkValue{Value: false},
+	}
+	var out strings.Builder
+	err := c.client.Chat(ctx, req, func(resp api.ChatResponse) error {
+		out.WriteString(resp.Message.Content)
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("oneshot completion: %w", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -571,3 +571,23 @@ func pruneHistory(h []openai.ChatCompletionMessage) []openai.ChatCompletionMessa
 	kept = append(kept, tail...)
 	return kept
 }
+
+// OneShot performs a single non-streaming completion independent of the
+// conversation history, so a background task cannot disturb the live turn.
+func (c *openaiClient) OneShot(ctx context.Context, system, user string) (string, error) {
+	resp, err := c.client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model:       c.model,
+		Temperature: 0,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleSystem, Content: system},
+			{Role: openai.ChatMessageRoleUser, Content: user},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("oneshot completion: %w", err)
+	}
+	if len(resp.Choices) == 0 {
+		return "", nil
+	}
+	return strings.TrimSpace(resp.Choices[0].Message.Content), nil
+}

--- a/internal/pipeline/agent.go
+++ b/internal/pipeline/agent.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/streamcoreai/server/internal/audio"
+	"github.com/streamcoreai/server/internal/procstat"
+	"github.com/streamcoreai/server/internal/rag"
 	"github.com/streamcoreai/server/internal/tts"
 )
 
@@ -105,17 +107,61 @@ func (p *Pipeline) respond(userText string, turnStart time.Time) {
 		}
 	}
 
-	// Retrieve relevant context via RAG before calling the LLM.
+	timing := &procstat.TurnTiming{}
+	if !turnStart.IsZero() {
+		timing.EndpointMs = time.Since(turnStart).Milliseconds()
+	}
+
+	// Retrieve relevant context via RAG before calling the LLM. Turns with no
+	// content-bearing words ("okay, sure, thanks") can't anchor a vector
+	// search, so skipping them removes a network round trip from the turn.
 	if p.ragClient != nil {
-		chunks, err := p.ragClient.Search(respCtx, userText, 0)
-		if err != nil {
-			log.Printf("[agent] RAG search error: %v", err)
-		} else if len(chunks) > 0 {
-			llmInput = fmt.Sprintf("[Context:\n%s]\n\nUser: %s", strings.Join(chunks, "\n---\n"), llmInput)
+		if skip, reason := shouldSkipRAG(p, userText); skip {
+			timing.RAGSkipped, timing.RAGSkipReason = true, reason
+			log.Printf("[agent] RAG skipped: %s", reason)
+		} else {
+			query := p.ragSearchQuery(userText)
+			var chunks []string
+			var err error
+
+			// A prefetch started during the turn-merge window has already paid
+			// the embedding + vector-search latency.
+			if st := p.takeRAGPrefetch(query); st != nil {
+				chunks, err = st.await(respCtx)
+				timing.RAGPrefetched = true
+				timing.EmbeddingMs, timing.VectorSearchMs = st.timing.EmbedMs, st.timing.QueryMs
+			} else {
+				rt := &rag.Timing{}
+				chunks, err = p.ragClient.Search(rag.WithTiming(respCtx, rt), query, 0)
+				timing.EmbeddingMs, timing.VectorSearchMs = rt.EmbedMs, rt.QueryMs
+			}
+
+			if err != nil {
+				log.Printf("[agent] RAG search error: %v", err)
+			} else if len(chunks) > 0 {
+				timing.RAGChunks = len(chunks)
+				llmInput = fmt.Sprintf("[Context:\n%s]\n\nUser: %s", strings.Join(chunks, "\n---\n"), llmInput)
+			}
 		}
 	}
 
+	// Prepend the rolling summary so facts from early in a long call survive
+	// after the LLM's own history window has dropped them.
+	if block := summaryContextBlock(p.currentRollingSummary()); block != "" {
+		llmInput = block + llmInput
+	}
+
+	// When the caller's speech came through garbled, tell the model to ask
+	// rather than guess. Escalates with consecutive low-confidence turns.
+	if note := p.misunderstandingNote(userText); note != "" {
+		llmInput += note
+	}
+
 	p.lastAgentText.Store("")
+	if p.transcriptLog != nil {
+		p.transcriptLog.Add("user", userText)
+	}
+	p.maybeRefreshRollingSummary()
 
 	// Channel decouples LLM sentence production from TTS synthesis so the
 	// LLM stream isn't blocked while waiting for audio.
@@ -167,6 +213,15 @@ func (p *Pipeline) respond(userText string, turnStart time.Time) {
 	}
 
 	wg.Wait()
+
+	if p.transcriptLog != nil {
+		if txt, _ := p.lastAgentText.Load().(string); txt != "" {
+			p.transcriptLog.Add("agent", txt)
+		}
+	}
+	if p.cfg.Pipeline.Debug {
+		timing.Log()
+	}
 }
 
 // synthesizeSentences reads sentences from the channel, calls TTS for each,

--- a/internal/pipeline/bargein.go
+++ b/internal/pipeline/bargein.go
@@ -1,0 +1,277 @@
+package pipeline
+
+// Barge-in classification helpers: pure text predicates shared by the
+// inbound reader and the turn buffer. Deliberately free of Pipeline state
+// so they stay unit-testable.
+
+import (
+	"strings"
+	"unicode"
+)
+
+// readbackPhraseMarkers are normalized word sequences that signal the
+// agent's current utterance is a readback / explicit confirmation
+// prompt (the moments when "yeah actually..." style soft corrections
+// destroy context if allowed to barge in). The list is intentionally
+// small and tied to wording the form-readback templates actually emit.
+// Matched on word boundaries against the normalized agent text — a raw
+// substring match would also fire on words that merely CONTAIN a marker.
+var readbackPhraseMarkers = []string{
+	"is that right",
+	"is that correct",
+	"let me read that back",
+	"just to confirm",
+	"could you spell",
+}
+
+// bargeInMinConfidence gates transcript barge-in on STT confidence so a
+// noise-hallucinated transcript can't mute agent audio. Deepgram reports
+// ≥0.8 for clear speech; hallucinations from line noise typically score
+// well below 0.6.
+const bargeInMinConfidence = 0.6
+
+// isBackchannelOnly reports whether every token of the (already normalized)
+// utterance is acknowledgement vocabulary — the combined-backchannel case.
+func isBackchannelOnly(tokens []string) bool {
+	if len(tokens) == 0 {
+		return false
+	}
+	for _, tok := range tokens {
+		if !backchannelWordTokens[tok] {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizedTranscriptText(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(strings.TrimSpace(s)) {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r):
+			b.WriteRune(r)
+		case r == '\'':
+			b.WriteRune(r)
+		default:
+			b.WriteByte(' ')
+		}
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
+}
+
+func isMeaningfulBargeInTranscript(s string) bool {
+	normalized := normalizedTranscriptText(s)
+	if normalized == "" || backchannelWordTokens[normalized] {
+		return false
+	}
+
+	tokens := strings.Fields(normalized)
+	if len(tokens) == 0 {
+		return false
+	}
+
+	for _, tok := range tokens {
+		if bargeInCommandTokens[tok] {
+			return true
+		}
+	}
+
+	// Combined backchannels ("yep okay", "yeah yeah right") are still just
+	// the caller signalling they're listening — checked after commands so
+	// "okay stop" interrupts but "okay yeah" doesn't.
+	if isBackchannelOnly(tokens) {
+		return false
+	}
+
+	contentWords := 0
+	for _, tok := range tokens {
+		if len(tok) >= 3 && !bargeInWeakTokens[tok] {
+			contentWords++
+		}
+	}
+
+	// Require a content-bearing phrase ("change address", "billing question",
+	// "what time") unless this is an explicit interruption command. This
+	// keeps coughs, acknowledgements, and STT filler artifacts from cutting
+	// off the agent without tying barge-in to any specific business domain.
+	return contentWords >= 1 && len(tokens) >= 2
+}
+
+func isSpeechActivityTranscript(s string) bool {
+	normalized := normalizedTranscriptText(s)
+	if normalized == "" {
+		return false
+	}
+	return len([]rune(strings.ReplaceAll(normalized, " ", ""))) >= 2
+}
+
+// bargeInConfidenceOK reports whether an STT result is confident enough to
+// drive barge-in. Zero means the provider didn't report a confidence —
+// treated as OK because "unknown" must not be conflated with "low".
+func bargeInConfidenceOK(conf float64) bool {
+	return conf == 0 || conf >= bargeInMinConfidence
+}
+
+// isStrongBargeInCommand returns true only for the small set of commands
+// that should always cut through a readback: "stop", "cancel", and
+// "hang up" (which also subsumes "stop talking" via the "stop" token).
+// Anything else — including the bargeInCommandTokens set used elsewhere
+// — is treated as a weak correction when the readback guard is engaged.
+func isStrongBargeInCommand(s string) bool {
+	normalized := normalizedTranscriptText(s)
+	if normalized == "" {
+		return false
+	}
+	tokens := strings.Fields(normalized)
+	for i, tok := range tokens {
+		switch tok {
+		case "stop", "cancel":
+			return true
+		case "hang":
+			if i+1 < len(tokens) && tokens[i+1] == "up" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// endsTerminal reports whether the utterance ends with sentence-terminal
+// punctuation — the strongest available signal that the speaker finished a
+// complete thought. Used to shrink the merge window for the common case.
+// Trailing quotes/brackets after the terminal mark are tolerated.
+func endsTerminal(s string) bool {
+	trimmed := strings.TrimSpace(s)
+	trimmed = strings.TrimRight(trimmed, "'\")]}")
+	if trimmed == "" {
+		return false
+	}
+	switch trimmed[len(trimmed)-1] {
+	case '.', '!', '?':
+		return true
+	}
+	return false
+}
+
+func endsIncomplete(s string) bool {
+	trimmed := strings.TrimSpace(strings.ToLower(s))
+	if trimmed == "" {
+		return false
+	}
+	trimmed = strings.TrimRight(trimmed, ",.!?;:-—'\"")
+	fields := strings.Fields(trimmed)
+	if len(fields) == 0 {
+		return false
+	}
+	last := strings.TrimRight(fields[len(fields)-1], ",.!?;:-—'\"")
+	return incompleteTailWords[last]
+}
+
+// endsDictation reports whether the pending turn text looks like an
+// in-progress spelled/numeric dictation: it ends on a separator word, a
+// lone letter ("…n z y"), or a digit run ("…0 4 1 2"). Callers pause far
+// longer between spelled segments than between words, and with 600ms
+// endpointing those pauses otherwise fragment the dictation into multiple
+// turns that garble email/phone extraction. Used ONLY for the turn-merge
+// window — deliberately NOT part of endsIncomplete, which also drives the
+// LLM's "caller trailed off" note (a complete spelled email legitimately
+// ends on a letter).
+func endsDictation(s string) bool {
+	trimmed := strings.TrimSpace(strings.ToLower(s))
+	if trimmed == "" {
+		return false
+	}
+	trimmed = strings.TrimRight(trimmed, ",.!?;:-—'\"")
+	fields := strings.Fields(trimmed)
+	if len(fields) == 0 {
+		return false
+	}
+	last := strings.TrimRight(fields[len(fields)-1], ",.!?;:-—'\"")
+	if dictationTailWords[last] {
+		return true
+	}
+	if len(last) == 1 && last[0] >= 'a' && last[0] <= 'z' {
+		return true
+	}
+	if last != "" {
+		allDigits := true
+		for _, r := range last {
+			if r < '0' || r > '9' {
+				allDigits = false
+				break
+			}
+		}
+		if allDigits {
+			return true
+		}
+	}
+	return false
+}
+
+// backchannelWordTokens is the per-word vocabulary used to reject COMBINED
+// backchannels ("yep okay", "yeah yeah, right") that the exact-phrase set
+// above misses — a caller stacking acknowledgement words is still just
+// listening, not interrupting. Includes common STT spelling variants
+// ("mmhmm", "yup", "gotcha") so transcription drift doesn't punch through.
+// Rejection requires EVERY token to be in this set, so adding common words
+// like "it"/"i" here is safe — any real content word breaks the match.
+var backchannelWordTokens = map[string]bool{
+	"mm": true, "mhm": true, "mmhmm": true, "mhmm": true, "hmm": true, "hm": true,
+	"uh": true, "huh": true, "uhhuh": true, "um": true, "umm": true,
+	"yep": true, "yup": true, "yeah": true, "yea": true, "yes": true, "ya": true,
+	"okay": true, "ok": true, "kay": true, "right": true, "sure": true,
+	"alright": true, "cool": true, "nice": true, "wow": true, "oh": true,
+	"ah": true, "aha": true, "gotcha": true, "got": true, "it": true,
+	"i": true, "see": true, "true": true, "totally": true, "exactly": true,
+	"thats": true, "that's": true,
+}
+
+var bargeInCommandTokens = map[string]bool{
+	"stop": true, "wait": true, "pause": true, "cancel": true,
+	"actually": true, "no": true, "hang": true, "hold": true,
+	"repeat": true, "transfer": true, "operator": true, "human": true,
+	"help": true,
+}
+
+var bargeInWeakTokens = map[string]bool{
+	"i": true, "im": true, "i'm": true, "me": true, "my": true,
+	"you": true, "your": true, "we": true, "it": true, "this": true,
+	"that": true, "the": true, "a": true, "an": true,
+	"and": true, "or": true, "but": true, "so": true, "to": true,
+	"of": true, "for": true, "with": true, "on": true, "in": true,
+	"at": true, "from": true, "about": true,
+	"is": true, "are": true, "was": true, "were": true, "be": true,
+	"can": true, "could": true, "would": true, "should": true,
+	"will": true, "do": true, "does": true, "did": true,
+	"need": true, "want": true,
+	"um": true, "uh": true, "uhh": true, "umm": true, "hmm": true,
+	"okay": true, "ok": true, "yeah": true, "yes": true, "yep": true,
+	"right": true, "sure": true,
+}
+
+// Words that, when appearing as the last word of an utterance, strongly
+// suggest the speaker was cut off by their own pause rather than finished.
+var incompleteTailWords = map[string]bool{
+	"um": true, "uh": true, "er": true, "hmm": true, "like": true,
+	"and": true, "or": true, "but": true, "so": true, "because": true,
+	"if": true, "when": true, "then": true, "while": true, "as": true,
+	"that": true, "which": true, "who": true, "where": true, "why": true, "how": true,
+	"the": true, "a": true, "an": true, "my": true, "your": true, "this": true,
+	"to": true, "of": true, "for": true, "with": true, "at": true, "on": true, "in": true,
+	"by": true, "from": true, "about": true, "into": true, "onto": true, "over": true, "under": true,
+	"is": true, "are": true, "was": true, "were": true, "be": true, "been": true, "being": true,
+	"am": true, "do": true, "does": true, "did": true, "have": true, "has": true, "had": true,
+	"will": true, "would": true, "can": true, "could": true, "shall": true, "should": true,
+	"may": true, "might": true, "must": true,
+	"i": true, "you": true, "he": true, "she": true, "we": true, "they": true, "it": true,
+}
+
+// dictationTailWords are tokens that signal the caller is mid-dictation of
+// an email, phone number, or spelled word — separators and provider names
+// spoken between segments.
+var dictationTailWords = map[string]bool{
+	"dot": true, "dash": true, "hyphen": true, "underscore": true,
+	"plus": true, "slash": true, "period": true, "point": true,
+	"gmail": true, "hotmail": true, "outlook": true, "yahoo": true,
+	"icloud": true, "mail": true,
+}

--- a/internal/pipeline/duck.go
+++ b/internal/pipeline/duck.go
@@ -1,0 +1,45 @@
+package pipeline
+
+import "log"
+
+// Ducking attenuates the agent's outbound audio while the caller talks over
+// it, instead of cutting straight to silence. A hard cut on every candidate
+// barge-in makes backchannels ("mm-hm", "yeah") clip the agent mid-word; a
+// duck is recoverable, so a false positive costs a brief dip in volume rather
+// than a lost sentence.
+
+// maybeStartDuck attenuates agent audio if it is not already ducked.
+func (p *Pipeline) maybeStartDuck() {
+	if p == nil || !p.speaking.Load() {
+		return
+	}
+	if p.audioMuted.CompareAndSwap(false, true) {
+		p.notifyDuckChange(true)
+		log.Println("[duck] agent audio attenuated (caller speaking)")
+	}
+}
+
+// maybeRestoreDuck returns agent audio to full volume.
+func (p *Pipeline) maybeRestoreDuck() {
+	if p == nil {
+		return
+	}
+	if p.audioMuted.CompareAndSwap(true, false) {
+		p.notifyDuckChange(false)
+		log.Println("[duck] agent audio restored")
+	}
+}
+
+// notifyDuckChange hands the new state to the sender goroutine. Non-blocking:
+// the audio path must never stall on a duck notification, and the sender also
+// reads audioMuted directly, so a dropped signal self-corrects on the next
+// frame.
+func (p *Pipeline) notifyDuckChange(ducked bool) {
+	if p.duckChangeCh == nil {
+		return
+	}
+	select {
+	case p.duckChangeCh <- ducked:
+	default:
+	}
+}

--- a/internal/pipeline/inbound.go
+++ b/internal/pipeline/inbound.go
@@ -66,14 +66,6 @@ func (p *Pipeline) runReader() {
 	}
 }
 
-// Backchannel tokens that should not trigger barge-in interruption.
-var backchannelTokens = map[string]bool{
-	"mm-hmm": true, "mm hmm": true, "mhm": true, "uh-huh": true,
-	"uh huh": true, "yeah": true, "yep": true, "yes": true,
-	"okay": true, "ok": true, "right": true, "sure": true,
-	"got it": true, "i see": true,
-}
-
 // runInbound consumes decoded PCM frames from inPCMCh, feeds them to the
 // STT provider, and runs barge-in detection via the energy-based VAD.
 func (p *Pipeline) runInbound() {
@@ -93,7 +85,16 @@ func (p *Pipeline) runInbound() {
 			ev.TurnStart = time.Now()
 			hasPartialText.Store(false)
 			latestPartial.Store("text", "")
-		} else {
+			p.storeLastUserConfidence(result.Confidence)
+			// Finals go to the turn buffer, which merges a caller's
+			// mid-sentence pauses into one turn before the agent responds.
+			select {
+			case p.finalCh <- ev:
+			case <-p.ctx.Done():
+			}
+			return
+		}
+		{
 			trimmed := strings.ToLower(strings.TrimSpace(result.Text))
 			latestPartial.Store("text", trimmed)
 			if len(trimmed) >= 2 {
@@ -107,6 +108,8 @@ func (p *Pipeline) runInbound() {
 		case <-p.ctx.Done():
 		}
 	}
+
+	go p.runTurnBuffer()
 
 	sttClient, err := stt.NewClient(p.ctx, p.cfg, sttCallback)
 	if err != nil {
@@ -150,6 +153,7 @@ func (p *Pipeline) runInbound() {
 						// Speech continued past the suppression window — real interruption.
 						log.Println("[inbound] barge-in confirmed (speech > 600ms)")
 						bargeInPending = false
+						p.maybeRestoreDuck()
 						p.bargeInVAD.Reset()
 						select {
 						case p.interruptCh <- struct{}{}:
@@ -159,10 +163,20 @@ func (p *Pipeline) runInbound() {
 						// Speech ended within the window — check for backchannel.
 						partial, _ := latestPartial.Load("text")
 						partialStr, _ := partial.(string)
-						if backchannelTokens[partialStr] {
+						if !isMeaningfulBargeInTranscript(partialStr) {
 							log.Printf("[inbound] backchannel suppressed: %q", partialStr)
 							bargeInPending = false
 							hasPartialText.Store(false)
+							p.maybeRestoreDuck()
+						} else if p.readbackBargeInGuardEnabled() && p.readbackInProgress() &&
+							!isStrongBargeInCommand(partialStr) {
+							// Mid-readback, a weak correction is usually the
+							// caller agreeing along. Only an explicit command
+							// (stop, cancel, hang up) cuts the readback off.
+							log.Printf("[inbound] readback guard held barge-in: %q", partialStr)
+							bargeInPending = false
+							hasPartialText.Store(false)
+							p.maybeRestoreDuck()
 						} else {
 							// Short but not a backchannel — fire immediately.
 							log.Printf("[inbound] barge-in detected (short utterance: %q)", partialStr)
@@ -180,6 +194,10 @@ func (p *Pipeline) runInbound() {
 					bargeInPending = true
 					bargeInStart = time.Now()
 					hasPartialText.Store(false)
+					// Duck rather than cut: the caller hears the agent lower
+					// its voice immediately, and it recovers if this turns out
+					// to be a backchannel.
+					p.maybeStartDuck()
 					log.Println("[inbound] barge-in candidate, checking for backchannel...")
 				}
 			}

--- a/internal/pipeline/misunderstanding.go
+++ b/internal/pipeline/misunderstanding.go
@@ -1,0 +1,101 @@
+package pipeline
+
+import "log"
+
+// lowConfidenceRepromptFloor is the STT-confidence ceiling below which a turn
+// is treated as "probably garbled". Set well under the high-care floor (0.75)
+// so this only fires on genuinely poor transcriptions — high-care already
+// covers the moderate-confidence "verify by spelling" band, and we don't want
+// the agent constantly asking callers to repeat themselves.
+const lowConfidenceRepromptFloor = 0.55
+
+// misunderstandingDirective (level 1) is the per-turn nudge appended on the
+// FIRST consecutive low-confidence caller turn. It asks the LLM to clarify
+// once rather than guess — distinct from high-care (which verifies captured
+// field values) and from the trailed-off handler (which infers from context).
+func misunderstandingDirective() string {
+	return "[System note: The caller's last utterance came through with low transcription confidence and may be garbled. " +
+		"If you cannot reasonably tell what they meant from the conversation so far, ask ONE short, friendly clarifying " +
+		"question (e.g. \"Sorry, I didn't quite catch that — could you say it once more?\") instead of guessing. " +
+		"Ask to clarify at most once; if it stays unclear you will receive different instructions.]"
+}
+
+// misunderstandingNarrowDirective (level 2) fires on the SECOND consecutive
+// low-confidence turn. Repeating "could you say that again?" is a robotic
+// loop, so narrow the space instead: offer the caller a short multiple
+// choice grounded in what this business actually does.
+func misunderstandingNarrowDirective() string {
+	return "[System note: This is the second consecutive caller turn with very low transcription confidence. " +
+		"Do NOT ask them to repeat again — that loop frustrates callers. Instead offer a short multiple-choice " +
+		"clarification: name the two or three most likely things they could be asking about given this conversation " +
+		"and this business, and ask which one they meant (e.g. \"I'm having a little trouble hearing you — are you " +
+		"calling about booking an appointment, our opening hours, or something else?\"). One short sentence.]"
+}
+
+// misunderstandingHandoffDirective (level 3+) fires from the THIRD
+// consecutive low-confidence turn. The line is effectively unusable for
+// free-form conversation — stop re-asking and offer an alternative path.
+func misunderstandingHandoffDirective() string {
+	return "[System note: Multiple consecutive caller turns have been unintelligible. Do NOT ask them to repeat " +
+		"again. Apologize briefly for the trouble. If a call-transfer or handoff tool is available in this session, " +
+		"offer to connect them to a person now. Otherwise offer to take their name and phone number so someone can " +
+		"call them back, or suggest calling again from a clearer line. Keep it warm and short.]"
+}
+
+// misunderstandingLevelDirective maps the consecutive low-confidence streak
+// to the escalation level's directive.
+func misunderstandingLevelDirective(streak int32) string {
+	switch {
+	case streak <= 1:
+		return misunderstandingDirective()
+	case streak == 2:
+		return misunderstandingNarrowDirective()
+	default:
+		return misunderstandingHandoffDirective()
+	}
+}
+
+// isLowConfidenceTurn is the pure per-turn decision: confidence is known
+// (>0) and below the floor, and the utterance isn't a trailing-off fragment
+// (the trailed-off handler owns that case — it infers from context rather
+// than re-asking). Zero confidence means "unknown" (provider didn't
+// report), never "low".
+func isLowConfidenceTurn(confidence float64, endsIncompleteFlag bool) bool {
+	if confidence <= 0 || confidence >= lowConfidenceRepromptFloor {
+		return false
+	}
+	return !endsIncompleteFlag
+}
+
+// misunderstandingNote returns the escalation directive for this turn, or ""
+// when the turn is clear. Consecutive low-confidence turns walk an
+// escalation ladder — clarify once → multiple-choice narrowing → offer a
+// person/callback — instead of the old behaviour of nudging once and then
+// silently guessing. A clear or unknown-confidence turn resets the ladder.
+func (p *Pipeline) misunderstandingNote(userText string) string {
+	if p == nil {
+		return ""
+	}
+	conf := p.lastUserConfidence()
+
+	// Form/booking field answers have their own recovery (re-prompts, failed-
+	// capture tracking); don't double up here.
+	if p.previousAgentWasCollectingField() && looksLikeCollectedFieldAnswer(userText) {
+		p.misunderstandingStreak.Store(0)
+		return ""
+	}
+
+	if !isLowConfidenceTurn(conf, endsIncomplete(userText)) {
+		// A clear (or unknown-confidence) turn resets the ladder. A low-
+		// confidence trailing-off turn neither escalates nor resets — the
+		// trailed-off handler owns that turn.
+		if conf <= 0 || conf >= lowConfidenceRepromptFloor {
+			p.misunderstandingStreak.Store(0)
+		}
+		return ""
+	}
+
+	streak := p.misunderstandingStreak.Add(1)
+	log.Printf("[misunderstanding] low-confidence turn (conf=%.2f, consecutive=%d)", conf, streak)
+	return misunderstandingLevelDirective(streak)
+}

--- a/internal/pipeline/misunderstanding_test.go
+++ b/internal/pipeline/misunderstanding_test.go
@@ -1,0 +1,91 @@
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsLowConfidenceTurn(t *testing.T) {
+	cases := []struct {
+		name       string
+		conf       float64
+		endsIncomp bool
+		want       bool
+	}{
+		{"clearly low", 0.40, false, true},
+		{"unknown (zero) never low", 0.0, false, false},
+		{"good confidence", 0.90, false, false},
+		{"just below floor", lowConfidenceRepromptFloor - 0.01, false, true},
+		{"at floor (not below)", lowConfidenceRepromptFloor, false, false},
+		{"low but trailing-off → defer to infer", 0.30, true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isLowConfidenceTurn(c.conf, c.endsIncomp); got != c.want {
+				t.Errorf("isLowConfidenceTurn(%.2f, ends=%v) = %v, want %v",
+					c.conf, c.endsIncomp, got, c.want)
+			}
+		})
+	}
+}
+
+func TestMisunderstandingDirectiveShapes(t *testing.T) {
+	for name, d := range map[string]string{
+		"clarify": misunderstandingDirective(),
+		"narrow":  misunderstandingNarrowDirective(),
+		"handoff": misunderstandingHandoffDirective(),
+	} {
+		if !strings.HasPrefix(d, "[System note:") || !strings.HasSuffix(d, "]") {
+			t.Errorf("%s directive should be a bracketed system note: %q", name, d)
+		}
+	}
+	// Level 1 asks to clarify; levels 2 and 3 explicitly forbid re-asking.
+	if !strings.Contains(strings.ToLower(misunderstandingDirective()), "clarif") {
+		t.Error("level 1 should ask to clarify")
+	}
+	for name, d := range map[string]string{
+		"narrow":  misunderstandingNarrowDirective(),
+		"handoff": misunderstandingHandoffDirective(),
+	} {
+		if !strings.Contains(d, "Do NOT ask them to repeat") {
+			t.Errorf("%s directive must forbid repeat-loops: %q", name, d)
+		}
+	}
+}
+
+// Pipeline-level: consecutive low-confidence turns escalate clarify →
+// multiple-choice → handoff, and a clear turn resets the ladder.
+func TestMisunderstandingEscalationLadder(t *testing.T) {
+	p := &Pipeline{}
+
+	p.storeLastUserConfidence(0.3)
+	if note := p.misunderstandingNote("blarghle wuh"); note != misunderstandingDirective() {
+		t.Fatalf("turn 1: got %q, want clarify directive", note)
+	}
+
+	p.storeLastUserConfidence(0.3)
+	if note := p.misunderstandingNote("mumble again"); note != misunderstandingNarrowDirective() {
+		t.Fatalf("turn 2: got %q, want narrowing directive", note)
+	}
+
+	p.storeLastUserConfidence(0.3)
+	if note := p.misunderstandingNote("still garbled"); note != misunderstandingHandoffDirective() {
+		t.Fatalf("turn 3: got %q, want handoff directive", note)
+	}
+
+	// Stays at handoff level while the line stays bad.
+	p.storeLastUserConfidence(0.3)
+	if note := p.misunderstandingNote("more noise"); note != misunderstandingHandoffDirective() {
+		t.Fatalf("turn 4: got %q, want handoff directive", note)
+	}
+
+	// A clear turn resets the ladder back to level 1.
+	p.storeLastUserConfidence(0.95)
+	if note := p.misunderstandingNote("I'd like to book a service"); note != "" {
+		t.Fatalf("clear turn: got %q, want no directive", note)
+	}
+	p.storeLastUserConfidence(0.3)
+	if note := p.misunderstandingNote("garbled once more"); note != misunderstandingDirective() {
+		t.Fatalf("after reset: got %q, want clarify directive", note)
+	}
+}

--- a/internal/pipeline/outbound.go
+++ b/internal/pipeline/outbound.go
@@ -76,6 +76,17 @@ func (p *Pipeline) encodeAndSend(frame PCMFrame) {
 		samples = padded
 	}
 
+	// While the caller is talking over the agent, attenuate rather than cut.
+	// A backchannel then costs a brief dip in volume instead of a clipped
+	// word, and the duck lifts as soon as the caller stops.
+	if p.audioMuted.Load() {
+		ducked := make([]int16, len(samples))
+		for i, v := range samples {
+			ducked[i] = int16(int32(v) * duckGainNumerator / duckGainDenominator)
+		}
+		samples = ducked
+	}
+
 	opusData, err := p.encoder.Encode(samples)
 	if err != nil {
 		log.Printf("[sender] encode error: %v", err)
@@ -118,3 +129,11 @@ func (p *Pipeline) markTalkspurt() {
 	defer p.rtpMu.Unlock()
 	p.markerNext = true
 }
+
+// Duck attenuation, expressed as an integer ratio so the hot path does no
+// float conversion. 1/4 is roughly -12 dB: clearly quieter, still audible
+// enough that the caller knows the agent is mid-sentence.
+const (
+	duckGainNumerator   = 1
+	duckGainDenominator = 4
+)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -61,7 +61,10 @@ type Pipeline struct {
 	bargeInVAD *vad.Detector
 
 	// Bounded channels
-	inPCMCh      chan PCMFrame
+	inPCMCh chan PCMFrame
+	// finalCh carries raw STT finals to the turn buffer, which merges them
+	// into whole turns before they reach transcriptCh.
+	finalCh      chan TranscriptEvent
 	transcriptCh chan TranscriptEvent
 	outPCMCh     chan PCMFrame
 	interruptCh  chan struct{}
@@ -70,7 +73,41 @@ type Pipeline struct {
 	sendEvent func(interface{}) error
 
 	// Agent state
-	speaking       atomic.Bool
+	speaking atomic.Bool
+
+	// --- Turn quality state (rolling summary, misunderstanding, RAG prefetch) ---
+
+	// transcriptLog is the running record of the conversation. The rolling
+	// summary and the low-confidence heuristics read it; it is not the
+	// LLM's own history.
+	transcriptLog *TranscriptLog
+
+	// rollingSummary holds the most recent background-generated digest of
+	// older turns, so long calls keep their early context after the LLM
+	// history window has dropped it.
+	rollingSummary       atomic.Value // string
+	lastSummaryAtEntries atomic.Int32
+	summaryGenerating    atomic.Bool
+
+	// misunderstandingStreak counts consecutive low-confidence caller turns,
+	// driving an escalating "could you repeat that" rather than a guess.
+	misunderstandingStreak atomic.Int32
+	// userConfidence is the STT confidence of the most recent final turn.
+	userConfidence atomic.Value // float64
+
+	// ragDisabled short-circuits retrieval for the rest of the call after a
+	// hard failure, so every turn does not re-pay the timeout.
+	ragDisabled atomic.Bool
+	// ragPrefetch holds a speculative retrieval started during the turn-merge
+	// window, so embedding and vector search overlap the debounce.
+	ragPrefetchMu sync.Mutex
+	ragPrefetch   *ragPrefetchState
+
+	// duckChangeCh signals the outbound sender to attenuate or restore agent
+	// audio while the caller is talking over it.
+	duckChangeCh   chan bool
+	audioMuted     atomic.Bool
+	processing     atomic.Bool
 	responseMu     sync.Mutex
 	responseCancel context.CancelFunc
 
@@ -126,28 +163,31 @@ func New(
 	imgRecv := newImageReceiver()
 
 	p := &Pipeline{
-		ctx:          pCtx,
-		cancel:       cancel,
-		cfg:          cfg,
-		decoder:      dec,
-		encoder:      enc,
-		remoteTrack:  remoteTrack,
-		localTrack:   localTrack,
-		llmClient:    llmClient,
-		ttsClient:    ttsClient,
-		ragClient:    ragClient,
-		pluginMgr:    pluginMgr,
-		imageRecv:    imgRecv,
-		vad:          vad.NewDefault(),
-		bargeInVAD:   vad.NewBargeIn(),
-		inPCMCh:      make(chan PCMFrame, inPCMChSize),
-		transcriptCh: make(chan TranscriptEvent, transcriptChSize),
-		outPCMCh:     make(chan PCMFrame, outPCMChSize),
-		interruptCh:  make(chan struct{}, 1),
-		sendEvent:    sendEvent,
-		direction:    direction,
-		ssrc:         12345678,
-		markerNext:   true,
+		ctx:           pCtx,
+		cancel:        cancel,
+		cfg:           cfg,
+		decoder:       dec,
+		encoder:       enc,
+		remoteTrack:   remoteTrack,
+		localTrack:    localTrack,
+		llmClient:     llmClient,
+		ttsClient:     ttsClient,
+		ragClient:     ragClient,
+		pluginMgr:     pluginMgr,
+		imageRecv:     imgRecv,
+		vad:           vad.NewDefault(),
+		bargeInVAD:    vad.NewBargeIn(),
+		inPCMCh:       make(chan PCMFrame, inPCMChSize),
+		finalCh:       make(chan TranscriptEvent, transcriptChSize),
+		transcriptCh:  make(chan TranscriptEvent, transcriptChSize),
+		outPCMCh:      make(chan PCMFrame, outPCMChSize),
+		interruptCh:   make(chan struct{}, 1),
+		duckChangeCh:  make(chan bool, 1),
+		transcriptLog: &TranscriptLog{},
+		sendEvent:     sendEvent,
+		direction:     direction,
+		ssrc:          12345678,
+		markerNext:    true,
 	}
 
 	// Wire plugins into the LLM as function-calling tools.

--- a/internal/pipeline/rag_gate.go
+++ b/internal/pipeline/rag_gate.go
@@ -1,0 +1,93 @@
+package pipeline
+
+import (
+	"strings"
+	"unicode"
+)
+
+// fillerWords are interjections, courtesy phrases, common English
+// stopwords, written-out numbers, and date/time vocabulary — words
+// whose presence in a user turn does not indicate the caller is
+// asking a corpus-answerable question. When a turn contains nothing
+// but words from this set (plus digits/punctuation), retrieval has
+// nothing useful to anchor on and is skipped.
+//
+// The list is intentionally narrow: only words that almost never
+// carry a content-bearing query on their own. Anything that could
+// plausibly name a product, brand, place, or topic stays out — the
+// gate's bias is to run RAG when in doubt.
+var fillerWords = map[string]bool{
+	// confirmations / negations / interjections
+	"yes": true, "yeah": true, "yep": true, "yup": true,
+	"no": true, "nope": true, "nah": true,
+	"sure": true, "okay": true, "alright": true, "right": true, "fine": true,
+	// courtesy
+	"thanks": true, "thank": true, "please": true, "welcome": true,
+	// greetings / sign-offs
+	"hi": true, "hello": true, "hey": true, "bye": true, "goodbye": true,
+	// hesitation / backchannel
+	"um": true, "uh": true, "uhh": true, "umm": true, "hmm": true, "mhm": true,
+	// pronouns / aux verbs / common english stopwords
+	"the": true, "and": true, "but": true, "for": true, "not": true, "with": true,
+	"you": true, "your": true, "yours": true, "yourself": true,
+	"are": true, "was": true, "were": true, "been": true, "being": true,
+	"have": true, "has": true, "had": true, "having": true,
+	"can": true, "could": true, "will": true, "would": true,
+	"shall": true, "should": true, "may": true, "might": true, "must": true,
+	"this": true, "that": true, "these": true, "those": true,
+	"what": true, "which": true, "who": true, "whom": true, "whose": true,
+	"where": true, "when": true, "why": true, "how": true,
+	"just": true, "very": true, "too": true, "also": true, "now": true,
+	"some": true, "any": true, "all": true, "more": true, "most": true,
+	"here": true, "there": true, "then": true, "than": true,
+	"like": true, "want": true, "need": true,
+	"about": true, "from": true, "into": true, "onto": true,
+	// number words
+	"one": true, "two": true, "three": true, "four": true, "five": true,
+	"six": true, "seven": true, "eight": true, "nine": true, "ten": true,
+	"eleven": true, "twelve": true, "thirteen": true, "fourteen": true,
+	"fifteen": true, "sixteen": true, "seventeen": true, "eighteen": true, "nineteen": true,
+	"twenty": true, "thirty": true, "forty": true, "fifty": true,
+	"sixty": true, "seventy": true, "eighty": true, "ninety": true,
+	"hundred": true, "thousand": true, "million": true,
+	"first": true, "second": true, "third": true, "fourth": true, "fifth": true,
+	// time-of-day / date words
+	"morning": true, "afternoon": true, "evening": true, "night": true, "midday": true,
+	"today": true, "tomorrow": true, "yesterday": true, "tonight": true,
+	"oclock": true,
+	"monday": true, "tuesday": true, "wednesday": true, "thursday": true,
+	"friday": true, "saturday": true, "sunday": true,
+	"january": true, "february": true, "march": true, "april": true, "june": true,
+	"july": true, "august": true, "september": true, "october": true, "november": true, "december": true,
+	"week": true, "month": true, "year": true, "day": true, "hour": true, "minute": true,
+	"next": true, "last": true,
+}
+
+// shouldSkipRAG returns (true, reason) when the user's utterance has
+// essentially no chance of benefiting from corpus retrieval, so we
+// can avoid an OpenAI embedding call and a Supabase RPC for it.
+//
+// The gate is intentionally conservative — when in doubt, run RAG.
+//
+// Skipped when:
+//   - The utterance has no content-bearing words after stripping
+//     fillers, common English stopwords, and number/date vocabulary.
+//     A "content-bearing word" is any token of length >= 3 that is
+//     not in fillerWords. Brand names and short product codes
+//     (e.g. "BYD") therefore still trigger retrieval.
+func shouldSkipRAG(p *Pipeline, userText string) (bool, string) {
+	var b strings.Builder
+	for _, r := range userText {
+		if unicode.IsLetter(r) {
+			b.WriteRune(unicode.ToLower(r))
+		} else {
+			b.WriteByte(' ')
+		}
+	}
+	for _, tok := range strings.Fields(b.String()) {
+		if len(tok) >= 3 && !fillerWords[tok] {
+			return false, ""
+		}
+	}
+	return true, "no content words"
+}

--- a/internal/pipeline/rag_gate_test.go
+++ b/internal/pipeline/rag_gate_test.go
@@ -1,0 +1,34 @@
+package pipeline
+
+import "testing"
+
+// The gate exists to keep turns that cannot anchor a vector search off the
+// retrieval path. A turn of pure acknowledgement has nothing to embed, so the
+// round trip is wasted latency on the caller's critical path.
+func TestShouldSkipRAG(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		skip bool
+	}{
+		{"pure backchannel", "okay sure thanks", true},
+		{"filler only", "um yeah right", true},
+		{"empty", "", true},
+		{"digits and fillers only", "yeah okay 2", true},
+		{"real question", "what are your opening hours", false},
+		{"short brand name still retrieves", "do you stock BYD", false},
+		{"product question", "how much is the annual subscription", false},
+		{"single content word", "parking", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, reason := shouldSkipRAG(nil, tc.text)
+			if got != tc.skip {
+				t.Fatalf("shouldSkipRAG(%q) = %v (%s), want %v", tc.text, got, reason, tc.skip)
+			}
+			if got && reason == "" {
+				t.Error("a skip must report a reason for the turn-timing log")
+			}
+		})
+	}
+}

--- a/internal/pipeline/rag_prefetch.go
+++ b/internal/pipeline/rag_prefetch.go
@@ -1,0 +1,91 @@
+package pipeline
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/streamcoreai/server/internal/rag"
+)
+
+// ragPrefetchTimeout bounds a speculative retrieval so an abandoned prefetch
+// can never hold resources past its useful life.
+const ragPrefetchTimeout = 10 * time.Second
+
+// ragPrefetchState is one speculative retrieval started while the
+// turn-merge debounce window is still running. The merge window (200-800ms)
+// and the embedding+vector-search round-trip (~150-300ms) are both pure
+// waiting on the critical path — overlapping them hides retrieval entirely
+// on most turns.
+type ragPrefetchState struct {
+	query   string
+	done    chan struct{}
+	results []string
+	err     error
+	timing  rag.Timing
+}
+
+// startRAGPrefetch kicks off retrieval for the pending (not yet flushed)
+// turn text. Called from the turn buffer when the first final of a turn
+// arrives. If a later final merges into the turn, the query won't match at
+// take time and respond() falls back to a live search — the speculative
+// result is simply discarded.
+func (p *Pipeline) startRAGPrefetch(pendingText string) {
+	if p == nil || p.ragClient == nil || p.ragDisabled.Load() {
+		return
+	}
+	if skip, _ := shouldSkipRAG(p, pendingText); skip {
+		return
+	}
+	st := &ragPrefetchState{
+		query: p.ragSearchQuery(pendingText),
+		done:  make(chan struct{}),
+	}
+	p.ragPrefetchMu.Lock()
+	p.ragPrefetch = st
+	p.ragPrefetchMu.Unlock()
+
+	go func() {
+		defer close(st.done)
+		// Call-scoped context, not turn-scoped: the prefetch outlives the
+		// merge window by design and is awaited (or discarded) later.
+		ctx, cancel := context.WithTimeout(p.ctx, ragPrefetchTimeout)
+		defer cancel()
+		ctx = rag.WithTiming(ctx, &st.timing)
+		st.results, st.err = p.ragClient.Search(ctx, st.query, 0)
+	}()
+}
+
+// takeRAGPrefetch claims the pending prefetch if its query matches what this
+// turn would search for. Always clears the slot — a mismatched (stale)
+// prefetch is discarded so it can't leak into a later turn.
+func (p *Pipeline) takeRAGPrefetch(query string) *ragPrefetchState {
+	if p == nil {
+		return nil
+	}
+	p.ragPrefetchMu.Lock()
+	st := p.ragPrefetch
+	p.ragPrefetch = nil
+	p.ragPrefetchMu.Unlock()
+	if st == nil {
+		return nil
+	}
+	if st.query != query {
+		log.Printf("[agent] RAG prefetch discarded — turn text changed during merge window")
+		return nil
+	}
+	return st
+}
+
+// await blocks until the speculative search finishes and returns its result.
+// The prefetch goroutine has its own timeout, so this only waits out the
+// remainder of a search already in flight; ctx cancellation (barge-in, hangup)
+// abandons the wait without disturbing that goroutine.
+func (st *ragPrefetchState) await(ctx context.Context) ([]string, error) {
+	select {
+	case <-st.done:
+		return st.results, st.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/internal/pipeline/rag_prefetch_test.go
+++ b/internal/pipeline/rag_prefetch_test.go
@@ -1,0 +1,79 @@
+package pipeline
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type fakeRAGClient struct {
+	calls   atomic.Int32
+	results []string
+}
+
+func (f *fakeRAGClient) Search(ctx context.Context, query string, topK int) ([]string, error) {
+	f.calls.Add(1)
+	return f.results, nil
+}
+
+func TestRAGPrefetchHitOnMatchingQuery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fake := &fakeRAGClient{results: []string{"chunk one"}}
+	p := &Pipeline{ctx: ctx, ragClient: fake, transcriptLog: &TranscriptLog{}}
+
+	const query = "what are your opening hours on the weekend"
+	p.startRAGPrefetch(query)
+
+	st := p.takeRAGPrefetch(p.ragSearchQuery(query))
+	if st == nil {
+		t.Fatal("expected prefetch hit for matching query")
+	}
+	select {
+	case <-st.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("prefetch never completed")
+	}
+	if st.err != nil || len(st.results) != 1 {
+		t.Fatalf("prefetch results = %v err = %v", st.results, st.err)
+	}
+	if got := fake.calls.Load(); got != 1 {
+		t.Errorf("search calls = %d, want 1", got)
+	}
+	// Slot is one-shot.
+	if p.takeRAGPrefetch(query) != nil {
+		t.Error("prefetch slot should be cleared after take")
+	}
+}
+
+func TestRAGPrefetchDiscardedOnQueryChange(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fake := &fakeRAGClient{}
+	p := &Pipeline{ctx: ctx, ragClient: fake, transcriptLog: &TranscriptLog{}}
+
+	p.startRAGPrefetch("what are your opening hours")
+	// The turn merged more text — the final query differs.
+	if st := p.takeRAGPrefetch("what are your opening hours on public holidays"); st != nil {
+		t.Error("expected stale prefetch to be discarded on query mismatch")
+	}
+}
+
+func TestRAGPrefetchSkipsWhenGateSkips(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fake := &fakeRAGClient{}
+	p := &Pipeline{ctx: ctx, ragClient: fake, transcriptLog: &TranscriptLog{}}
+
+	// A bare affirmation is gated out by shouldSkipRAG — no prefetch, no
+	// embedding spend.
+	p.startRAGPrefetch("yeah sure")
+	time.Sleep(50 * time.Millisecond)
+	if got := fake.calls.Load(); got != 0 {
+		t.Errorf("search calls = %d, want 0 for gated utterance", got)
+	}
+}

--- a/internal/pipeline/rolling_summary.go
+++ b/internal/pipeline/rolling_summary.go
@@ -1,0 +1,150 @@
+package pipeline
+
+import (
+	"context"
+	"log"
+	"strings"
+	"time"
+)
+
+// Rolling-summary tuning. Entries count both user and agent turns, so an
+// "exchange" is ~2 entries.
+const (
+	// summaryActivateEntries is the transcript size at which summarization
+	// begins. The LLM client keeps ~30 messages (≈15 exchanges) before it
+	// drops the oldest, so we start a few exchanges earlier to have a summary
+	// ready before any context is actually lost.
+	summaryActivateEntries = 24
+
+	// summaryRefreshEntries is how many new transcript entries accumulate
+	// before the summary is regenerated. ~6 exchanges keeps it current
+	// without an LLM call every turn.
+	summaryRefreshEntries = 12
+
+	// summaryMaxChars bounds the input we send to the summarizer so a very
+	// long call can't balloon the prompt. We keep the most recent characters.
+	summaryMaxChars = 8000
+
+	// summaryGenerateTimeout bounds one background summarization call. A
+	// slow/wedged provider must not hold the summaryGenerating slot forever
+	// — that would silently stop summaries refreshing for the rest of the
+	// call. Generous next to a normal 1-3s OneShot; this is a wedge guard,
+	// not a latency target (the live turn never waits on this call).
+	summaryGenerateTimeout = 10 * time.Second
+)
+
+// summarySystemPrompt instructs the model to retain only durable facts.
+const summarySystemPrompt = "You maintain a running memory of a live phone call between an AI receptionist and a caller. " +
+	"Summarize ONLY the durable facts the agent must not forget for the rest of the call: " +
+	"the caller's name and contact details, what they want (their goal/intent), any decisions or commitments made, " +
+	"and specifics already discussed (dates, times, items, prices, addresses). " +
+	"Omit pleasantries and filler. Be concise — at most a few short lines. Output only the summary text, no preamble."
+
+// shouldRefreshSummary decides whether respond() should kick off a new
+// background summarization this turn. Pure so it can be unit-tested.
+//   - entries: current transcript entry count
+//   - lastAt: entry count when the last summary was produced
+//   - generating: whether a background summary is already running
+//   - haveSummary: whether a summary already exists
+func shouldRefreshSummary(entries, lastAt int, generating, haveSummary bool) bool {
+	if generating {
+		return false
+	}
+	if entries < summaryActivateEntries {
+		return false
+	}
+	if !haveSummary {
+		return true
+	}
+	return entries-lastAt >= summaryRefreshEntries
+}
+
+// formatTranscriptForSummary renders transcript entries into a plain script for
+// the summarizer, keeping at most summaryMaxChars from the end. Pure.
+func formatTranscriptForSummary(entries []TranscriptEntry) string {
+	var b strings.Builder
+	for _, e := range entries {
+		text := strings.TrimSpace(e.Text)
+		if text == "" {
+			continue
+		}
+		speaker := "Caller"
+		if e.Role != "user" { // "agent" and "agent_filler" are both the agent speaking
+			speaker = "Agent"
+		}
+		b.WriteString(speaker)
+		b.WriteString(": ")
+		b.WriteString(text)
+		b.WriteString("\n")
+	}
+	s := b.String()
+	if len(s) > summaryMaxChars {
+		s = s[len(s)-summaryMaxChars:]
+	}
+	return s
+}
+
+// summaryContextBlock wraps a summary for injection into the LLM context, or
+// returns "" when there's nothing to inject. Pure.
+func summaryContextBlock(summary string) string {
+	summary = strings.TrimSpace(summary)
+	if summary == "" {
+		return ""
+	}
+	return "[Conversation so far (durable facts — do not re-ask what's already known):\n" + summary + "]"
+}
+
+// currentRollingSummary returns the latest background-generated summary, or "".
+func (p *Pipeline) currentRollingSummary() string {
+	s, _ := p.rollingSummary.Load().(string)
+	return s
+}
+
+// maybeRefreshRollingSummary kicks off a background summary regeneration when
+// the call is long enough and it's time. Non-blocking: the live turn never
+// waits on the LLM call. Safe to call every turn from respond().
+func (p *Pipeline) maybeRefreshRollingSummary() {
+	if p == nil || p.llmClient == nil {
+		return
+	}
+	entries := p.transcriptLog.Len()
+	haveSummary := p.currentRollingSummary() != ""
+	if !shouldRefreshSummary(entries, int(p.lastSummaryAtEntries.Load()), p.summaryGenerating.Load(), haveSummary) {
+		return
+	}
+	// Claim the slot; bail if another goroutine beat us to it.
+	if !p.summaryGenerating.CompareAndSwap(false, true) {
+		return
+	}
+
+	script := formatTranscriptForSummary(p.transcriptLog.Entries())
+	if strings.TrimSpace(script) == "" {
+		p.summaryGenerating.Store(false)
+		return
+	}
+
+	// Use the call-scoped context (p.ctx), not the per-turn respCtx, so a
+	// barge-in cancelling the current turn doesn't abort the summary.
+	go func(atEntries int32) {
+		defer p.summaryGenerating.Store(false)
+		genCtx, cancel := context.WithTimeout(p.ctx, summaryGenerateTimeout)
+		defer cancel()
+		start := time.Now()
+		summary, err := p.llmClient.OneShot(genCtx, summarySystemPrompt, script)
+		if err != nil {
+			if genCtx.Err() == context.DeadlineExceeded {
+				log.Printf("[summary] rolling summary timed out after %s — will retry on a later turn", time.Since(start).Round(time.Millisecond))
+			} else {
+				log.Printf("[summary] rolling summary failed: %v", err)
+			}
+			return
+		}
+		summary = strings.TrimSpace(summary)
+		if summary == "" {
+			return
+		}
+		p.rollingSummary.Store(summary)
+		p.lastSummaryAtEntries.Store(atEntries)
+		log.Printf("[summary] rolling summary refreshed at %d entries (%d chars)", atEntries, len(summary))
+	}(int32(entries))
+}

--- a/internal/pipeline/rolling_summary_test.go
+++ b/internal/pipeline/rolling_summary_test.go
@@ -1,0 +1,66 @@
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestShouldRefreshSummary(t *testing.T) {
+	cases := []struct {
+		name                    string
+		entries, lastAt         int
+		generating, haveSummary bool
+		want                    bool
+	}{
+		{"short call, no summary", 10, 0, false, false, false},
+		{"already generating", 30, 0, true, false, false},
+		{"activates at threshold", summaryActivateEntries, 0, false, false, true},
+		{"have summary, too soon", summaryActivateEntries + 4, summaryActivateEntries, false, true, false},
+		{"have summary, time to refresh", summaryActivateEntries + summaryRefreshEntries, summaryActivateEntries, false, true, true},
+		{"just below activation", summaryActivateEntries - 1, 0, false, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldRefreshSummary(c.entries, c.lastAt, c.generating, c.haveSummary); got != c.want {
+				t.Errorf("shouldRefreshSummary(%d,%d,%v,%v) = %v, want %v",
+					c.entries, c.lastAt, c.generating, c.haveSummary, got, c.want)
+			}
+		})
+	}
+}
+
+func TestFormatTranscriptForSummary(t *testing.T) {
+	entries := []TranscriptEntry{
+		{Role: "user", Text: "Hi, I'm Jason"},
+		{Role: "agent", Text: "Hello Jason"},
+		{Role: "user", Text: "  "}, // blank skipped
+	}
+	got := formatTranscriptForSummary(entries)
+	if !strings.Contains(got, "Caller: Hi, I'm Jason") {
+		t.Errorf("missing caller line: %q", got)
+	}
+	if !strings.Contains(got, "Agent: Hello Jason") {
+		t.Errorf("missing agent line: %q", got)
+	}
+	if strings.Count(got, "\n") != 2 {
+		t.Errorf("blank entry should be skipped, got %d lines: %q", strings.Count(got, "\n"), got)
+	}
+}
+
+func TestFormatTranscriptForSummaryTruncates(t *testing.T) {
+	long := strings.Repeat("x", summaryMaxChars*2)
+	got := formatTranscriptForSummary([]TranscriptEntry{{Role: "user", Text: long}})
+	if len(got) > summaryMaxChars {
+		t.Errorf("expected <= %d chars, got %d", summaryMaxChars, len(got))
+	}
+}
+
+func TestSummaryContextBlock(t *testing.T) {
+	if got := summaryContextBlock("   "); got != "" {
+		t.Errorf("blank summary should yield no block, got %q", got)
+	}
+	got := summaryContextBlock("Caller is Jason; wants a quote for a kitchen reno.")
+	if !strings.HasPrefix(got, "[Conversation so far") || !strings.HasSuffix(got, "]") {
+		t.Errorf("unexpected block format: %q", got)
+	}
+}

--- a/internal/pipeline/transcript.go
+++ b/internal/pipeline/transcript.go
@@ -1,0 +1,63 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+// TranscriptEntry represents a single turn in a conversation transcript.
+type TranscriptEntry struct {
+	Role string    `json:"role"` // "user" or "agent"
+	Text string    `json:"text"`
+	At   time.Time `json:"at"`
+}
+
+// TranscriptLog is a thread-safe accumulator for conversation transcript entries.
+type TranscriptLog struct {
+	mu      sync.Mutex
+	entries []TranscriptEntry
+}
+
+// Add appends a new transcript entry with the given role and text, timestamped at time.Now().
+func (l *TranscriptLog) Add(role, text string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = append(l.entries, TranscriptEntry{
+		Role: role,
+		Text: text,
+		At:   time.Now(),
+	})
+}
+
+// Entries returns a copy of the current transcript entries.
+func (l *TranscriptLog) Entries() []TranscriptEntry {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]TranscriptEntry, len(l.entries))
+	copy(out, l.entries)
+	return out
+}
+
+// JSON marshals the transcript entries to JSON. It returns [] if there are no entries.
+func (l *TranscriptLog) JSON() ([]byte, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(l.entries) == 0 {
+		return []byte("[]"), nil
+	}
+	return json.Marshal(l.entries)
+}
+
+// Len returns the number of transcript entries.
+func (l *TranscriptLog) Len() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.entries)
+}
+
+// TranscriptCallback is a function that receives transcript events as they occur.
+type TranscriptCallback func(role, text string)
+
+// NoopTranscriptCallback is a TranscriptCallback that does nothing.
+var NoopTranscriptCallback TranscriptCallback = func(string, string) {}

--- a/internal/pipeline/transcript_test.go
+++ b/internal/pipeline/transcript_test.go
@@ -1,0 +1,344 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestTranscriptEntry_JSONFormat(t *testing.T) {
+	ts := time.Date(2025, 6, 15, 10, 30, 0, 0, time.UTC)
+	entry := TranscriptEntry{Role: "user", Text: "Hello", At: ts}
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if parsed["role"] != "user" {
+		t.Errorf("role = %v, want user", parsed["role"])
+	}
+	if parsed["text"] != "Hello" {
+		t.Errorf("text = %v, want Hello", parsed["text"])
+	}
+	if _, ok := parsed["at"]; !ok {
+		t.Error("missing 'at' field")
+	}
+}
+
+func TestTranscriptEntry_RoundTrip(t *testing.T) {
+	original := TranscriptEntry{
+		Role: "agent",
+		Text: "How can I help you today?",
+		At:   time.Date(2025, 6, 15, 10, 30, 5, 0, time.UTC),
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded TranscriptEntry
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded.Role != original.Role {
+		t.Errorf("role = %q, want %q", decoded.Role, original.Role)
+	}
+	if decoded.Text != original.Text {
+		t.Errorf("text = %q, want %q", decoded.Text, original.Text)
+	}
+}
+
+func TestTranscriptLog_Empty(t *testing.T) {
+	log := &TranscriptLog{}
+
+	if log.Len() != 0 {
+		t.Errorf("Len() = %d, want 0", log.Len())
+	}
+
+	entries := log.Entries()
+	if len(entries) != 0 {
+		t.Errorf("Entries() returned %d items, want 0", len(entries))
+	}
+
+	j, err := log.JSON()
+	if err != nil {
+		t.Fatalf("JSON() error: %v", err)
+	}
+	if string(j) != "[]" {
+		t.Errorf("JSON() = %s, want []", string(j))
+	}
+}
+
+func TestTranscriptLog_AddAndEntries(t *testing.T) {
+	log := &TranscriptLog{}
+
+	log.Add("user", "I need a reservation")
+	log.Add("agent", "For how many people?")
+	log.Add("user", "Four")
+
+	if log.Len() != 3 {
+		t.Fatalf("Len() = %d, want 3", log.Len())
+	}
+
+	entries := log.Entries()
+	if len(entries) != 3 {
+		t.Fatalf("len(Entries()) = %d, want 3", len(entries))
+	}
+
+	if entries[0].Role != "user" || entries[0].Text != "I need a reservation" {
+		t.Errorf("entry[0] = %+v, wrong", entries[0])
+	}
+	if entries[1].Role != "agent" || entries[1].Text != "For how many people?" {
+		t.Errorf("entry[1] = %+v, wrong", entries[1])
+	}
+	if entries[2].Role != "user" || entries[2].Text != "Four" {
+		t.Errorf("entry[2] = %+v, wrong", entries[2])
+	}
+
+	for _, e := range entries {
+		if e.At.IsZero() {
+			t.Error("At should not be zero")
+		}
+	}
+}
+
+func TestTranscriptLog_EntriesIsCopy(t *testing.T) {
+	log := &TranscriptLog{}
+	log.Add("user", "hello")
+
+	entries := log.Entries()
+	entries[0] = TranscriptEntry{Role: "hacked", Text: "nope"}
+
+	original := log.Entries()
+	if original[0].Role == "hacked" {
+		t.Error("Entries() returned a reference, not a copy")
+	}
+}
+
+func TestTranscriptLog_JSONRoundTrip(t *testing.T) {
+	log := &TranscriptLog{}
+	log.Add("user", "Book a table for two")
+	log.Add("agent", "What time works for you?")
+	log.Add("user", "7pm tonight")
+	log.Add("agent", "All set, see you at 7!")
+
+	data, err := log.JSON()
+	if err != nil {
+		t.Fatalf("JSON() error: %v", err)
+	}
+
+	var decoded []TranscriptEntry
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(decoded) != 4 {
+		t.Fatalf("len = %d, want 4", len(decoded))
+	}
+
+	want := []struct{ role, text string }{
+		{"user", "Book a table for two"},
+		{"agent", "What time works for you?"},
+		{"user", "7pm tonight"},
+		{"agent", "All set, see you at 7!"},
+	}
+	for i, w := range want {
+		if decoded[i].Role != w.role {
+			t.Errorf("entry[%d].role = %q, want %q", i, decoded[i].Role, w.role)
+		}
+		if decoded[i].Text != w.text {
+			t.Errorf("entry[%d].text = %q, want %q", i, decoded[i].Text, w.text)
+		}
+		if decoded[i].At.IsZero() {
+			t.Errorf("entry[%d].At is zero", i)
+		}
+	}
+}
+
+func TestTranscriptLog_JSONIsValidJSONArray(t *testing.T) {
+	log := &TranscriptLog{}
+	log.Add("user", "test")
+
+	data, err := log.JSON()
+	if err != nil {
+		t.Fatalf("JSON() error: %v", err)
+	}
+
+	if !json.Valid(data) {
+		t.Errorf("JSON() produced invalid JSON: %s", string(data))
+	}
+	if data[0] != '[' || data[len(data)-1] != ']' {
+		t.Errorf("JSON() = %s, want array", string(data))
+	}
+}
+
+func TestTranscriptLog_JSONMatchesConversationTranscriptSchema(t *testing.T) {
+	// Verify the JSON matches what the conversation_transcript JSONB column expects:
+	// [{"role": "user"|"agent", "text": "...", "at": "<ISO-8601>"}]
+	log := &TranscriptLog{}
+	log.Add("user", "Hello")
+	log.Add("agent", "Hi there!")
+
+	data, err := log.JSON()
+	if err != nil {
+		t.Fatalf("JSON() error: %v", err)
+	}
+
+	var raw []map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	for i, entry := range raw {
+		role, ok := entry["role"].(string)
+		if !ok {
+			t.Errorf("entry[%d]: 'role' is not a string", i)
+			continue
+		}
+		if role != "user" && role != "agent" {
+			t.Errorf("entry[%d].role = %q, want 'user' or 'agent'", i, role)
+		}
+
+		text, ok := entry["text"].(string)
+		if !ok {
+			t.Errorf("entry[%d]: 'text' is not a string", i)
+			continue
+		}
+		if text == "" {
+			t.Errorf("entry[%d].text is empty", i)
+		}
+
+		at, ok := entry["at"].(string)
+		if !ok {
+			t.Errorf("entry[%d]: 'at' is not a string", i)
+			continue
+		}
+		if _, err := time.Parse(time.RFC3339, at); err != nil {
+			t.Errorf("entry[%d].at = %q is not valid RFC3339: %v", i, at, err)
+		}
+	}
+}
+
+func TestTranscriptLog_ConcurrentAdd(t *testing.T) {
+	log := &TranscriptLog{}
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			if n%2 == 0 {
+				log.Add("user", "msg")
+			} else {
+				log.Add("agent", "msg")
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if log.Len() != 100 {
+		t.Errorf("Len() = %d, want 100", log.Len())
+	}
+}
+
+func TestTranscriptLog_SpecialCharacters(t *testing.T) {
+	log := &TranscriptLog{}
+	log.Add("user", `He said "hello" and left`)
+	log.Add("user", "Unicode: 日本語テスト 🎉")
+	log.Add("user", "Newlines:\nline2\nline3")
+	log.Add("user", `Back\slash`)
+
+	data, err := log.JSON()
+	if err != nil {
+		t.Fatalf("JSON() error: %v", err)
+	}
+	if !json.Valid(data) {
+		t.Fatalf("produced invalid JSON: %s", string(data))
+	}
+
+	var decoded []TranscriptEntry
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded[0].Text != `He said "hello" and left` {
+		t.Errorf("quotes mangled: %q", decoded[0].Text)
+	}
+	if decoded[1].Text != "Unicode: 日本語テスト 🎉" {
+		t.Errorf("unicode mangled: %q", decoded[1].Text)
+	}
+	if !strings.Contains(decoded[2].Text, "line2") {
+		t.Errorf("newlines mangled: %q", decoded[2].Text)
+	}
+}
+
+func TestTranscriptLog_EmptyTextAllowed(t *testing.T) {
+	log := &TranscriptLog{}
+	log.Add("user", "")
+
+	if log.Len() != 1 {
+		t.Fatalf("Len() = %d, want 1", log.Len())
+	}
+
+	data, err := log.JSON()
+	if err != nil {
+		t.Fatalf("JSON() error: %v", err)
+	}
+
+	var decoded []TranscriptEntry
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded[0].Text != "" {
+		t.Errorf("text = %q, want empty", decoded[0].Text)
+	}
+}
+
+func TestMarshalTranscript_ProducesValidJSONB(t *testing.T) {
+	// Simulate what marshalTranscript in manager.go does:
+	// takes TranscriptSnapshot entries and json.Marshal's them.
+	entries := []TranscriptEntry{
+		{Role: "user", Text: "I want to book a table", At: time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)},
+		{Role: "agent", Text: "Sure! For how many?", At: time.Date(2025, 6, 15, 10, 0, 3, 0, time.UTC)},
+		{Role: "user", Text: "Four people", At: time.Date(2025, 6, 15, 10, 0, 8, 0, time.UTC)},
+		{Role: "agent", Text: "Done!", At: time.Date(2025, 6, 15, 10, 0, 12, 0, time.UTC)},
+	}
+
+	j, err := json.Marshal(entries)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// This string would be passed to COALESCE($N::jsonb, ...) in SQL.
+	// Verify PostgreSQL would accept it by checking it's valid JSON.
+	if !json.Valid(j) {
+		t.Fatalf("invalid JSON: %s", string(j))
+	}
+
+	// Verify it parses back to the same entries.
+	var decoded []TranscriptEntry
+	if err := json.Unmarshal(j, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(decoded) != 4 {
+		t.Fatalf("len = %d, want 4", len(decoded))
+	}
+
+	// Verify order is preserved (important for conversation chronology).
+	if decoded[0].Text != "I want to book a table" {
+		t.Errorf("entry[0] out of order: %q", decoded[0].Text)
+	}
+	if decoded[3].Text != "Done!" {
+		t.Errorf("entry[3] out of order: %q", decoded[3].Text)
+	}
+}

--- a/internal/pipeline/turnbuffer.go
+++ b/internal/pipeline/turnbuffer.go
@@ -1,0 +1,126 @@
+package pipeline
+
+import (
+	"log"
+	"strings"
+	"time"
+)
+
+// Turn-buffer tuning. A caller who pauses mid-sentence ("I want to... um...
+// book a table") produces two finals from the STT provider. Answering the
+// first half is the single most common way a voice agent feels like it is
+// interrupting, so finals are held briefly and merged.
+const (
+	// turnMergeMax bounds how long a turn can be extended by repeated
+	// continuations, so a caller who never pauses cleanly still gets an answer.
+	turnMergeMax = 2500 * time.Millisecond
+	// turnMergeIncomplete is the longer wait used when the text ends on a
+	// dangling word ("and", "my number is") or mid-dictation — the caller is
+	// clearly not finished.
+	turnMergeIncomplete = 900 * time.Millisecond
+)
+
+// runTurnBuffer debounces final transcripts into whole turns. It waits a
+// short window after each final; a further final inside that window is merged
+// and the window restarts. The wait adapts to how the text ends:
+//
+//   - terminal punctuation ("...book a table.") — the caller sounds finished,
+//     so the configured (short) window applies
+//   - a dangling connective or dictation tail — extend, they are mid-thought
+//
+// While the window runs, retrieval is prefetched speculatively so the wait
+// costs nothing on turns that do need context.
+func (p *Pipeline) runTurnBuffer() {
+	base := time.Duration(p.cfg.Pipeline.TurnMergeMs) * time.Millisecond
+	if base <= 0 {
+		base = 350 * time.Millisecond
+	}
+
+	var (
+		pending    *TranscriptEvent
+		timer      *time.Timer
+		timerC     <-chan time.Time
+		turnBegan  time.Time
+		prefetched bool
+	)
+	stop := func() {
+		if timer != nil {
+			timer.Stop()
+			timer, timerC = nil, nil
+		}
+	}
+	arm := func(d time.Duration) {
+		stop()
+		timer = time.NewTimer(d)
+		timerC = timer.C
+	}
+	flush := func() {
+		if pending == nil {
+			return
+		}
+		ev := *pending
+		pending, prefetched = nil, false
+		stop()
+		if !turnBegan.IsZero() {
+			ev.MergeWaitMs = time.Since(turnBegan).Milliseconds()
+		}
+		select {
+		case p.transcriptCh <- ev:
+		case <-p.ctx.Done():
+		}
+	}
+
+	for {
+		select {
+		case <-p.ctx.Done():
+			stop()
+			return
+
+		case ev := <-p.finalCh:
+			text := strings.TrimSpace(ev.Text)
+			if text == "" {
+				continue
+			}
+			if pending == nil {
+				merged := ev
+				merged.Text = text
+				pending = &merged
+				turnBegan = time.Now()
+			} else {
+				pending.Text = strings.TrimSpace(pending.Text + " " + text)
+				// Keep the earliest turn start: latency is measured from when
+				// the caller first stopped speaking, not from the last chunk.
+			}
+
+			// A caller still mid-thought gets a longer grace period.
+			wait := base
+			if endsIncomplete(pending.Text) || endsDictation(pending.Text) {
+				wait = turnMergeIncomplete
+			} else if endsTerminal(pending.Text) {
+				wait = base
+			}
+			if elapsed := time.Since(turnBegan); elapsed+wait > turnMergeMax {
+				if remaining := turnMergeMax - elapsed; remaining > 0 {
+					wait = remaining
+				} else {
+					flush()
+					continue
+				}
+			}
+
+			// Overlap retrieval with the wait rather than paying for it after.
+			if !prefetched && p.cfg.Pipeline.RAGPrefetch {
+				prefetched = true
+				p.startRAGPrefetch(pending.Text)
+			}
+			arm(wait)
+
+		case <-timerC:
+			if pending != nil {
+				log.Printf("[turn-buffer] turn complete after %dms: %q",
+					time.Since(turnBegan).Milliseconds(), pending.Text)
+			}
+			flush()
+		}
+	}
+}

--- a/internal/pipeline/turnquality.go
+++ b/internal/pipeline/turnquality.go
@@ -1,0 +1,111 @@
+package pipeline
+
+import (
+	"strings"
+)
+
+// lastUserConfidence returns the STT confidence of the most recent final
+// caller turn, or 0 when the provider reported none.
+func (p *Pipeline) lastUserConfidence() float64 {
+	if p == nil {
+		return 0
+	}
+	c, _ := p.userConfidence.Load().(float64)
+	return c
+}
+
+func (p *Pipeline) storeLastUserConfidence(c float64) {
+	if p != nil {
+		p.userConfidence.Store(c)
+	}
+}
+
+// readbackBargeInGuardEnabled reports whether weak barge-ins should be
+// ignored while the agent is reading values back for confirmation.
+func (p *Pipeline) readbackBargeInGuardEnabled() bool {
+	return p != nil && p.cfg != nil && p.cfg.Pipeline.ReadbackBargeInGuardEnabled
+}
+
+// readbackInProgress reports whether the agent is currently speaking a
+// confirmation readback, judged from what it is saying right now.
+func (p *Pipeline) readbackInProgress() bool {
+	if p == nil || !p.speaking.Load() {
+		return false
+	}
+	txt, _ := p.lastAgentText.Load().(string)
+	if txt == "" {
+		return false
+	}
+	normalized := " " + normalizedTranscriptText(txt) + " "
+	for _, m := range readbackPhraseMarkers {
+		if strings.Contains(normalized, " "+m+" ") {
+			return true
+		}
+	}
+	return false
+}
+
+// previousAgentWasCollectingField reports whether the agent's last turn was a
+// question asking the caller for a specific value. A terse reply to such a
+// question is an answer, not a misunderstanding.
+func (p *Pipeline) previousAgentWasCollectingField() bool {
+	if p == nil || p.transcriptLog == nil {
+		return false
+	}
+	entries := p.transcriptLog.Entries()
+	for i := len(entries) - 1; i >= 0; i-- {
+		if entries[i].Role != "agent" {
+			continue
+		}
+		return isCollectionPrompt(entries[i].Text)
+	}
+	return false
+}
+
+// isCollectionPrompt matches an agent question that asks for a concrete value.
+func isCollectionPrompt(text string) bool {
+	t := normalizedTranscriptText(text)
+	if t == "" || !strings.Contains(text, "?") {
+		return false
+	}
+	if strings.Contains(t, "is that all correct") || strings.Contains(t, "anything youd like to change") {
+		return false
+	}
+	for _, cue := range collectionPromptCues {
+		if strings.Contains(t, cue) {
+			return true
+		}
+	}
+	return false
+}
+
+var collectionPromptCues = []string{
+	"what is your", "whats your", "can i get your", "could i get your",
+	"may i have your", "can i have your", "what name", "your name",
+	"your number", "phone number", "your email", "email address",
+	"what date", "what time", "how many",
+}
+
+// looksLikeCollectedFieldAnswer reports whether a short caller utterance reads
+// as a direct answer (a name, a number) rather than a garbled turn.
+func looksLikeCollectedFieldAnswer(text string) bool {
+	t := normalizedTranscriptText(text)
+	if t == "" || strings.Contains(text, "?") {
+		return false
+	}
+	words := strings.Fields(t)
+	if len(words) == 0 || len(words) > 8 {
+		return false
+	}
+	for _, word := range words {
+		if !fillerWords[word] {
+			return true
+		}
+	}
+	return false
+}
+
+// ragSearchQuery returns the text to retrieve on for this turn.
+func (p *Pipeline) ragSearchQuery(userText string) string {
+	return strings.TrimSpace(userText)
+}

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -14,6 +14,9 @@ type TranscriptEvent struct {
 	Text      string
 	Final     bool
 	TurnStart time.Time // set on final transcripts for latency measurement
+	// MergeWaitMs is how long the turn buffer held this turn open merging
+	// continuations, so latency accounting can separate debounce from work.
+	MergeWaitMs int64
 }
 
 // DataChannel message types sent to the client via the events DataChannel.
@@ -39,4 +42,3 @@ type stateMsg struct {
 	Type  string `json:"type"`
 	State string `json:"state"`
 }
-

--- a/internal/procstat/procstat.go
+++ b/internal/procstat/procstat.go
@@ -1,0 +1,75 @@
+// Package procstat samples the process's own CPU usage from getrusage on a
+// stable interval and stores the latest normalised percentage (0..100,
+// averaged across all cores). Public reads are lock-free and never reset
+// the baseline, so frequent callers (e.g. /health hit by an ALB) don't
+// interfere with the rolling window.
+//
+// Typical use: one Sampler per process. New() starts the background loop.
+package procstat
+
+import (
+	"math"
+	"runtime"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+// defaultInterval balances responsiveness against signal-to-noise. 5s is
+// long enough that an idle Go process accumulates measurable CPU time,
+// short enough that a sudden burst shows up within ~one heartbeat cycle.
+const defaultInterval = 5 * time.Second
+
+type Sampler struct {
+	cores int
+	pct   atomic.Uint64 // float64 bits via math.Float64bits
+}
+
+// New returns a Sampler with a background goroutine that updates the
+// current CPU percentage every defaultInterval. The goroutine is intended
+// to live for the life of the process — there is no Stop().
+func New() *Sampler {
+	s := &Sampler{cores: max(1, runtime.NumCPU())}
+	go s.run(defaultInterval)
+	return s
+}
+
+func (s *Sampler) run(interval time.Duration) {
+	last, ok := readCPU()
+	lastAt := time.Now()
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for now := range t.C {
+		cur, curOK := readCPU()
+		if ok && curOK {
+			elapsed := now.Sub(lastAt)
+			delta := cur - last
+			if elapsed > 0 && delta >= 0 {
+				pct := float64(delta) / float64(elapsed) * 100.0
+				pct = pct / float64(s.cores)
+				if pct < 0 {
+					pct = 0
+				}
+				s.pct.Store(math.Float64bits(pct))
+			}
+		}
+		last, ok = cur, curOK
+		lastAt = now
+	}
+}
+
+// CPUPercent returns the most recent normalized CPU percent the background
+// loop computed. Zero is returned before the first interval completes.
+// This call is lock-free and safe to invoke from any goroutine.
+func (s *Sampler) CPUPercent() float64 {
+	return math.Float64frombits(s.pct.Load())
+}
+
+func readCPU() (time.Duration, bool) {
+	var ru syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &ru); err != nil {
+		return 0, false
+	}
+	return time.Duration(int64(ru.Utime.Sec)+int64(ru.Stime.Sec))*time.Second +
+		time.Duration(int64(ru.Utime.Usec)+int64(ru.Stime.Usec))*time.Microsecond, true
+}

--- a/internal/procstat/turn_timing.go
+++ b/internal/procstat/turn_timing.go
@@ -1,0 +1,45 @@
+package procstat
+
+import "log"
+
+// TurnTiming is the per-turn latency breakdown for one user→agent exchange.
+// All durations are milliseconds measured from the turn boundary (the first
+// final transcript). It is the baseline measuring stick for latency work: it
+// separates the embedding network hop from the vector query and from LLM/TTS
+// time so regressions and wins are attributable to a single stage.
+//
+// A zero field means "not measured this turn" (e.g. RAG was skipped, or the
+// turn was cancelled before that stage ran).
+type TurnTiming struct {
+	RAGSkipped     bool
+	RAGSkipReason  string
+	RAGPrefetched  bool  // retrieval overlapped the turn-merge window
+	EndpointMs     int64 // caller's last VAD speech → first STT final (provider endpointing)
+	MergeWaitMs    int64 // first STT final → turn fired (turn-buffer debounce)
+	QuietWaitMs    int64 // pre-LLM quiet grace
+	EmbeddingMs    int64 // embedding provider round-trip (public-internet hop)
+	VectorSearchMs int64 // vector store query
+	RAGChunks      int
+	MaxSimilarity  float64 // best chunk similarity this turn (0 if skipped/miss)
+	LLMTTFTMs      int64   // turn boundary → first LLM token
+	TTSFirstByteMs int64   // turn boundary → first audio frame (total user-to-speech)
+}
+
+// Log emits a single structured line per turn. Cheap and allocation-light so it
+// is safe to call on every turn from the agent goroutine.
+func (t *TurnTiming) Log() {
+	if t == nil {
+		return
+	}
+	rag := "hit"
+	if t.RAGSkipped {
+		rag = "skip:" + t.RAGSkipReason
+	} else if t.RAGPrefetched {
+		rag = "prefetch"
+	}
+	// TTSFirstByteMs is measured from the turn boundary (first STT final),
+	// which already includes the merge-window hold, so the caller-perceived
+	// silence is endpointing + turn-boundary→first-audio.
+	log.Printf("[turn-timing] rag=%s endpoint_ms=%d merge_wait_ms=%d quiet_wait_ms=%d embed_ms=%d vsearch_ms=%d rag_chunks=%d max_sim=%.2f llm_ttft_ms=%d tts_ttfb_ms=%d total_user_to_speech_ms=%d",
+		rag, t.EndpointMs, t.MergeWaitMs, t.QuietWaitMs, t.EmbeddingMs, t.VectorSearchMs, t.RAGChunks, t.MaxSimilarity, t.LLMTTFTMs, t.TTSFirstByteMs, t.EndpointMs+t.TTSFirstByteMs)
+}

--- a/internal/procstat/turn_timing_test.go
+++ b/internal/procstat/turn_timing_test.go
@@ -1,0 +1,52 @@
+package procstat
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestTurnTimingLogHit(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	(&TurnTiming{
+		EndpointMs:     600,
+		MergeWaitMs:    400,
+		EmbeddingMs:    300,
+		VectorSearchMs: 20,
+		RAGChunks:      3,
+		QuietWaitMs:    100,
+		LLMTTFTMs:      800,
+		TTSFirstByteMs: 950,
+	}).Log()
+
+	out := buf.String()
+	// total = endpoint (600) + turn-boundary→first-audio (950); the merge
+	// wait is already inside TTSFirstByteMs, which counts from the first final.
+	for _, want := range []string{"rag=hit", "endpoint_ms=600", "merge_wait_ms=400", "embed_ms=300", "vsearch_ms=20", "llm_ttft_ms=800", "total_user_to_speech_ms=1550"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log line missing %q: %s", want, out)
+		}
+	}
+}
+
+func TestTurnTimingLogSkip(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	(&TurnTiming{RAGSkipped: true, RAGSkipReason: "form-active"}).Log()
+
+	if out := buf.String(); !strings.Contains(out, "rag=skip:form-active") {
+		t.Errorf("expected skip reason in log, got: %s", out)
+	}
+}
+
+func TestTurnTimingLogNilSafe(t *testing.T) {
+	var tt *TurnTiming
+	tt.Log() // must not panic
+}

--- a/internal/rag/timing.go
+++ b/internal/rag/timing.go
@@ -1,0 +1,26 @@
+package rag
+
+import "context"
+
+// Timing collects per-search stage durations in milliseconds. A caller opts in
+// by putting a *Timing into the search context via WithTiming; the active
+// Client populates it. Absent collector = zero cost, so this never affects the
+// hot path unless telemetry is explicitly requested.
+type Timing struct {
+	EmbedMs int64 // embedding provider round-trip (the public-internet hop)
+	QueryMs int64 // vector store query (pgvector SQL or Supabase RPC)
+}
+
+type timingKey struct{}
+
+// WithTiming returns a context carrying t. The RAG client records embedding and
+// vector-store stage timings into t during Search.
+func WithTiming(ctx context.Context, t *Timing) context.Context {
+	return context.WithValue(ctx, timingKey{}, t)
+}
+
+// timingFrom returns the collector in ctx, or nil if none was attached.
+func timingFrom(ctx context.Context) *Timing {
+	t, _ := ctx.Value(timingKey{}).(*Timing)
+	return t
+}

--- a/internal/rag/timing_test.go
+++ b/internal/rag/timing_test.go
@@ -1,0 +1,28 @@
+package rag
+
+import (
+	"context"
+	"testing"
+)
+
+func TestWithTimingRoundTrip(t *testing.T) {
+	var tm Timing
+	ctx := WithTiming(context.Background(), &tm)
+
+	got := timingFrom(ctx)
+	if got != &tm {
+		t.Fatalf("timingFrom returned %p, want %p", got, &tm)
+	}
+
+	got.EmbedMs = 42
+	got.QueryMs = 7
+	if tm.EmbedMs != 42 || tm.QueryMs != 7 {
+		t.Fatalf("writes through collector not visible: %+v", tm)
+	}
+}
+
+func TestTimingFromAbsent(t *testing.T) {
+	if got := timingFrom(context.Background()); got != nil {
+		t.Fatalf("timingFrom on bare context = %v, want nil", got)
+	}
+}

--- a/internal/signaling/handler.go
+++ b/internal/signaling/handler.go
@@ -4,7 +4,9 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/streamcoreai/server/internal/session"
@@ -16,7 +18,18 @@ import (
 //	POST   /whip                   – Session setup (SDP offer/answer), returns sessionId
 //	DELETE /whip/{sessionId}       – Session teardown
 //	OPTIONS (any)                  – CORS preflight
+//
+// Session creation is rate limited per client IP. /whip is unauthenticated by
+// default, and each POST builds a peer connection and gathers ICE, so an
+// unthrottled endpoint lets one client burn CPU and ports at will.
+// defaultWhipRateLimit caps session-creation POSTs per client IP per minute.
+// Generous for humans — a browser session is one POST — while throttling an
+// abusive burst.
+const defaultWhipRateLimit = 30
+
 func NewWHIPHandler(sm *session.Manager) http.HandlerFunc {
+	limiter := newWidgetRateLimiter(defaultWhipRateLimit, time.Minute)
+
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Parse path segment: /whip or /whip/{sessionId}
 		trimmed := strings.TrimPrefix(r.URL.Path, "/whip")
@@ -29,6 +42,12 @@ func NewWHIPHandler(sm *session.Manager) http.HandlerFunc {
 			w.WriteHeader(http.StatusNoContent)
 
 		case http.MethodPost:
+			if ok, retryAfter := limiter.Allow(clientIP(r)); !ok {
+				w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+				log.Printf("[whip] rate limited %s", clientIP(r))
+				http.Error(w, "too many session requests", http.StatusTooManyRequests)
+				return
+			}
 			handleWHIPPost(w, r, sm)
 
 		case http.MethodDelete:

--- a/internal/signaling/rate_limiter.go
+++ b/internal/signaling/rate_limiter.go
@@ -1,0 +1,120 @@
+package signaling
+
+import (
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// widgetRateLimiter is a small fixed-window per-IP rate limiter for the
+// public /widget-config endpoint. The endpoint is unauthenticated and
+// served from a tenant-resolver cache, so each request is cheap — but a
+// determined attacker could still consume CPU / bandwidth without one.
+//
+// In-memory only. For multi-replica deployments where strict global
+// limits matter, swap to a Redis-backed bucket; for single-instance the
+// per-process counter is sufficient.
+type widgetRateLimiter struct {
+	mu     sync.Mutex
+	limit  int
+	window time.Duration
+	counts map[string]*rateCount
+}
+
+type rateCount struct {
+	count   int
+	resetAt time.Time
+}
+
+const (
+	// Defaults tuned to be invisible to legitimate users (one widget load
+	// usually fires one /widget-config request per page) while throttling
+	// abusive bursts to a manageable rate.
+	defaultWidgetRateLimit  = 120
+	defaultWidgetRateWindow = time.Minute
+	// Opportunistic GC threshold — purge expired entries when the map
+	// grows past this size to keep memory bounded under sustained load.
+	rateLimiterGCThreshold = 8192
+)
+
+func newWidgetRateLimiter(limit int, window time.Duration) *widgetRateLimiter {
+	if limit <= 0 {
+		limit = defaultWidgetRateLimit
+	}
+	if window <= 0 {
+		window = defaultWidgetRateWindow
+	}
+	return &widgetRateLimiter{
+		limit:  limit,
+		window: window,
+		counts: make(map[string]*rateCount),
+	}
+}
+
+// Allow reports whether a request from the given client may proceed and,
+// if not, how many seconds the client should wait before retrying. The
+// limiter resets the counter once the window elapses.
+func (l *widgetRateLimiter) Allow(client string) (bool, int) {
+	if client == "" {
+		client = "_unknown"
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := time.Now()
+	c, ok := l.counts[client]
+	if !ok || now.After(c.resetAt) {
+		l.counts[client] = &rateCount{count: 1, resetAt: now.Add(l.window)}
+		l.maybeGC(now)
+		return true, 0
+	}
+	if c.count >= l.limit {
+		retryAfter := int(c.resetAt.Sub(now).Seconds())
+		if retryAfter < 1 {
+			retryAfter = 1
+		}
+		return false, retryAfter
+	}
+	c.count++
+	return true, 0
+}
+
+// maybeGC purges expired entries when the map is large. Caller must hold
+// the lock. Cheap amortised cost since we only walk the map after it
+// crosses the threshold.
+func (l *widgetRateLimiter) maybeGC(now time.Time) {
+	if len(l.counts) < rateLimiterGCThreshold {
+		return
+	}
+	for k, v := range l.counts {
+		if now.After(v.resetAt) {
+			delete(l.counts, k)
+		}
+	}
+}
+
+// clientIP extracts the most-trusted client IP from the request:
+//  1. The first hop in X-Forwarded-For (set by the load balancer / CDN
+//     before forwarding to the origin).
+//  2. RemoteAddr's host portion as a fallback for direct connections.
+//
+// Production deployments must terminate inbound traffic at a trusted edge
+// — otherwise the X-Forwarded-For header is attacker-controlled.
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if first, _, ok := strings.Cut(xff, ","); ok {
+			return strings.TrimSpace(first)
+		}
+		return strings.TrimSpace(xff)
+	}
+	if real := r.Header.Get("X-Real-IP"); real != "" {
+		return strings.TrimSpace(real)
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/internal/signaling/rate_limiter_test.go
+++ b/internal/signaling/rate_limiter_test.go
@@ -1,0 +1,152 @@
+package signaling
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestWidgetRateLimiterAllowsUnderLimit(t *testing.T) {
+	l := newWidgetRateLimiter(3, time.Minute)
+	for i := 0; i < 3; i++ {
+		ok, retry := l.Allow("1.2.3.4")
+		if !ok {
+			t.Errorf("call %d: expected Allow=true, got false (retry=%d)", i+1, retry)
+		}
+		if retry != 0 {
+			t.Errorf("call %d: expected retry=0 when allowed, got %d", i+1, retry)
+		}
+	}
+}
+
+func TestWidgetRateLimiterRejectsOverLimit(t *testing.T) {
+	l := newWidgetRateLimiter(2, time.Minute)
+	l.Allow("9.9.9.9")
+	l.Allow("9.9.9.9")
+	ok, retry := l.Allow("9.9.9.9")
+	if ok {
+		t.Errorf("expected rejection on 3rd call with limit=2")
+	}
+	if retry < 1 {
+		t.Errorf("expected retry-after >= 1 when rejected, got %d", retry)
+	}
+}
+
+func TestWidgetRateLimiterIsolatesByClient(t *testing.T) {
+	// Two different IPs each get their own bucket.
+	l := newWidgetRateLimiter(1, time.Minute)
+	if ok, _ := l.Allow("1.1.1.1"); !ok {
+		t.Errorf("expected first call from 1.1.1.1 to succeed")
+	}
+	if ok, _ := l.Allow("1.1.1.1"); ok {
+		t.Errorf("expected second call from 1.1.1.1 to be rate-limited")
+	}
+	if ok, _ := l.Allow("2.2.2.2"); !ok {
+		t.Errorf("different IP should have its own bucket")
+	}
+}
+
+func TestWidgetRateLimiterResetsAfterWindow(t *testing.T) {
+	// 50ms window so we can confirm the reset path without a slow test.
+	l := newWidgetRateLimiter(1, 50*time.Millisecond)
+	if ok, _ := l.Allow("3.3.3.3"); !ok {
+		t.Fatalf("expected first call to succeed")
+	}
+	if ok, _ := l.Allow("3.3.3.3"); ok {
+		t.Errorf("expected second call within window to fail")
+	}
+	time.Sleep(80 * time.Millisecond)
+	if ok, _ := l.Allow("3.3.3.3"); !ok {
+		t.Errorf("expected call after window to succeed (window reset)")
+	}
+}
+
+func TestWidgetRateLimiterDefaults(t *testing.T) {
+	// Negative or zero values should fall back to defaults rather than
+	// produce a limiter that always rejects.
+	l := newWidgetRateLimiter(0, 0)
+	for i := 0; i < 50; i++ {
+		ok, _ := l.Allow("4.4.4.4")
+		if !ok {
+			t.Errorf("default limit should comfortably allow 50 calls; failed at %d", i)
+			return
+		}
+	}
+}
+
+func TestWidgetRateLimiterBlankClientBucketed(t *testing.T) {
+	// Empty client identifier all bucket together as "_unknown" so a flood
+	// of caller-IP-stripped requests still gets throttled.
+	l := newWidgetRateLimiter(2, time.Minute)
+	l.Allow("")
+	l.Allow("")
+	if ok, _ := l.Allow(""); ok {
+		t.Errorf("expected blank-client bucket to enforce limit")
+	}
+}
+
+func TestClientIPPrefersXForwardedFor(t *testing.T) {
+	cases := []struct {
+		name       string
+		xff        string
+		realIP     string
+		remoteAddr string
+		want       string
+	}{
+		{
+			name:       "xff first hop",
+			xff:        "203.0.113.5, 10.0.0.1",
+			remoteAddr: "10.0.0.1:54321",
+			want:       "203.0.113.5",
+		},
+		{
+			name:       "xff single",
+			xff:        "203.0.113.7",
+			remoteAddr: "10.0.0.1:54321",
+			want:       "203.0.113.7",
+		},
+		{
+			name:       "x-real-ip when no xff",
+			realIP:     "203.0.113.9",
+			remoteAddr: "10.0.0.1:54321",
+			want:       "203.0.113.9",
+		},
+		{
+			name:       "remoteaddr fallback",
+			remoteAddr: "198.51.100.42:8080",
+			want:       "198.51.100.42",
+		},
+		{
+			name:       "ipv6 remoteaddr",
+			remoteAddr: "[2001:db8::1]:443",
+			want:       "2001:db8::1",
+		},
+		{
+			name:       "remoteaddr without port",
+			remoteAddr: "198.51.100.99",
+			want:       "198.51.100.99",
+		},
+		{
+			name:       "xff with whitespace stripped",
+			xff:        "   203.0.113.42   , proxy",
+			remoteAddr: "10.0.0.1:54321",
+			want:       "203.0.113.42",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/x", nil)
+			if tc.xff != "" {
+				req.Header.Set("X-Forwarded-For", tc.xff)
+			}
+			if tc.realIP != "" {
+				req.Header.Set("X-Real-IP", tc.realIP)
+			}
+			req.RemoteAddr = tc.remoteAddr
+			got := clientIP(req)
+			if got != tc.want {
+				t.Errorf("clientIP() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Duck agent audio on barge-in candidates instead of cutting, and classify multi-word backchannels properly so 'yeah okay sure' no longer clips a sentence; add an optional readback guard
- Debounce final transcripts into whole turns so a caller who pauses mid-sentence is not answered halfway through
- Skip retrieval on turns with no content-bearing words, and prefetch
This pull request introduces several improvements to the agent's speech interaction pipeline, focusing on more natural turn-taking, improved barge-in handling, and infrastructure for speculative retrieval and focused LLM calls. The changes add new configuration options, refactor barge-in logic for better accuracy, introduce audio "ducking" during interruptions, and implement a new "OneShot" LLM API for non-streaming, stateless completions.

**Barge-in and Turn-taking Improvements**
- Added new configuration options to `PipelineConfig` for user speech quiet time, turn merging debounce, readback barge-in guard, and speculative RAG prefetching, along with sensible defaults to reduce agent interruptions and improve turn segmentation. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR42-R64) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR232-R240)
- Refactored barge-in logic into `bargein.go` with improved detection of meaningful interruptions, backchannel suppression, and special handling for readback confirmation prompts. Now only strong commands (e.g., "stop", "cancel") can interrupt during readback, reducing accidental context loss. [[1]](diffhunk://#diff-0a94efa911d33abe2ff02a0f441ea58f45ba024ff41c86653b36cd9d72a39df2R1-R277) [[2]](diffhunk://#diff-ea8636b9d9e095b51c568a4bde20d34dfdb61d91d71746704aa989fd9f59aff8L162-R179)
- Removed the old `backchannelTokens` map and replaced its usage with more robust text normalization and token-based checks for barge-in.

**Audio Handling Enhancements**
- Implemented "ducking" in `duck.go`, which smoothly attenuates agent audio when the caller speaks over it, instead of abruptly cutting off, making the interaction less jarring and more recoverable. [[1]](diffhunk://#diff-ccdc1b1f0a811bd9f5a9e848146c5804ba1e0cc2e9b67792f0ba51e43af7b273R1-R45) [[2]](diffhunk://#diff-ea8636b9d9e095b51c568a4bde20d34dfdb61d91d71746704aa989fd9f59aff8R156)

**LLM and RAG Pipeline Improvements**
- Added a new `OneShot` method to the LLM client interface and implemented it for both Ollama and OpenAI clients. This allows for single, stateless, non-streaming LLM calls, useful for focused tasks like summarization or background transforms without disturbing the conversation state. [[1]](diffhunk://#diff-15e84642b9ee7cbb81fbfc09f439cc544bcabb6fc29b0835f8a31c77802d6aebR34-R36) [[2]](diffhunk://#diff-d7410c57c6fd8c938d791257f4c6a51e2ec0ad9ca5856362d678bce2b7ce6b57R299-R323) [[3]](diffhunk://#diff-b784602960fcf6fb9fb45f82224c87527cf99d94d1276502b1520a04c898eda2R574-R593)
- Improved RAG (retrieval-augmented generation) handling in the agent pipeline: skips unnecessary RAG queries for non-contentful turns, supports speculative prefetching to overlap retrieval latency with the turn-merge window, and logs detailed timing for debugging.

These changes collectively make the agent more responsive and robust in real-time conversations, especially in handling interruptions and minimizing unnecessary delays.

**References:**  
[[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR42-R64) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR232-R240) [[3]](diffhunk://#diff-0a94efa911d33abe2ff02a0f441ea58f45ba024ff41c86653b36cd9d72a39df2R1-R277) [[4]](diffhunk://#diff-ea8636b9d9e095b51c568a4bde20d34dfdb61d91d71746704aa989fd9f59aff8L69-L76) [[5]](diffhunk://#diff-ea8636b9d9e095b51c568a4bde20d34dfdb61d91d71746704aa989fd9f59aff8L162-R179) [[6]](diffhunk://#diff-ccdc1b1f0a811bd9f5a9e848146c5804ba1e0cc2e9b67792f0ba51e43af7b273R1-R45) [[7]](diffhunk://#diff-ea8636b9d9e095b51c568a4bde20d34dfdb61d91d71746704aa989fd9f59aff8R156) [[8]](diffhunk://#diff-15e84642b9ee7cbb81fbfc09f439cc544bcabb6fc29b0835f8a31c77802d6aebR34-R36) [[9]](diffhunk://#diff-d7410c57c6fd8c938d791257f4c6a51e2ec0ad9ca5856362d678bce2b7ce6b57R299-R323) [[10]](diffhunk://#diff-b784602960fcf6fb9fb45f82224c87527cf99d94d1276502b1520a04c898eda2R574-R593) [[11]](diffhunk://#diff-f7a5228cef5de0e6d0f63ca5af285d6403c836d7292e4f6a1ef337dff4d36c03L108-R164) speculatively during the merge window so RAG latency overlaps the wait
- Summarise older turns in the background so long calls keep early context
- Escalate to a clarifying question on repeated low-confidence turns
- Record a per-turn latency breakdown behind pipeline.debug
- Rate limit WHIP session creation per client IP