### PR TITLE
Add MiniMax TTS provider and let Nova-3 transcribe Mandarin directly

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -114,6 +114,14 @@ api_key = ""            # Required if tts.provider = "speechify"
 voice_id = ""           # Optional; defaults to Geffen (geffen_32). Simba 3.2 uses its curated voice set.
 model = ""              # Optional; defaults to simba-3.2
 
+[minimax]
+api_key = ""            # Required if tts.provider = "minimax"
+voice_id = ""           # Optional; defaults to English_Graceful_Lady. Chinese (Mandarin)_News_Anchor and 40+ languages available
+model = ""              # Optional; defaults to speech-2.6-turbo (low latency). A Token Plan key (sk-cp-) covers only
+                        # speech-2.8-hd — any other model routes to pay-as-you-go and fails with 2056 on a zero balance
+# base_url = ""         # Optional; defaults to https://api.minimax.io/v1. Accounts registered on the mainland-China
+                        # platform use https://api.minimaxi.com/v1 — keys are not interchangeable between the two
+
 # VibeVoice — local STT and TTS via external Python services.
 # Start the servers first:
 #   python external/vibeVoice/vibeVoiceAsr/server.py   (default port 8200)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Cartesia   CartesiaConfig   `toml:"cartesia"`
 	ElevenLabs ElevenLabsConfig `toml:"elevenlabs"`
 	Speechify  SpeechifyConfig  `toml:"speechify"`
+	MiniMax    MiniMaxConfig    `toml:"minimax"`
 	Pgvector   PgvectorConfig   `toml:"pgvector"`
 	Supabase   SupabaseConfig   `toml:"supabase"`
 }
@@ -238,6 +239,15 @@ type SpeechifyConfig struct {
 	APIKey  string `toml:"api_key"`
 	VoiceID string `toml:"voice_id"`
 	Model   string `toml:"model"`
+}
+
+type MiniMaxConfig struct {
+	APIKey  string `toml:"api_key"`
+	VoiceID string `toml:"voice_id"`
+	Model   string `toml:"model"`
+	// BaseURL overrides the API host. Empty uses the global endpoint;
+	// mainland-China accounts need https://api.minimaxi.chat/v1.
+	BaseURL string `toml:"base_url"`
 }
 
 type RAGConfig struct {

--- a/internal/stt/deepgram.go
+++ b/internal/stt/deepgram.go
@@ -228,8 +228,15 @@ func NewDeepgramClient(ctx context.Context, cfg config.DeepgramConfig, onResult 
 }
 
 // nova3Language maps a BCP-47 locale to the language code Nova-3 accepts.
-// English and Spanish have dedicated models; everything else routes to the
-// multilingual model rather than failing.
+// Languages Nova-3 recognises on their own are passed through; anything else
+// routes to the multilingual model rather than failing.
+//
+// Routing a directly-supported language to "multi" is not a graceful
+// degradation, it is a broken transcript: Mandarin audio that "zh" returns
+// verbatim at confidence 1.00 comes back from "multi" as
+// "你好、徐死意gue ю因ceder shi" at 0.25. Only add a case here after checking
+// the language against real audio — an untested code silently produces that
+// same soup.
 func nova3Language(locale string) string {
 	base := strings.ToLower(strings.TrimSpace(locale))
 	if idx := strings.Index(base, "-"); idx > 0 {
@@ -240,6 +247,8 @@ func nova3Language(locale string) string {
 		return "en"
 	case "es":
 		return "es"
+	case "zh":
+		return "zh"
 	default:
 		return "multi"
 	}

--- a/internal/stt/deepgram_test.go
+++ b/internal/stt/deepgram_test.go
@@ -17,7 +17,11 @@ func TestNova3LanguageStripsLocale(t *testing.T) {
 		"en-ZA": "en",
 		"es":    "es",
 		"es-ES": "es",
-		"zh-CN": "multi",
+		// Nova-3 transcribes Mandarin directly; routing it to "multi" returns
+		// garbage rather than a worse-but-usable transcript.
+		"zh":    "zh",
+		"zh-CN": "zh",
+		"zh-TW": "zh",
 		"ja-JP": "multi",
 		"ko-KR": "multi",
 		"hi-IN": "multi",

--- a/internal/tts/client.go
+++ b/internal/tts/client.go
@@ -72,10 +72,15 @@ func newProviderClient(cfg *config.Config) (Client, error) {
 			return nil, ErrMissingAPIKey{Provider: "speechify", Field: "[speechify] api_key"}
 		}
 		return NewSpeechifyClient(cfg.Speechify.APIKey, cfg.Speechify.VoiceID, cfg.Speechify.Model), nil
+	case "minimax":
+		if cfg.MiniMax.APIKey == "" {
+			return nil, ErrMissingAPIKey{Provider: "minimax", Field: "[minimax] api_key"}
+		}
+		return NewMiniMaxClient(cfg.MiniMax.APIKey, cfg.MiniMax.VoiceID, cfg.MiniMax.Model, cfg.MiniMax.BaseURL), nil
 	case "vibevoice":
 		return NewVibeVoiceClient(cfg.VibeVoice.TTSURL, cfg.VibeVoice.Voice), nil
 	default:
-		return nil, fmt.Errorf("unknown tts provider %q (supported: cartesia, deepgram, elevenlabs, speechify, vibevoice)", cfg.TTS.Provider)
+		return nil, fmt.Errorf("unknown tts provider %q (supported: cartesia, deepgram, elevenlabs, minimax, speechify, vibevoice)", cfg.TTS.Provider)
 	}
 }
 

--- a/internal/tts/minimax.go
+++ b/internal/tts/minimax.go
@@ -1,0 +1,308 @@
+package tts
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+const (
+	// defaultMiniMaxBaseURL is the global endpoint. Deployments in mainland
+	// China use https://api.minimaxi.chat/v1 instead, and api-uw.minimax.io
+	// trades region for a lower time-to-first-audio; both are reachable by
+	// setting base_url.
+	defaultMiniMaxBaseURL = "https://api.minimax.io/v1"
+	// speech-2.6-turbo is the low-latency tier — the right default on a live
+	// audio path. The -hd models sound better but add hundreds of ms.
+	defaultMiniMaxModel   = "speech-2.6-turbo"
+	defaultMiniMaxVoiceID = "English_Graceful_Lady"
+
+	// MiniMax emits PCM at whatever rate we ask for, and 16 kHz mono is
+	// exactly what the pipeline runs at — so unlike the 24 kHz-only
+	// providers there is no resampling stage here.
+	minimaxSampleRate = 16000
+)
+
+type minimaxClient struct {
+	apiKey     string
+	voiceID    string
+	model      string
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewMiniMaxClient creates a MiniMax T2A v2 TTS client. Empty voiceID, model
+// and baseURL fall back to the package defaults.
+func NewMiniMaxClient(apiKey, voiceID, model, baseURL string) Client {
+	if voiceID == "" {
+		voiceID = defaultMiniMaxVoiceID
+	}
+	if model == "" {
+		model = defaultMiniMaxModel
+	}
+	if baseURL == "" {
+		baseURL = defaultMiniMaxBaseURL
+	}
+	return &minimaxClient{
+		apiKey:     apiKey,
+		voiceID:    voiceID,
+		model:      model,
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		httpClient: newPooledHTTPClient(),
+	}
+}
+
+type minimaxVoiceSetting struct {
+	VoiceID string  `json:"voice_id"`
+	Speed   float64 `json:"speed,omitempty"`
+	Emotion string  `json:"emotion,omitempty"`
+}
+
+type minimaxAudioSetting struct {
+	SampleRate int    `json:"sample_rate"`
+	Format     string `json:"format"`
+	Channel    int    `json:"channel"`
+}
+
+type minimaxRequest struct {
+	Model        string              `json:"model"`
+	Text         string              `json:"text"`
+	Stream       bool                `json:"stream"`
+	OutputFormat string              `json:"output_format"`
+	VoiceSetting minimaxVoiceSetting `json:"voice_setting"`
+	AudioSetting minimaxAudioSetting `json:"audio_setting"`
+}
+
+// minimaxResponse covers both the one-shot body and a single streamed event —
+// they share a shape, differing only in data.status.
+type minimaxResponse struct {
+	Data struct {
+		// Audio is hex-encoded, not base64: two ASCII characters per byte.
+		Audio string `json:"audio"`
+		// Status is 1 for an incremental chunk and 2 for the final event.
+		Status int `json:"status"`
+	} `json:"data"`
+	BaseResp struct {
+		StatusCode int    `json:"status_code"`
+		StatusMsg  string `json:"status_msg"`
+	} `json:"base_resp"`
+}
+
+// err returns the provider-level error carried in base_resp, if any. MiniMax
+// reports failures with HTTP 200 and a non-zero status_code, so checking the
+// HTTP status alone silently turns an auth or quota failure into empty audio.
+func (r *minimaxResponse) err() error {
+	if r.BaseResp.StatusCode != 0 {
+		return fmt.Errorf("minimax error %d: %s", r.BaseResp.StatusCode, r.BaseResp.StatusMsg)
+	}
+	return nil
+}
+
+// minimaxEmotions maps the pipeline's delivery tags onto MiniMax's emotion
+// enum (happy, sad, angry, fearful, disgusted, surprised, calm, fluent,
+// neutral). The mapping is deliberately conservative: "empathetic" marks
+// apologies and bad news, where MiniMax's "sad" overshoots into sounding
+// upset itself, so it lands on "calm" alongside the calm tag. Tags absent
+// here still take effect through Speed.
+var minimaxEmotions = map[string]string{
+	"warm":       "happy",
+	"excited":    "happy",
+	"calm":       "calm",
+	"empathetic": "calm",
+}
+
+func (c *minimaxClient) buildRequest(ctx context.Context, text string, stream bool, vc VoiceControls) (*http.Request, error) {
+	voice := minimaxVoiceSetting{VoiceID: c.voiceID}
+	if vc.Speed > 0 {
+		// MiniMax accepts 0.5-2.0; the tag presets sit well inside that, but
+		// clamp so a future preset cannot produce a 400 mid-call.
+		voice.Speed = clampFloat(vc.Speed, 0.5, 2.0)
+	}
+	if e, ok := minimaxEmotions[vc.Tone]; ok {
+		voice.Emotion = e
+	}
+
+	body := minimaxRequest{
+		Model:        c.model,
+		Text:         text,
+		Stream:       stream,
+		OutputFormat: "hex",
+		VoiceSetting: voice,
+		AudioSetting: minimaxAudioSetting{
+			SampleRate: minimaxSampleRate,
+			Format:     "pcm",
+			Channel:    1,
+		},
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("minimax marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/t2a_v2", bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("minimax create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+func (c *minimaxClient) Synthesize(ctx context.Context, text string) ([]byte, error) {
+	req, err := c.buildRequest(ctx, text, false, VoiceControls{})
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("minimax request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return nil, fmt.Errorf("minimax error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var parsed minimaxResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("minimax parse response: %w", err)
+	}
+	if err := parsed.err(); err != nil {
+		return nil, err
+	}
+
+	pcm, err := hex.DecodeString(parsed.Data.Audio)
+	if err != nil {
+		return nil, fmt.Errorf("minimax decode audio: %w", err)
+	}
+
+	log.Printf("[tts:minimax] synthesized %d bytes for %d chars of text", len(pcm), len(text))
+	return pcm, nil
+}
+
+func (c *minimaxClient) SynthesizeStream(ctx context.Context, text string) (<-chan StreamChunk, error) {
+	return c.SynthesizeStreamWithControls(ctx, text, VoiceControls{})
+}
+
+// SynthesizeStreamWithControls is SynthesizeStream with per-utterance voice
+// controls applied to voice_setting.
+func (c *minimaxClient) SynthesizeStreamWithControls(ctx context.Context, text string, vc VoiceControls) (<-chan StreamChunk, error) {
+	req, err := c.buildRequest(ctx, text, true, vc)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("minimax request: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		resp.Body.Close()
+		return nil, fmt.Errorf("minimax error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	ch := make(chan StreamChunk, 8)
+	go func() {
+		defer close(ch)
+		defer resp.Body.Close()
+		c.pumpSSE(ctx, resp.Body, ch)
+	}()
+	return ch, nil
+}
+
+// pumpSSE decodes MiniMax's text/event-stream into PCM chunks.
+//
+// Unlike the providers that stream raw PCM straight down the response body,
+// each event here is a JSON envelope whose audio is hex-encoded, so the
+// generic pumpPCMStream cannot be reused.
+func (c *minimaxClient) pumpSSE(ctx context.Context, body io.Reader, ch chan<- StreamChunk) {
+	scanner := bufio.NewScanner(body)
+	// A single event carries a whole synthesized segment as hex (two bytes of
+	// line per byte of audio), which overruns the 64 KB default.
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+
+	emit := func(c StreamChunk) bool {
+		select {
+		case ch <- c:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return
+		}
+
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+
+		var ev minimaxResponse
+		if err := json.Unmarshal([]byte(payload), &ev); err != nil {
+			// A malformed event is not worth killing a live utterance over;
+			// the stream usually recovers on the next one.
+			log.Printf("[tts:minimax] skipping unparsable event: %v", err)
+			continue
+		}
+		if err := ev.err(); err != nil {
+			emit(StreamChunk{Err: err})
+			return
+		}
+
+		// Status 2 is the terminal event. It repeats the whole utterance as
+		// one aggregated blob, so emitting its audio would play everything a
+		// second time on top of the chunks already sent.
+		if ev.Data.Status == 2 {
+			return
+		}
+		if ev.Data.Audio == "" {
+			continue
+		}
+
+		pcm, err := hex.DecodeString(ev.Data.Audio)
+		if err != nil {
+			emit(StreamChunk{Err: fmt.Errorf("minimax decode audio: %w", err)})
+			return
+		}
+		if len(pcm) == 0 {
+			continue
+		}
+		if !emit(StreamChunk{PCM: pcm}) {
+			return
+		}
+	}
+
+	if err := scanner.Err(); err != nil && ctx.Err() == nil {
+		emit(StreamChunk{Err: fmt.Errorf("minimax stream read: %w", err)})
+	}
+}
+
+func clampFloat(v, lo, hi float64) float64 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}


### PR DESCRIPTION
Adds `tts.provider = "minimax"` backed by MiniMax's T2A v2 API, and fixes the Deepgram language mapping that made Mandarin unusable on the way in. Either is useful alone, but it takes both for a Chinese-speaking agent to work end to end — I hit the STT half while testing the TTS half.

## MiniMax TTS

MiniMax returns `format: "pcm", sample_rate: 16000` natively, which is exactly what the pipeline runs at — so there is no resampling stage here and no filter to get wrong. It also has 40+ languages and per-utterance emotion control.

Three behaviours worth calling out, all checked against the live API rather than taken from the docs:

**The terminal event repeats everything.** A streamed response ends with a `status: 2` event carrying the whole utterance as one aggregated blob. Emitting it plays every sentence twice. Measured on one request: seven incremental chunks summing to 164584 bytes, then a final event carrying the same 164584. `pumpSSE` returns on `status == 2` without emitting.

**Failures arrive as HTTP 200.** Errors are reported in `base_resp.status_code` with a 200 status line, so checking the HTTP status alone turns an auth or quota failure into silent empty audio. Both the one-shot and streaming paths check `base_resp`.

**Emotion mapping is deliberately conservative.** `ControllableStreamer` maps delivery tags onto MiniMax's emotion enum. `empathetic` maps to `calm`, not `sad` — the tag marks apologies and bad news, where `sad` makes the agent sound upset itself rather than sympathetic. Tags with no entry still take effect through `speed`.

## Deepgram Mandarin

`nova3Language` collapsed every locale except English and Spanish onto the multilingual model, on the assumption that this degrades gracefully. For Mandarin it does not — it produces a broken transcript. Same audio, same request otherwise:

| `language` | transcript | confidence |
|---|---|---|
| `zh` | `你好这是一个语音测试。` | 1.00 |
| `multi` | `你好、徐死意gue ю因ceder shi` | 0.25 |

Nova-3 transcribes `zh` directly, and on a newer model build than `multi` resolves to (`2026-03-31` vs `2026-01-27`), so it is now passed through. The existing test asserted `"zh-CN": "multi"`, encoding the old behaviour as the spec, so it is updated alongside.

I only added `zh`, because it is the only one I checked against real audio. Nova-3 may well handle other languages directly too, but an untested code silently produces the same soup as above, so the comment now says to verify before adding more.

## Verification

- Both paths exercised against the live MiniMax API: one-shot returned 87308 bytes for 2.728 s of audio (matching the reported `audio_length`), streaming produced the chunk sequence described above.
- Deepgram comparison run through both the prerecorded REST endpoint and the live WebSocket path the server actually uses.
- Full voice call end to end — Mandarin in, Mandarin out, audio confirmed audible — with `stt.provider = "deepgram"`, `tts.provider = "minimax"`.
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.

## Not covered

- Only `zh` was added to `nova3Language`; other locales still route to `multi`.
- The emotion mapping was reasoned from the tag semantics, not A/B'd perceptually.
- Cloned voices (`voice_clone`) are untouched — a cloned `voice_id` should work since it is passed straight through, but I did not test one.
