### PR TITLE
fixed tts bug, overlaps after barge-in

### DIFF
--- a/internal/pipeline/acknowledgement_test.go
+++ b/internal/pipeline/acknowledgement_test.go
@@ -1,0 +1,179 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/streamcoreai/server/internal/config"
+)
+
+func TestIsAcknowledgementOnly(t *testing.T) {
+	tests := []struct {
+		text string
+		want bool
+		why  string
+	}{
+		// Pure listening noises — the reported case and its variants.
+		{"Okay.", true, "the reported case"},
+		{"okay", true, "bare acknowledgement"},
+		{"yeah, okay", true, "stacked acknowledgements"},
+		{"mm-hmm", true, "hummed backchannel"},
+		{"got it", true, "multi-word acknowledgement"},
+		{"right, sure", true, "stacked acknowledgements"},
+		{"I see", true, "acknowledgement phrased as a clause"},
+		{"exactly", true, "agreement"},
+
+		// Single tokens that carry intent. These are the reason this predicate
+		// cannot reuse isMeaningfulBargeInTranscript, which requires >= 2
+		// tokens and would swallow every one of them.
+		{"why?", false, "one-word question"},
+		{"no", false, "correction"},
+		{"stop", false, "command"},
+		{"wait", false, "command"},
+		{"what?", false, "request to repeat"},
+		{"help", false, "request"},
+
+		// Anything with content.
+		{"okay but what about billing", false, "acknowledgement plus a question"},
+		{"yeah actually change that", false, "acknowledgement plus a correction"},
+		{"can you repeat that", false, "real request"},
+		{"", false, "empty text is not an acknowledgement"},
+	}
+
+	for _, tc := range tests {
+		if got := isAcknowledgementOnly(tc.text); got != tc.want {
+			t.Errorf("isAcknowledgementOnly(%q) = %v, want %v (%s)", tc.text, got, tc.want, tc.why)
+		}
+	}
+}
+
+// The reported bug: "Okay." spoken over the agent's explanation started a whole
+// new LLM turn whose audio played on top of the sentences still in flight.
+func TestPassiveAcknowledgementOverAgentSpeechIsIgnored(t *testing.T) {
+	p := newResponseStatePipeline(nil)
+	p.interruptedText.Store("")
+
+	ev := TranscriptEvent{Text: "Okay.", Final: true, OverAgentSpeech: true}
+	if !p.isPassiveAcknowledgement(ev) {
+		t.Fatal(`"Okay." over agent speech should not start a new turn`)
+	}
+}
+
+// The same words said into silence are the caller handing the floor back.
+func TestAcknowledgementInSilenceStillGetsAnswered(t *testing.T) {
+	p := newResponseStatePipeline(nil)
+	p.interruptedText.Store("")
+
+	ev := TranscriptEvent{Text: "Okay.", Final: true, OverAgentSpeech: false}
+	if p.isPassiveAcknowledgement(ev) {
+		t.Fatal(`"Okay." said into silence is a real turn and must be answered`)
+	}
+}
+
+// After a confirmed barge-in the agent has already been cut off mid-sentence.
+// Swallowing the turn would leave the caller listening to nothing.
+func TestAcknowledgementAfterBargeInIsAnswered(t *testing.T) {
+	p := newResponseStatePipeline(nil)
+	p.interruptedText.Store("the plugin system allows for extensibility")
+
+	ev := TranscriptEvent{Text: "yeah okay", Final: true, OverAgentSpeech: true}
+	if p.isPassiveAcknowledgement(ev) {
+		t.Fatal("suppressing this turn leaves dead air — the agent was already cut off")
+	}
+}
+
+// Intent spoken over the agent must always reach the LLM, however short.
+func TestMeaningfulTurnOverAgentSpeechIsNeverSuppressed(t *testing.T) {
+	p := newResponseStatePipeline(nil)
+	p.interruptedText.Store("")
+
+	for _, text := range []string{"no", "stop", "why?", "okay but wait", "hang on"} {
+		ev := TranscriptEvent{Text: text, Final: true, OverAgentSpeech: true}
+		if p.isPassiveAcknowledgement(ev) {
+			t.Errorf("%q was suppressed but carries intent", text)
+		}
+	}
+}
+
+// The talking-over flag has to be sampled while the agent is still audible.
+// STT endpointing delays a final by several hundred ms, so the flag must
+// survive the agent finishing in the meantime.
+func TestAgentSpeechRecentCoversEndpointingLag(t *testing.T) {
+	p := newResponseStatePipeline(nil)
+
+	if p.agentSpeechRecent() {
+		t.Fatal("a pipeline that has never spoken should not report recent speech")
+	}
+
+	p.setSpeaking(true)
+	if !p.agentSpeechRecent() {
+		t.Fatal("agent is speaking right now")
+	}
+
+	p.setSpeaking(false)
+	if !p.agentSpeechRecent() {
+		t.Fatal("speech that just ended must still count — the STT final is in flight")
+	}
+
+	// Rewind the stamp past the grace window.
+	p.speechEndedAt.Store(time.Now().Add(-2 * backchannelGrace).UnixNano())
+	if p.agentSpeechRecent() {
+		t.Fatal("speech that ended long ago must not count as talking-over")
+	}
+}
+
+// setSpeaking must only stamp on a true → false transition; a redundant
+// clear would otherwise keep pushing the grace window forward forever.
+func TestSetSpeakingStampsOnlyOnTransition(t *testing.T) {
+	p := newResponseStatePipeline(nil)
+
+	p.setSpeaking(true)
+	p.setSpeaking(false)
+	first := p.speechEndedAt.Load()
+	if first == 0 {
+		t.Fatal("ending speech should stamp speechEndedAt")
+	}
+
+	p.setSpeaking(false)
+	if p.speechEndedAt.Load() != first {
+		t.Fatal("a redundant clear re-stamped the timestamp, extending the grace window")
+	}
+}
+
+// A turn that begins over the agent's voice stays flagged through the turn
+// buffer even when its later halves are merged in after the agent has stopped
+// — which is the common shape, since the merge window runs for hundreds of ms
+// past the first final.
+func TestTurnBufferKeepsOverAgentSpeechAcrossMerge(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p := newResponseStatePipeline(nil)
+	p.ctx = ctx
+	p.cfg = &config.Config{}
+	p.cfg.Pipeline.TurnMergeMs = 60
+	p.finalCh = make(chan TranscriptEvent, transcriptChSize)
+	p.transcriptCh = make(chan TranscriptEvent, transcriptChSize)
+
+	go p.runTurnBuffer()
+
+	// Caller starts over the agent's voice, then continues after it stops.
+	p.finalCh <- TranscriptEvent{Text: "okay", Final: true, OverAgentSpeech: true}
+	p.finalCh <- TranscriptEvent{Text: "sure", Final: true, OverAgentSpeech: false}
+
+	select {
+	case merged := <-p.transcriptCh:
+		if merged.Text != "okay sure" {
+			t.Fatalf("merged text = %q, want %q", merged.Text, "okay sure")
+		}
+		if !merged.OverAgentSpeech {
+			t.Fatal("merged turn lost the talking-over flag from its first half")
+		}
+		if !isAcknowledgementOnly(merged.Text) {
+			t.Fatalf("merged acknowledgement %q should still classify as one", merged.Text)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("turn buffer never emitted the merged turn")
+	}
+}

--- a/internal/pipeline/agent.go
+++ b/internal/pipeline/agent.go
@@ -36,10 +36,15 @@ func (p *Pipeline) runAgent() {
 				continue
 			}
 
+			if p.isPassiveAcknowledgement(ev) {
+				log.Printf("[agent] acknowledgement ignored (caller talking over agent): %q", ev.Text)
+				continue
+			}
+
 			log.Printf("[agent] user: %s", ev.Text)
-			p.cancelResponse()
+			gen := p.supersedeResponse()
 			p.sendEvent(stateMsg{Type: "state", State: "thinking"})
-			go p.respond(ev.Text, ev.TurnStart)
+			go p.respond(gen, ev.Text, ev.TurnStart)
 
 		case <-p.interruptCh:
 			// Capture what agent was saying for interruption context
@@ -47,37 +52,55 @@ func (p *Pipeline) runAgent() {
 				p.interruptedText.Store(txt)
 			}
 			log.Println("[agent] interrupted (barge-in)")
-			p.cancelResponse()
-			p.drainOutbound()
+			p.supersedeResponse()
 		}
 	}
 }
 
+// isPassiveAcknowledgement reports whether a completed turn is just the caller
+// signalling "I'm still with you" over the agent's voice, rather than a turn
+// that wants an answer.
+//
+// These arrive as ordinary finals, and the backchannel suppression in
+// runInbound only guards the VAD barge-in path — it never sees them. So
+// without this check an "okay" dropped mid-explanation starts a full LLM turn
+// whose audio lands on top of the sentences still in flight.
+func (p *Pipeline) isPassiveAcknowledgement(ev TranscriptEvent) bool {
+	// Said into silence, an acknowledgement is a real (if minimal) turn — the
+	// caller is handing the floor back and deserves a reply. Only one spoken
+	// over the agent is passive.
+	if !ev.OverAgentSpeech || !isAcknowledgementOnly(ev.Text) {
+		return false
+	}
+
+	// A confirmed barge-in already cut the agent off mid-sentence. Swallowing
+	// the turn now would leave the caller in dead air, so answer it even
+	// though the words themselves carry nothing.
+	if interrupted, _ := p.interruptedText.Load().(string); interrupted != "" {
+		return false
+	}
+
+	return true
+}
+
 // respond runs the LLM → TTS → outbound flow for a single user utterance.
-// It is cancellable via responseCancel (barge-in or new utterance).
-func (p *Pipeline) respond(userText string, turnStart time.Time) {
+// gen is the response generation issued by supersedeResponse; it scopes every
+// mutation of shared speaking state to this response, so a barge-in or a newer
+// turn cleanly takes ownership of the audio path.
+func (p *Pipeline) respond(gen uint64, userText string, turnStart time.Time) {
 	respCtx, cancel := context.WithCancel(p.ctx)
 
-	p.responseMu.Lock()
-	if p.responseCancel != nil {
-		p.responseCancel()
+	// Superseded between the turn being dispatched and this goroutine getting
+	// scheduled — a newer turn already owns the audio path, and synthesizing
+	// now would put two responses on outPCMCh at once.
+	if !p.registerResponse(gen, cancel) {
+		cancel()
+		return
 	}
-	p.responseCancel = cancel
-	p.responseMu.Unlock()
 
 	defer func() {
 		cancel()
-		p.speaking.Store(false)
-		p.responseMu.Lock()
-		p.responseCancel = nil
-		p.responseMu.Unlock()
-
-		// Wait for outbound PCM queue to drain before signalling "listening".
-		// This ensures the sender goroutine has consumed and RTP-sent all
-		// frames before we tell the client the agent finished speaking.
-		p.waitOutboundDrain()
-
-		p.sendEvent(stateMsg{Type: "state", State: "listening"})
+		p.finishResponse(gen)
 	}()
 
 	// NOTE: speaking flag is set in synthesizeSentences when first TTS audio
@@ -253,7 +276,7 @@ func (p *Pipeline) synthesizeSentences(ctx context.Context, sentences <-chan str
 			// state visible while the LLM and TTS are working.
 			if !emittedSpeaking {
 				emittedSpeaking = true
-				p.speaking.Store(true)
+				p.setSpeaking(true)
 				p.sendEvent(stateMsg{Type: "state", State: "speaking"})
 			}
 			return true
@@ -337,10 +360,15 @@ func (p *Pipeline) synthesizeSentences(ctx context.Context, sentences <-chan str
 
 // waitOutboundDrain waits until the outbound PCM channel is empty, meaning
 // runSender has picked up all queued frames. It polls briefly with a timeout
-// to avoid blocking forever.
-func (p *Pipeline) waitOutboundDrain() {
+// to avoid blocking forever, and gives up as soon as generation gen is
+// superseded — the frames it would be waiting on have been discarded, and the
+// new response is already filling the channel behind them.
+func (p *Pipeline) waitOutboundDrain(gen uint64) {
 	deadline := time.After(5 * time.Second)
 	for {
+		if p.responseGen.Load() != gen {
+			return
+		}
 		if len(p.outPCMCh) == 0 {
 			// Frames consumed by sender; add a small grace period for the
 			// last few RTP packets to reach the client and be played.
@@ -353,6 +381,104 @@ func (p *Pipeline) waitOutboundDrain() {
 		case <-time.After(20 * time.Millisecond):
 		}
 	}
+}
+
+// supersedeResponse retires whatever the agent is currently saying so a new
+// turn can start on a clear audio path, and returns the generation that the
+// incoming response owns.
+//
+// All three steps are load-bearing:
+//
+//   - bumping the generation invalidates the outgoing response, so that when
+//     it finally unwinds it leaves speaking / responseCancel / the client
+//     state alone — those now belong to its successor
+//   - cancelling stops the LLM and TTS from producing any MORE audio
+//   - draining discards audio the old response ALREADY queued; cancellation
+//     does nothing about the frames sitting in outPCMCh (up to outPCMChSize,
+//     ~2s worth), and leaving them there is what makes the caller hear the
+//     previous answer keep playing while the new one stacks up behind it
+func (p *Pipeline) supersedeResponse() uint64 {
+	gen := p.responseGen.Add(1)
+	p.cancelResponse()
+	p.drainOutbound()
+	// The queued audio is gone, so the agent is no longer speaking. The next
+	// response re-raises this when its first frame actually reaches the wire.
+	p.setSpeaking(false)
+	return gen
+}
+
+// backchannelGrace is how long after the agent's last frame an incoming final
+// still counts as having been spoken over it. STT endpointing sits on a final
+// for ~600ms after the caller stops, so an "okay" landing on the agent's
+// closing words reaches the agent goroutine well after speaking cleared.
+const backchannelGrace = 1500 * time.Millisecond
+
+// setSpeaking updates the speaking flag, stamping the moment agent speech
+// ended so agentSpeechRecent can cover the STT endpointing lag.
+func (p *Pipeline) setSpeaking(speaking bool) {
+	if prev := p.speaking.Swap(speaking); prev && !speaking {
+		p.speechEndedAt.Store(time.Now().UnixNano())
+	}
+}
+
+// agentSpeechRecent reports whether the agent is speaking, or stopped recently
+// enough that a caller utterance arriving now was plausibly spoken over it.
+func (p *Pipeline) agentSpeechRecent() bool {
+	if p.speaking.Load() {
+		return true
+	}
+	endedAt := p.speechEndedAt.Load()
+	return endedAt != 0 && time.Since(time.Unix(0, endedAt)) < backchannelGrace
+}
+
+// registerResponse installs cancel as the cancel func for generation gen,
+// reporting false if gen has already been superseded.
+func (p *Pipeline) registerResponse(gen uint64, cancel context.CancelFunc) bool {
+	p.responseMu.Lock()
+	defer p.responseMu.Unlock()
+	if p.responseGen.Load() != gen {
+		return false
+	}
+	if p.responseCancel != nil {
+		p.responseCancel()
+	}
+	p.responseCancel = cancel
+	p.responseCancelGen = gen
+	return true
+}
+
+// finishResponse releases the shared speaking state owned by generation gen.
+//
+// A superseded response returns without touching anything. This guard is the
+// fix for responses talking over each other: a cancelled response unwinds
+// asynchronously (its LLM stream has to return first), by which point its
+// successor is already registered, and the unconditional cleanup this
+// replaced would nil out the successor's cancel func — leaving it immune to
+// the next barge-in and audible underneath the turn after it.
+func (p *Pipeline) finishResponse(gen uint64) {
+	p.responseMu.Lock()
+	if p.responseCancelGen == gen {
+		p.responseCancel = nil
+	}
+	stale := p.responseGen.Load() != gen
+	p.responseMu.Unlock()
+	if stale {
+		return
+	}
+
+	p.setSpeaking(false)
+
+	// Wait for the outbound PCM queue to drain before signalling "listening",
+	// so the sender has RTP-sent every frame before the client is told the
+	// agent finished speaking.
+	p.waitOutboundDrain(gen)
+
+	// The drain can block for seconds; a new turn may have started inside it,
+	// in which case "listening" would contradict the response now speaking.
+	if p.responseGen.Load() != gen {
+		return
+	}
+	p.sendEvent(stateMsg{Type: "state", State: "listening"})
 }
 
 // cancelResponse cancels any in-progress LLM/TTS response.
@@ -383,17 +509,26 @@ func (p *Pipeline) greet(text string) {
 	// NOTE: speaking flag and "speaking" state event are set inside
 	// synthesizeSentences when TTS audio is actually produced.
 
+	// The greeting goes through the same ownership handshake as a response so
+	// that a caller who starts talking over it can actually cut it off. Run on
+	// the pipeline context instead, and cancelResponse has nothing to cancel:
+	// the greeting keeps synthesizing underneath the first real answer.
+	gen := p.responseGen.Load()
+	ctx, cancel := context.WithCancel(p.ctx)
+	if !p.registerResponse(gen, cancel) {
+		cancel()
+		return
+	}
 	defer func() {
-		p.speaking.Store(false)
-		p.waitOutboundDrain()
-		p.sendEvent(stateMsg{Type: "state", State: "listening"})
+		cancel()
+		p.finishResponse(gen)
 	}()
 
 	sentences := make(chan string, 1)
 	sentences <- text
 	close(sentences)
 
-	p.synthesizeSentences(p.ctx, sentences, time.Time{})
+	p.synthesizeSentences(ctx, sentences, time.Time{})
 }
 
 // greetingText returns the appropriate greeting based on call direction.

--- a/internal/pipeline/bargein.go
+++ b/internal/pipeline/bargein.go
@@ -97,6 +97,23 @@ func isMeaningfulBargeInTranscript(s string) bool {
 	return contentWords >= 1 && len(tokens) >= 2
 }
 
+// isAcknowledgementOnly reports whether a whole turn is nothing but listening
+// noises — "okay", "yeah yeah", "mm-hm right", "got it".
+//
+// Deliberately a much lower bar than isMeaningfulBargeInTranscript. That
+// predicate decides whether to CUT THE AGENT OFF mid-word, so it can afford to
+// be conservative and demand two tokens plus a content word. This one decides
+// whether a turn is answered at all, so anything carrying meaning has to pass:
+// one-word questions ("why?"), corrections ("no"), and commands ("stop") are
+// all a single token and none of them are acknowledgement vocabulary.
+func isAcknowledgementOnly(s string) bool {
+	normalized := normalizedTranscriptText(s)
+	if normalized == "" {
+		return false
+	}
+	return isBackchannelOnly(strings.Fields(normalized))
+}
+
 func isSpeechActivityTranscript(s string) bool {
 	normalized := normalizedTranscriptText(s)
 	if normalized == "" {

--- a/internal/pipeline/inbound.go
+++ b/internal/pipeline/inbound.go
@@ -83,6 +83,10 @@ func (p *Pipeline) runInbound() {
 		ev := TranscriptEvent{Text: result.Text, Final: result.IsFinal}
 		if result.IsFinal {
 			ev.TurnStart = time.Now()
+			// Sampled here, not in runAgent: the turn buffer may hold this
+			// final for up to turnMergeMax, by which point the agent has
+			// finished and the talking-over question can no longer be asked.
+			ev.OverAgentSpeech = p.agentSpeechRecent()
 			hasPartialText.Store(false)
 			latestPartial.Store("text", "")
 			p.storeLastUserConfidence(result.Confidence)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -74,6 +74,12 @@ type Pipeline struct {
 
 	// Agent state
 	speaking atomic.Bool
+	// speechEndedAt is the wall-clock nanosecond at which speaking last went
+	// true → false, always written via setSpeaking. STT endpointing delays a
+	// final by several hundred ms, so an acknowledgement spoken over the
+	// agent's closing words routinely arrives after the flag has cleared;
+	// agentSpeechRecent uses this to still classify it as talking-over.
+	speechEndedAt atomic.Int64
 
 	// --- Turn quality state (rolling summary, misunderstanding, RAG prefetch) ---
 
@@ -105,11 +111,20 @@ type Pipeline struct {
 
 	// duckChangeCh signals the outbound sender to attenuate or restore agent
 	// audio while the caller is talking over it.
-	duckChangeCh   chan bool
-	audioMuted     atomic.Bool
-	processing     atomic.Bool
-	responseMu     sync.Mutex
-	responseCancel context.CancelFunc
+	duckChangeCh chan bool
+	audioMuted   atomic.Bool
+	processing   atomic.Bool
+
+	// responseGen identifies the response that currently owns the audio path.
+	// It is bumped every time a response is superseded (new turn or barge-in),
+	// so a cancelled response unwinding late can tell that speaking,
+	// responseCancel, and the client-facing state now belong to its successor
+	// and must not be cleared. Without this, a late unwind strands the live
+	// response with no cancel func and it talks over the next one.
+	responseGen       atomic.Uint64
+	responseMu        sync.Mutex
+	responseCancel    context.CancelFunc
+	responseCancelGen uint64
 
 	// Interruption tracking
 	lastAgentText   atomic.Value // string — accumulates current response text

--- a/internal/pipeline/response_gen_test.go
+++ b/internal/pipeline/response_gen_test.go
@@ -1,0 +1,128 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+)
+
+// newResponseStatePipeline builds the minimal Pipeline needed to exercise the
+// response-ownership handshake: no codecs, no providers, just the shared state
+// that supersedeResponse / registerResponse / finishResponse mutate.
+func newResponseStatePipeline(events *[]string) *Pipeline {
+	return &Pipeline{
+		outPCMCh: make(chan PCMFrame, outPCMChSize),
+		sendEvent: func(msg interface{}) error {
+			if st, ok := msg.(stateMsg); ok && events != nil {
+				*events = append(*events, st.State)
+			}
+			return nil
+		},
+	}
+}
+
+// A response that unwinds after being superseded must not clear the cancel
+// func its successor registered. This is the regression that made the agent
+// talk over itself: the stale cleanup left the live response uncancellable,
+// so the turn after it synthesized into outPCMCh alongside it.
+func TestFinishResponseDoesNotClobberSuccessor(t *testing.T) {
+	p := newResponseStatePipeline(nil)
+
+	genA := p.supersedeResponse()
+	_, cancelA := context.WithCancel(context.Background())
+	if !p.registerResponse(genA, cancelA) {
+		t.Fatal("registerResponse(genA) rejected the first response")
+	}
+
+	// New turn arrives while A is still streaming.
+	genB := p.supersedeResponse()
+	bCancelled := false
+	if !p.registerResponse(genB, func() { bCancelled = true }) {
+		t.Fatal("registerResponse(genB) rejected the successor")
+	}
+
+	// A's LLM stream returns only now, long after B took over.
+	p.finishResponse(genA)
+
+	p.cancelResponse()
+	if !bCancelled {
+		t.Fatal("B was left without a cancel func — a superseded response cleared it, " +
+			"so the next turn would synthesize on top of B")
+	}
+}
+
+// A superseded response must not clear `speaking` either: it gates barge-in
+// detection in runInbound, so clearing it while the successor talks makes the
+// agent deaf to interruption for the whole turn.
+func TestFinishResponseDoesNotClearSuccessorSpeaking(t *testing.T) {
+	p := newResponseStatePipeline(nil)
+
+	genA := p.supersedeResponse()
+	genB := p.supersedeResponse()
+	p.registerResponse(genB, func() {})
+
+	// B's first TTS frame reached the wire.
+	p.speaking.Store(true)
+
+	p.finishResponse(genA)
+
+	if !p.speaking.Load() {
+		t.Fatal("speaking cleared by a superseded response — barge-in is now dead for B's turn")
+	}
+}
+
+// The superseded response must also stay silent on the data channel: emitting
+// "listening" while its successor speaks desynchronizes the client UI.
+func TestFinishResponseSuppressesStaleListeningState(t *testing.T) {
+	var events []string
+	p := newResponseStatePipeline(&events)
+
+	genA := p.supersedeResponse()
+	p.supersedeResponse()
+
+	p.finishResponse(genA)
+	if len(events) != 0 {
+		t.Fatalf("superseded response emitted state events: %v", events)
+	}
+
+	// The current response still reports completion normally.
+	genC := p.supersedeResponse()
+	p.registerResponse(genC, func() {})
+	p.finishResponse(genC)
+	if len(events) != 1 || events[0] != "listening" {
+		t.Fatalf("current response should emit exactly one listening event, got %v", events)
+	}
+}
+
+// supersedeResponse must discard audio the retired response already queued.
+// Cancelling only stops NEW frames; the ones already in outPCMCh keep playing
+// while the next response stacks up behind them.
+func TestSupersedeResponseDropsQueuedAudio(t *testing.T) {
+	p := newResponseStatePipeline(nil)
+	p.speaking.Store(true)
+
+	for i := 0; i < 25; i++ {
+		p.outPCMCh <- PCMFrame{Samples: make([]int16, 320)}
+	}
+
+	p.supersedeResponse()
+
+	if n := len(p.outPCMCh); n != 0 {
+		t.Fatalf("outPCMCh still holds %d stale frames — the old answer plays into the new turn", n)
+	}
+	if p.speaking.Load() {
+		t.Fatal("speaking still set after the queued audio was discarded")
+	}
+}
+
+// A response goroutine scheduled after its turn was already superseded must
+// abandon itself rather than start synthesizing next to the live response.
+func TestRegisterResponseRejectsSupersededGeneration(t *testing.T) {
+	p := newResponseStatePipeline(nil)
+
+	stale := p.supersedeResponse()
+	p.supersedeResponse()
+
+	if p.registerResponse(stale, func() {}) {
+		t.Fatal("a superseded generation was allowed to claim the audio path")
+	}
+}

--- a/internal/pipeline/turnbuffer.go
+++ b/internal/pipeline/turnbuffer.go
@@ -90,6 +90,11 @@ func (p *Pipeline) runTurnBuffer() {
 				pending.Text = strings.TrimSpace(pending.Text + " " + text)
 				// Keep the earliest turn start: latency is measured from when
 				// the caller first stopped speaking, not from the last chunk.
+				//
+				// The talking-over flag is sticky across the merge: a turn that
+				// began over the agent's voice was an interruption regardless of
+				// whether its later halves landed after the agent stopped.
+				pending.OverAgentSpeech = pending.OverAgentSpeech || ev.OverAgentSpeech
 			}
 
 			// A caller still mid-thought gets a longer grace period.

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -17,6 +17,14 @@ type TranscriptEvent struct {
 	// MergeWaitMs is how long the turn buffer held this turn open merging
 	// continuations, so latency accounting can separate debounce from work.
 	MergeWaitMs int64
+	// OverAgentSpeech records whether the agent was mid-utterance when this
+	// final landed. Captured at the STT callback rather than read later,
+	// because the turn buffer holds a turn open for up to turnMergeMax and the
+	// agent can finish speaking inside that window — by the time the agent
+	// goroutine sees the turn, "was the caller talking over me?" is no longer
+	// answerable. Turns merged from several finals keep the flag if ANY of
+	// them landed over agent speech.
+	OverAgentSpeech bool
 }
 
 // DataChannel message types sent to the client via the events DataChannel.


### PR DESCRIPTION
This pull request introduces a robust mechanism for managing overlapping agent responses, ensuring that acknowledgements like "okay" spoken over the agent do not start new turns, and that only one response can own the audio path at a time. This resolves issues where the agent could talk over itself or where passive acknowledgements would trigger unnecessary responses. The changes also add comprehensive tests to cover edge cases and concurrency issues.

### Response Ownership and Audio Path Management

* Introduced a generation-based ownership model for agent responses using a new `responseGen` field and related methods (`supersedeResponse`, `registerResponse`, `finishResponse`), ensuring that only the current response can control the speaking state, cancel function, and client state events. This prevents late-arriving or superseded responses from interfering with the live response. [[1]](diffhunk://#diff-907bfb94a8c2367197d5b3de95c34ecd5cdab2944988165c644bd985722a3c56R117-R127) [[2]](diffhunk://#diff-f7a5228cef5de0e6d0f63ca5af285d6403c836d7292e4f6a1ef337dff4d36c03R386-R483) [[3]](diffhunk://#diff-f7a5228cef5de0e6d0f63ca5af285d6403c836d7292e4f6a1ef337dff4d36c03R512-R531) [[4]](diffhunk://#diff-33c0440300fdcbbcc9f4659fa57da836cd576a9def95986e12894f758fefd689R1-R128)
* Updated `respond`, `greet`, and related methods to use the new generation-based response ownership, ensuring proper handoff and cleanup between responses. [[1]](diffhunk://#diff-f7a5228cef5de0e6d0f63ca5af285d6403c836d7292e4f6a1ef337dff4d36c03R39-R103) [[2]](diffhunk://#diff-f7a5228cef5de0e6d0f63ca5af285d6403c836d7292e4f6a1ef337dff4d36c03R512-R531)

### Acknowledgement Suppression and Turn Handling

* Added `isPassiveAcknowledgement` logic to suppress turns that are only passive acknowledgements (e.g., "okay", "mm-hmm") spoken over the agent, preventing unnecessary LLM turns and overlapping audio. [[1]](diffhunk://#diff-f7a5228cef5de0e6d0f63ca5af285d6403c836d7292e4f6a1ef337dff4d36c03R39-R103) [[2]](diffhunk://#diff-0a94efa911d33abe2ff02a0f441ea58f45ba024ff41c86653b36cd9d72a39df2R100-R116) [[3]](diffhunk://#diff-078c3211432d632c8101ca8fe53c8b78f35a2e03a6759de5f63cd74862ea676fR1-R179)
* Implemented `isAcknowledgementOnly` to distinguish between true acknowledgements and short utterances with intent (e.g., "no", "stop").

### Agent Speech Timing and Barge-In Detection

* Introduced `speechEndedAt` and methods `setSpeaking` and `agentSpeechRecent` to accurately track when the agent was last speaking, covering STT endpointing lag and improving detection of whether a user is talking over the agent. [[1]](diffhunk://#diff-907bfb94a8c2367197d5b3de95c34ecd5cdab2944988165c644bd985722a3c56R77-R82) [[2]](diffhunk://#diff-f7a5228cef5de0e6d0f63ca5af285d6403c836d7292e4f6a1ef337dff4d36c03L256-R279) [[3]](diffhunk://#diff-f7a5228cef5de0e6d0f63ca5af285d6403c836d7292e4f6a1ef337dff4d36c03R386-R483) [[4]](diffhunk://#diff-ea8636b9d9e095b51c568a4bde20d34dfdb61d91d71746704aa989fd9f59aff8R86-R89)

### Testing and Reliability

* Added comprehensive tests for acknowledgement handling, response generation ownership, and edge cases involving overlapping responses and state transitions. [[1]](diffhunk://#diff-078c3211432d632c8101ca8fe53c8b78f35a2e03a6759de5f63cd74862ea676fR1-R179) [[2]](diffhunk://#diff-33c0440300fdcbbcc9f4659fa57da836cd576a9def95986e12894f758fefd689R1-R128)

### Refactoring and Code Quality

* Refactored response and speaking state management for clarity and correctness, replacing ad-hoc state handling with clear ownership semantics. [[1]](diffhunk://#diff-f7a5228cef5de0e6d0f63ca5af285d6403c836d7292e4f6a1ef337dff4d36c03R39-R103) [[2]](diffhunk://#diff-f7a5228cef5de0e6d0f63ca5af285d6403c836d7292e4f6a1ef337dff4d36c03R386-R483) [[3]](diffhunk://#diff-f7a5228cef5de0e6d0f63ca5af285d6403c836d7292e4f6a1ef337dff4d36c03R512-R531)

These changes significantly improve the robustness of turn-taking, audio playback, and agent-caller interaction in the pipeline.