### PR TITLE
switch tts to use deepgram

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ provider = "cartesia"
 [deepgram]
 api_key = ""
 model = "nova-3"
+tts_model = "aura-2-thalia-en"       # Aura voice when tts.provider = "deepgram"; aura-2-theia-en is Australian feminine
 # language = ""                      # BCP-47 tag (en-US, es-MX); non-en/es routes to the multilingual model
 endpointing = "300"                  # Silence (ms) before a transcript is finalised
 utterance_end_ms = "1000"            # Silence (ms) before UtteranceEnd; flushes a turn with no speech_final
@@ -671,6 +672,7 @@ Notes:
 - `pipeline.rag_prefetch` overlaps retrieval with the turn-merge window. Off by default; it issues a speculative embedding + search that is discarded if the turn text changes.
 - `pipeline.readback_bargein_guard_enabled` keeps weak corrections and backchannels from cutting off a confirmation readback. Only explicit commands (stop, cancel, hang up) interrupt. Off by default.
 - `deepgram.endpointing` and `deepgram.utterance_end_ms` tune when a turn is considered finished upstream; the turn-merge debounce runs on top of them.
+- `deepgram.tts_model` picks the Aura voice; STT (`model`) and TTS (`tts_model`) share the one API key. Voices are named `[family]-[voice]-[language]` — see [Deepgram's voice list](https://developers.deepgram.com/docs/tts-models).
 - `cartesia.max_concurrency` should match your plan's TTS concurrency limit — Cartesia counts active generations, not calls, and returns 429 past the limit.
 
 ## Architecture and implementation

--- a/config.toml.example
+++ b/config.toml.example
@@ -37,6 +37,9 @@ provider = "cartesia"   # Supported: cartesia, deepgram, elevenlabs, speechify, 
 [deepgram]
 api_key = ""            # Required for Deepgram STT, and for Deepgram TTS if selected
 model = "nova-3"        # STT model
+tts_model = "aura-2-thalia-en"  # Aura voice used when tts.provider = "deepgram".
+                        # e.g. aura-2-theia-en (Australian, feminine), aura-2-pandora-en (British, feminine).
+                        # Full list: https://developers.deepgram.com/docs/tts-models
 language = ""           # Optional BCP-47 tag (en-US, es-MX). Non-en/es routes to the multilingual model
 endpointing = "300"     # Silence (ms) before a transcript is finalised. Raise it if callers get cut off mid-sentence
 utterance_end_ms = "1000"  # Silence (ms) before an UtteranceEnd event; flushes a turn when no speech_final arrives (min 1000)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,6 +103,10 @@ type DeepgramConfig struct {
 	// phonetically ambiguous against common English (product names, place
 	// names). Ignored by other models.
 	Keyterms []string `toml:"keyterms"`
+	// TTSModel selects the Aura voice used when tts.provider = "deepgram".
+	// Model is STT-only, so TTS gets its own field on the same section (both
+	// roles share one API key). Empty defaults to aura-2-thalia-en.
+	TTSModel string `toml:"tts_model"`
 }
 
 type AssemblyAIConfig struct {
@@ -211,6 +215,7 @@ func Load(path string) (*Config, error) {
 	// flush that recovers a turn when no speech_final arrives.
 	setDefault(&cfg.Deepgram.Endpointing, "300")
 	setDefault(&cfg.Deepgram.UtteranceEndMs, "1000")
+	setDefault(&cfg.Deepgram.TTSModel, "aura-2-thalia-en")
 	setDefault(&cfg.AssemblyAI.Model, "u3-rt-pro")
 	// Cartesia counts concurrency by active generation context; 3 comfortably
 	// serves many concurrent calls because agent speech is bursty and

--- a/internal/tts/client.go
+++ b/internal/tts/client.go
@@ -48,7 +48,7 @@ func newProviderClient(cfg *config.Config) (Client, error) {
 		if cfg.Deepgram.APIKey == "" {
 			return nil, ErrMissingAPIKey{Provider: "deepgram", Field: "[deepgram] api_key"}
 		}
-		return NewDeepgramClient(cfg.Deepgram.APIKey), nil
+		return NewDeepgramClient(cfg.Deepgram.APIKey, cfg.Deepgram.TTSModel), nil
 	case "cartesia":
 		if cfg.Cartesia.APIKey == "" {
 			return nil, ErrMissingAPIKey{Provider: "cartesia", Field: "[cartesia] api_key"}

--- a/internal/tts/deepgram.go
+++ b/internal/tts/deepgram.go
@@ -10,22 +10,33 @@ import (
 	"strings"
 )
 
+// defaultDeepgramTTSModel is Deepgram's recommended general-purpose Aura-2
+// voice. Voices are named [family]-[voice]-[language]; see
+// https://developers.deepgram.com/docs/tts-models for the full list.
+const defaultDeepgramTTSModel = "aura-2-thalia-en"
+
 type deepgramClient struct {
 	apiKey     string
+	model      string
 	httpClient *http.Client
 }
 
-// NewDeepgramClient creates a Deepgram Aura TTS client.
-func NewDeepgramClient(apiKey string) Client {
+// NewDeepgramClient creates a Deepgram Aura TTS client. An empty model falls
+// back to defaultDeepgramTTSModel.
+func NewDeepgramClient(apiKey, model string) Client {
+	if model == "" {
+		model = defaultDeepgramTTSModel
+	}
 	return &deepgramClient{
 		apiKey:     apiKey,
+		model:      model,
 		httpClient: newPooledHTTPClient(),
 	}
 }
 
 func (c *deepgramClient) buildRequest(ctx context.Context, text string) (*http.Request, error) {
 	params := url.Values{}
-	params.Set("model", "aura-asteria-en")
+	params.Set("model", c.model)
 	params.Set("encoding", "linear16")
 	params.Set("sample_rate", "16000")
 	params.Set("container", "none")


### PR DESCRIPTION
This pull request adds support for selecting Deepgram TTS (text-to-speech) voices via configuration, making it possible to choose from Deepgram's Aura voice models. The change introduces a new `tts_model` setting, documents its usage, and ensures a sensible default is applied if none is specified. This improves flexibility and makes it easier to customize TTS voices without code changes.

**Deepgram TTS voice selection:**
- Added a new `tts_model` field to the `[deepgram]` section in `config.toml.example` and documented its usage and available options, allowing users to select a specific Aura voice for TTS. [[1]](diffhunk://#diff-514f3c6049dd26198894991be37accf7786d0b38e3a1fc21f201c14be271b642R40-R42) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R601) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R675)
- Updated the `DeepgramConfig` struct to include the `TTSModel` field, with documentation explaining its purpose and default behavior.
- Set the default value for `DeepgramConfig.TTSModel` to `"aura-2-thalia-en"` if not specified in the config file, ensuring backward compatibility and a working default.
- Modified the TTS client creation logic to pass the selected `TTSModel` to the Deepgram client, and updated the Deepgram client to use this model when building requests. [[1]](diffhunk://#diff-6464340c399f6c36e10ec84f1210195231f32fcf44750d3f684de99e415b516eL51-R51) [[2]](diffhunk://#diff-965b1e0067bc2c811894333e18b919e3193b56a93b4d1d03676f8012c4a870f4R13-R39)