### PR TITLE
Add MiMo TTS provider

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -114,6 +114,12 @@ api_key = ""            # Required if tts.provider = "speechify"
 voice_id = ""           # Optional; defaults to Geffen (geffen_32). Simba 3.2 uses its curated voice set.
 model = ""              # Optional; defaults to simba-3.2
 
+[mimo]
+api_key = ""            # Required if tts.provider = "mimo"
+voice = ""              # Optional; defaults to mimo_default. Chinese: 茉莉 冰糖 苏打 白桦; English: Mia Chloe Milo Dean
+model = ""              # Optional; defaults to mimo-v2.5-tts. Also mimo-v2.5-tts-voiceclone / -voicedesign (paid)
+# base_url = ""         # Optional; defaults to https://api.xiaomimimo.com/v1
+
 [minimax]
 api_key = ""            # Required if tts.provider = "minimax"
 voice_id = ""           # Optional; defaults to English_Graceful_Lady. Chinese (Mandarin)_News_Anchor and 40+ languages available

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	ElevenLabs ElevenLabsConfig `toml:"elevenlabs"`
 	Speechify  SpeechifyConfig  `toml:"speechify"`
 	MiniMax    MiniMaxConfig    `toml:"minimax"`
+	MiMo       MiMoConfig       `toml:"mimo"`
 	Pgvector   PgvectorConfig   `toml:"pgvector"`
 	Supabase   SupabaseConfig   `toml:"supabase"`
 }
@@ -239,6 +240,16 @@ type SpeechifyConfig struct {
 	APIKey  string `toml:"api_key"`
 	VoiceID string `toml:"voice_id"`
 	Model   string `toml:"model"`
+}
+
+type MiMoConfig struct {
+	APIKey string `toml:"api_key"`
+	// Voice is a built-in voice name, passed through verbatim — the Chinese
+	// set (茉莉, 冰糖, 苏打, 白桦 …) and the English one (Mia, Chloe, Milo,
+	// Dean …) share this field.
+	Voice   string `toml:"voice"`
+	Model   string `toml:"model"`
+	BaseURL string `toml:"base_url"`
 }
 
 type MiniMaxConfig struct {

--- a/internal/tts/client.go
+++ b/internal/tts/client.go
@@ -77,10 +77,15 @@ func newProviderClient(cfg *config.Config) (Client, error) {
 			return nil, ErrMissingAPIKey{Provider: "minimax", Field: "[minimax] api_key"}
 		}
 		return NewMiniMaxClient(cfg.MiniMax.APIKey, cfg.MiniMax.VoiceID, cfg.MiniMax.Model, cfg.MiniMax.BaseURL), nil
+	case "mimo":
+		if cfg.MiMo.APIKey == "" {
+			return nil, ErrMissingAPIKey{Provider: "mimo", Field: "[mimo] api_key"}
+		}
+		return NewMiMoClient(cfg.MiMo.APIKey, cfg.MiMo.Voice, cfg.MiMo.Model, cfg.MiMo.BaseURL), nil
 	case "vibevoice":
 		return NewVibeVoiceClient(cfg.VibeVoice.TTSURL, cfg.VibeVoice.Voice), nil
 	default:
-		return nil, fmt.Errorf("unknown tts provider %q (supported: cartesia, deepgram, elevenlabs, minimax, speechify, vibevoice)", cfg.TTS.Provider)
+		return nil, fmt.Errorf("unknown tts provider %q (supported: cartesia, deepgram, elevenlabs, mimo, minimax, speechify, vibevoice)", cfg.TTS.Provider)
 	}
 }
 

--- a/internal/tts/mimo.go
+++ b/internal/tts/mimo.go
@@ -1,0 +1,270 @@
+package tts
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+const (
+	defaultMiMoBaseURL = "https://api.xiaomimimo.com/v1"
+	defaultMiMoModel   = "mimo-v2.5-tts"
+	// mimo_default is the neutral house voice; the named Chinese voices
+	// (茉莉, 冰糖, 苏打, 白桦 …) and the English ones (Mia, Chloe, Milo, Dean)
+	// are selected by passing their name verbatim as voice_id.
+	defaultMiMoVoice = "mimo_default"
+)
+
+type mimoClient struct {
+	apiKey     string
+	voice      string
+	model      string
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewMiMoClient creates a Xiaomi MiMo TTS client. Empty voice, model and
+// baseURL fall back to the package defaults.
+func NewMiMoClient(apiKey, voice, model, baseURL string) Client {
+	if voice == "" {
+		voice = defaultMiMoVoice
+	}
+	if model == "" {
+		model = defaultMiMoModel
+	}
+	if baseURL == "" {
+		baseURL = defaultMiMoBaseURL
+	}
+	return &mimoClient{
+		apiKey:     apiKey,
+		voice:      voice,
+		model:      model,
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		httpClient: newPooledHTTPClient(),
+	}
+}
+
+type mimoAudioSetting struct {
+	Format string `json:"format"`
+	Voice  string `json:"voice"`
+}
+
+type mimoMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type mimoRequest struct {
+	Model    string           `json:"model"`
+	Messages []mimoMessage    `json:"messages"`
+	Audio    mimoAudioSetting `json:"audio"`
+	Stream   bool             `json:"stream"`
+}
+
+// mimoAudio is the audio payload, base64-encoded, shared by the one-shot
+// message and the streaming delta.
+type mimoAudio struct {
+	Data string `json:"data"`
+}
+
+type mimoResponse struct {
+	Choices []struct {
+		Message struct {
+			Audio mimoAudio `json:"audio"`
+		} `json:"message"`
+		Delta struct {
+			Audio mimoAudio `json:"audio"`
+		} `json:"delta"`
+	} `json:"choices"`
+	Error *struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+		Type    string `json:"type"`
+	} `json:"error"`
+}
+
+func (r *mimoResponse) err() error {
+	if r.Error != nil {
+		return fmt.Errorf("mimo error %s: %s", r.Error.Code, r.Error.Message)
+	}
+	return nil
+}
+
+// buildRequest composes a synthesis call.
+//
+// Two things about this API are worth knowing before reading the body: it is
+// shaped like a chat completion rather than a speech endpoint, and the text to
+// speak goes in an *assistant* message — putting it in a user message asks the
+// model to reply to the text instead of reading it. Authentication is an
+// `api-key` header, not the usual bearer token.
+func (c *mimoClient) buildRequest(ctx context.Context, text string, stream bool) (*http.Request, error) {
+	// "pcm" returns headerless little-endian linear16. Requesting a sample
+	// rate has no effect — the API ignores it and always returns 24 kHz (a
+	// wav request for 16000 comes back stamped 24000), so the rate conversion
+	// happens here rather than server-side.
+	body := mimoRequest{
+		Model:    c.model,
+		Messages: []mimoMessage{{Role: "assistant", Content: text}},
+		Audio:    mimoAudioSetting{Format: "pcm", Voice: c.voice},
+		Stream:   stream,
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("mimo marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("mimo create request: %w", err)
+	}
+	req.Header.Set("api-key", c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+func (c *mimoClient) Synthesize(ctx context.Context, text string) ([]byte, error) {
+	req, err := c.buildRequest(ctx, text, false)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("mimo request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return nil, fmt.Errorf("mimo error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var parsed mimoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("mimo parse response: %w", err)
+	}
+	if err := parsed.err(); err != nil {
+		return nil, err
+	}
+	if len(parsed.Choices) == 0 {
+		return nil, fmt.Errorf("mimo response carried no choices")
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(parsed.Choices[0].Message.Audio.Data)
+	if err != nil {
+		return nil, fmt.Errorf("mimo decode audio: %w", err)
+	}
+
+	pcm := resample24kTo16k(raw)
+	log.Printf("[tts:mimo] synthesized %d bytes for %d chars of text", len(pcm), len(text))
+	return pcm, nil
+}
+
+func (c *mimoClient) SynthesizeStream(ctx context.Context, text string) (<-chan StreamChunk, error) {
+	req, err := c.buildRequest(ctx, text, true)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("mimo request: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		resp.Body.Close()
+		return nil, fmt.Errorf("mimo error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	ch := make(chan StreamChunk, 8)
+	go func() {
+		defer close(ch)
+		defer resp.Body.Close()
+		c.pumpSSE(ctx, resp.Body, ch)
+	}()
+	return ch, nil
+}
+
+// pumpSSE decodes the event stream into 16 kHz PCM chunks.
+//
+// Each event carries a slice of the utterance, so the 24 kHz to 16 kHz
+// conversion runs through a streaming resampler that keeps its filter state
+// across events — resampling each event independently would zero-pad at every
+// boundary and click once per chunk.
+func (c *mimoClient) pumpSSE(ctx context.Context, body io.Reader, ch chan<- StreamChunk) {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+
+	var rs streamResampler24to16
+
+	emit := func(chunk StreamChunk) bool {
+		select {
+		case ch <- chunk:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return
+		}
+
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" {
+			continue
+		}
+		if payload == "[DONE]" {
+			break
+		}
+
+		var ev mimoResponse
+		if err := json.Unmarshal([]byte(payload), &ev); err != nil {
+			log.Printf("[tts:mimo] skipping unparsable event: %v", err)
+			continue
+		}
+		if err := ev.err(); err != nil {
+			emit(StreamChunk{Err: err})
+			return
+		}
+		if len(ev.Choices) == 0 || ev.Choices[0].Delta.Audio.Data == "" {
+			continue
+		}
+
+		raw, err := base64.StdEncoding.DecodeString(ev.Choices[0].Delta.Audio.Data)
+		if err != nil {
+			emit(StreamChunk{Err: fmt.Errorf("mimo decode audio: %w", err)})
+			return
+		}
+		if out := rs.Write(raw); len(out) > 0 {
+			if !emit(StreamChunk{PCM: out}) {
+				return
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil && ctx.Err() == nil {
+		emit(StreamChunk{Err: fmt.Errorf("mimo stream read: %w", err)})
+		return
+	}
+
+	// The tail the resampler was holding back for filter context.
+	if out := rs.Flush(); len(out) > 0 {
+		emit(StreamChunk{PCM: out})
+	}
+}

--- a/internal/tts/mimo_test.go
+++ b/internal/tts/mimo_test.go
@@ -1,0 +1,327 @@
+package tts
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeMiMo stands in for the MiMo endpoint. It records the request it was
+// given and replies with whatever the test scripted, so the adapter can be
+// exercised without network access or an API key.
+type fakeMiMo struct {
+	server *httptest.Server
+
+	// gotBody and gotHeader capture the last request for assertions.
+	gotBody   map[string]any
+	gotHeader http.Header
+	gotPath   string
+
+	// status and reply are what the handler sends back.
+	status int
+	reply  string
+}
+
+func newFakeMiMo(t *testing.T, reply string) *fakeMiMo {
+	t.Helper()
+	f := &fakeMiMo{status: http.StatusOK, reply: reply}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		f.gotBody = map[string]any{}
+		json.Unmarshal(body, &f.gotBody)
+		f.gotHeader = r.Header.Clone()
+		f.gotPath = r.URL.Path
+
+		w.WriteHeader(f.status)
+		io.WriteString(w, f.reply)
+	}))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func (f *fakeMiMo) client(voice string) Client {
+	return NewMiMoClient("test-key", voice, "", f.server.URL)
+}
+
+// pcm24kBytes renders n samples of silence-adjacent PCM so decoded audio has a
+// predictable length without the tests caring about its content.
+func pcm24kBytes(n int) []byte {
+	out := make([]byte, n*2)
+	for i := 0; i < n; i++ {
+		out[2*i] = byte(i)
+		out[2*i+1] = 0
+	}
+	return out
+}
+
+func oneShotReply(pcm []byte) string {
+	return fmt.Sprintf(`{"choices":[{"message":{"audio":{"data":%q}}}]}`,
+		base64.StdEncoding.EncodeToString(pcm))
+}
+
+func sseEvent(pcm []byte) string {
+	return fmt.Sprintf("data: {\"choices\":[{\"delta\":{\"audio\":{\"data\":%q}}}]}\n\n",
+		base64.StdEncoding.EncodeToString(pcm))
+}
+
+func drain(t *testing.T, ch <-chan StreamChunk) ([]byte, error) {
+	t.Helper()
+	var pcm []byte
+	for chunk := range ch {
+		if chunk.Err != nil {
+			return pcm, chunk.Err
+		}
+		pcm = append(pcm, chunk.PCM...)
+	}
+	return pcm, nil
+}
+
+// The text to speak goes in an assistant message. Sending it as a user message
+// asks the model to reply to the text instead of reading it aloud, which comes
+// back as audio of the wrong words rather than as an error.
+func TestMiMoSendsTextAsAssistantMessage(t *testing.T) {
+	f := newFakeMiMo(t, oneShotReply(pcm24kBytes(2400)))
+
+	if _, err := f.client("茉莉").Synthesize(context.Background(), "你好"); err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+
+	msgs, ok := f.gotBody["messages"].([]any)
+	if !ok || len(msgs) != 1 {
+		t.Fatalf("got messages %v, want exactly one", f.gotBody["messages"])
+	}
+	m := msgs[0].(map[string]any)
+	if m["role"] != "assistant" {
+		t.Errorf("role = %v, want assistant", m["role"])
+	}
+	if m["content"] != "你好" {
+		t.Errorf("content = %v, want 你好", m["content"])
+	}
+}
+
+// MiMo authenticates with an api-key header. A bearer token — the shape every
+// other provider here uses — is silently unauthenticated.
+func TestMiMoAuthenticatesWithAPIKeyHeader(t *testing.T) {
+	f := newFakeMiMo(t, oneShotReply(pcm24kBytes(2400)))
+
+	if _, err := f.client("").Synthesize(context.Background(), "hi"); err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+
+	if got := f.gotHeader.Get("api-key"); got != "test-key" {
+		t.Errorf("api-key header = %q, want test-key", got)
+	}
+	if got := f.gotHeader.Get("Authorization"); got != "" {
+		t.Errorf("Authorization header = %q, want it unset", got)
+	}
+	if !strings.HasSuffix(f.gotPath, "/chat/completions") {
+		t.Errorf("path = %q, want it to end in /chat/completions", f.gotPath)
+	}
+}
+
+// Requesting pcm keeps the response headerless. Asking for wav would prepend a
+// RIFF header that the pipeline would play as a burst of noise.
+func TestMiMoRequestsHeaderlessPCM(t *testing.T) {
+	f := newFakeMiMo(t, oneShotReply(pcm24kBytes(2400)))
+
+	if _, err := f.client("茉莉").Synthesize(context.Background(), "hi"); err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+
+	audio, ok := f.gotBody["audio"].(map[string]any)
+	if !ok {
+		t.Fatalf("no audio setting in request: %v", f.gotBody)
+	}
+	if audio["format"] != "pcm" {
+		t.Errorf("format = %v, want pcm", audio["format"])
+	}
+	if audio["voice"] != "茉莉" {
+		t.Errorf("voice = %v, want 茉莉", audio["voice"])
+	}
+}
+
+// The provider returns 24 kHz; the pipeline runs at 16 kHz. Handing its audio
+// straight through would play every utterance 1.5x too slow.
+func TestMiMoResamplesTo16k(t *testing.T) {
+	const in24k = 2400 // 100 ms at 24 kHz
+	f := newFakeMiMo(t, oneShotReply(pcm24kBytes(in24k)))
+
+	pcm, err := f.client("").Synthesize(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+
+	want := in24k * 2 / 3
+	if got := len(pcm) / 2; got != want {
+		t.Errorf("got %d samples, want %d (16 kHz for %d samples at 24 kHz)", got, want, in24k)
+	}
+}
+
+// Streaming has to deliver the same audio as one shot — that is the whole
+// premise of starting playback before synthesis finishes.
+func TestMiMoStreamMatchesOneShot(t *testing.T) {
+	const total = 2400
+	full := pcm24kBytes(total)
+
+	oneShot := newFakeMiMo(t, oneShotReply(full))
+	want, err := oneShot.client("").Synthesize(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+
+	// Same audio, cut into four events plus the terminator.
+	var sse strings.Builder
+	for i := 0; i < 4; i++ {
+		sse.WriteString(sseEvent(full[i*len(full)/4 : (i+1)*len(full)/4]))
+	}
+	sse.WriteString("data: [DONE]\n\n")
+
+	streamed := newFakeMiMo(t, sse.String())
+	ch, err := streamed.client("").SynthesizeStream(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("SynthesizeStream: %v", err)
+	}
+	got, err := drain(t, ch)
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("streamed %d bytes, one-shot produced %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("streamed audio diverges from one-shot at byte %d", i)
+		}
+	}
+}
+
+// MiMo reports quota and auth failures in an error object. Ignoring it would
+// turn "insufficient balance" into an utterance of silence, which reads
+// downstream as the agent simply having nothing to say.
+func TestMiMoSurfacesAPIErrorInStream(t *testing.T) {
+	body := `data: {"error":{"code":"402","message":"Insufficient account balance","type":"insufficient_balance"}}` + "\n\n"
+	f := newFakeMiMo(t, body)
+
+	ch, err := f.client("").SynthesizeStream(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("SynthesizeStream: %v", err)
+	}
+	if _, err := drain(t, ch); err == nil {
+		t.Fatal("stream reported no error, want the 402 surfaced")
+	} else if !strings.Contains(err.Error(), "Insufficient account balance") {
+		t.Errorf("error = %v, want it to carry the provider message", err)
+	}
+}
+
+func TestMiMoSurfacesAPIErrorOneShot(t *testing.T) {
+	f := newFakeMiMo(t, `{"error":{"code":"402","message":"Insufficient account balance"}}`)
+
+	if _, err := f.client("").Synthesize(context.Background(), "hi"); err == nil {
+		t.Fatal("Synthesize reported no error, want the 402 surfaced")
+	}
+}
+
+// A non-200 has to carry the body: the status alone does not say whether the
+// model name was wrong, the key was rejected, or the account is out of credit.
+func TestMiMoNon200IncludesBody(t *testing.T) {
+	f := newFakeMiMo(t, `{"error":{"code":"400","message":"Unsupported model mimo-v2-tts"}}`)
+	f.status = http.StatusBadRequest
+
+	_, err := f.client("").Synthesize(context.Background(), "hi")
+	if err == nil {
+		t.Fatal("Synthesize reported no error, want the 400 surfaced")
+	}
+	if !strings.Contains(err.Error(), "Unsupported model") {
+		t.Errorf("error = %v, want it to include the response body", err)
+	}
+}
+
+// One malformed event must not kill the utterance — the stream recovers on the
+// next one, so the caller hears a gap rather than silence.
+func TestMiMoSkipsMalformedEvent(t *testing.T) {
+	pcm := pcm24kBytes(1200)
+	body := "data: {not json\n\n" + sseEvent(pcm) + "data: [DONE]\n\n"
+	f := newFakeMiMo(t, body)
+
+	ch, err := f.client("").SynthesizeStream(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("SynthesizeStream: %v", err)
+	}
+	got, err := drain(t, ch)
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("got no audio, want the event after the malformed one to survive")
+	}
+}
+
+// Events after [DONE] are not part of the utterance. Reading past it would
+// append whatever the connection carried next to the audio just played.
+func TestMiMoStopsAtDone(t *testing.T) {
+	pcm := pcm24kBytes(1200)
+	body := sseEvent(pcm) + "data: [DONE]\n\n" + sseEvent(pcm24kBytes(9600))
+	f := newFakeMiMo(t, body)
+
+	ch, err := f.client("").SynthesizeStream(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("SynthesizeStream: %v", err)
+	}
+	got, err := drain(t, ch)
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+
+	want := 1200 * 2 / 3
+	if samples := len(got) / 2; samples != want {
+		t.Errorf("got %d samples, want %d — audio after [DONE] should be ignored", samples, want)
+	}
+}
+
+// Cancellation has to stop the stream: on barge-in the pipeline cancels the
+// context and expects the channel to close rather than keep producing audio
+// for a response the caller already interrupted.
+func TestMiMoStreamStopsOnCancel(t *testing.T) {
+	var sse strings.Builder
+	for i := 0; i < 8; i++ {
+		sse.WriteString(sseEvent(pcm24kBytes(2400)))
+	}
+	sse.WriteString("data: [DONE]\n\n")
+	f := newFakeMiMo(t, sse.String())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := f.client("").SynthesizeStream(ctx, "hi")
+	if err != nil {
+		t.Fatalf("SynthesizeStream: %v", err)
+	}
+	cancel()
+
+	// Draining must terminate; without the ctx check it would block or run on.
+	for range ch {
+	}
+}
+
+// An empty voice falls back to the house voice rather than sending "" and
+// having the provider reject the request.
+func TestMiMoDefaultsVoiceAndModel(t *testing.T) {
+	f := newFakeMiMo(t, oneShotReply(pcm24kBytes(2400)))
+
+	if _, err := f.client("").Synthesize(context.Background(), "hi"); err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+
+	audio := f.gotBody["audio"].(map[string]any)
+	if audio["voice"] != defaultMiMoVoice {
+		t.Errorf("voice = %v, want %v", audio["voice"], defaultMiMoVoice)
+	}
+	if f.gotBody["model"] != defaultMiMoModel {
+		t.Errorf("model = %v, want %v", f.gotBody["model"], defaultMiMoModel)
+	}
+}

--- a/internal/tts/resample_stream.go
+++ b/internal/tts/resample_stream.go
@@ -1,0 +1,144 @@
+package tts
+
+import "math"
+
+// streamResampler24to16 is the streaming counterpart to resample24kTo16k.
+//
+// The one-shot version treats its input as a complete utterance and lets the
+// filter window run off both ends into implicit zeros. That is correct for a
+// whole utterance and wrong for a chunk of one: applied per chunk it zero-pads
+// at every boundary, so a response arriving in eighteen pieces gets seventeen
+// discontinuities the caller hears as clicks.
+//
+// This keeps the input tail each output sample still needs, so the filter sees
+// a continuous signal across chunk boundaries. Only the true end of the
+// utterance gets edge treatment, via Flush.
+type streamResampler24to16 struct {
+	// hist holds input samples that later outputs still need. base is the
+	// index of hist[0] in the overall input stream, so absolute sample
+	// positions survive the trimming below.
+	hist []float64
+	base int
+	// m is the next output index to produce, counted from the start of the
+	// stream so the output phase never resets mid-utterance.
+	m int
+	// n counts every input sample written, including those already trimmed
+	// out of hist. Flush needs it to produce exactly the sample count the
+	// one-shot path would, which is derived from the total input length.
+	n int
+	// carry holds the leading byte of a sample split across two chunks.
+	// Chunk boundaries fall wherever the provider put them, so dropping an
+	// odd trailing byte would shift every following sample by one byte and
+	// turn the rest of the utterance into noise.
+	carry    byte
+	hasCarry bool
+}
+
+// Write consumes a chunk of little-endian linear16 PCM at 24 kHz and returns
+// the 16 kHz samples that are fully resolved by the data seen so far. It
+// returns nil when a chunk is too short to complete another output sample.
+func (r *streamResampler24to16) Write(in []byte) []byte {
+	i := 0
+	if r.hasCarry && len(in) > 0 {
+		r.hist = append(r.hist, float64(int16(uint16(r.carry)|uint16(in[0])<<8)))
+		r.n++
+		r.hasCarry = false
+		i = 1
+	}
+	for ; i+1 < len(in); i += 2 {
+		r.hist = append(r.hist, float64(int16(uint16(in[i])|uint16(in[i+1])<<8)))
+		r.n++
+	}
+	if i < len(in) {
+		r.carry, r.hasCarry = in[i], true
+	}
+	return r.emit(false)
+}
+
+// Flush returns the remaining output, treating the stream as ended: the filter
+// window may now run past the last input sample, exactly as the one-shot path
+// allows at the end of an utterance.
+func (r *streamResampler24to16) Flush() []byte {
+	out := r.emit(true)
+	r.hist, r.base, r.m, r.n = nil, 0, 0, 0
+	r.carry, r.hasCarry = 0, false
+	return out
+}
+
+// emit produces every output sample whose filter window is fully covered by
+// the buffered input. With final set, it instead runs to the output length the
+// one-shot path would produce for this much input, letting the last few
+// windows overhang the end exactly as that path allows.
+func (r *streamResampler24to16) emit(final bool) []byte {
+	h := resampleKernel()
+	half := (len(h) - 1) / 2
+	last := r.base + len(r.hist) - 1 // index of the newest buffered sample
+	if last < r.base {
+		return nil
+	}
+
+	// Matches resample24kTo16k's outN for the whole stream, so a chunked
+	// utterance and a whole one yield the same number of samples.
+	outN := (r.n*resampleUp + resampleDown - 1) / resampleDown
+
+	out := make([]byte, 0, 64)
+	for {
+		if final && r.m >= outN {
+			break
+		}
+		center := r.m*resampleDown + half
+
+		hi := center / resampleUp
+		if hi > last {
+			if !final {
+				break // needs input that has not arrived yet
+			}
+			hi = last
+		}
+
+		lo := (center - len(h) + 1) / resampleUp
+		if lo < 0 {
+			lo = 0
+		}
+		if lo < r.base {
+			// Should not happen — trimming below never drops a sample a later
+			// output needs — but clamping keeps a bug from indexing out of range.
+			lo = r.base
+		}
+
+		var acc float64
+		for i := lo; i <= hi; i++ {
+			if k := center - i*resampleUp; k >= 0 && k < len(h) {
+				acc += r.hist[i-r.base] * h[k]
+			}
+		}
+
+		v := math.Round(acc)
+		if v > math.MaxInt16 {
+			v = math.MaxInt16
+		} else if v < math.MinInt16 {
+			v = math.MinInt16
+		}
+		s := int16(v)
+		out = append(out, byte(uint16(s)), byte(uint16(s)>>8))
+
+		r.m++
+	}
+
+	r.trim(h)
+	return out
+}
+
+// trim drops history the next output can no longer reach, bounding memory on
+// a long utterance while keeping every sample the filter still needs.
+func (r *streamResampler24to16) trim(h []float64) {
+	center := r.m*resampleDown + (len(h)-1)/2
+	keepFrom := (center - len(h) + 1) / resampleUp
+	if keepFrom <= r.base {
+		return
+	}
+	if drop := keepFrom - r.base; drop < len(r.hist) {
+		r.hist = append([]float64(nil), r.hist[drop:]...)
+		r.base = keepFrom
+	}
+}

--- a/internal/tts/resample_stream_test.go
+++ b/internal/tts/resample_stream_test.go
@@ -1,0 +1,102 @@
+package tts
+
+import (
+	"math"
+	"testing"
+)
+
+// pcm24k renders n samples of a sine at freq Hz as little-endian linear16.
+func pcm24k(n int, freq float64) []byte {
+	out := make([]byte, 0, n*2)
+	for i := 0; i < n; i++ {
+		v := int16(12000 * math.Sin(2*math.Pi*freq*float64(i)/float64(resampleSourceRate)))
+		out = append(out, byte(uint16(v)), byte(uint16(v)>>8))
+	}
+	return out
+}
+
+func samples(b []byte) []int16 {
+	out := make([]int16, len(b)/2)
+	for i := range out {
+		out[i] = int16(uint16(b[2*i]) | uint16(b[2*i+1])<<8)
+	}
+	return out
+}
+
+// The streaming resampler exists so a chunked utterance sounds like the same
+// utterance resampled whole. If the two diverge, the chunk boundaries are
+// audible — which is the entire failure this type is here to prevent.
+func TestStreamResamplerMatchesOneShot(t *testing.T) {
+	in := pcm24k(4800, 440) // 200 ms
+
+	for _, chunk := range []int{2, 64, 321, 1024, 9600} {
+		var rs streamResampler24to16
+		var got []byte
+		for off := 0; off < len(in); off += chunk {
+			end := off + chunk
+			if end > len(in) {
+				end = len(in)
+			}
+			got = append(got, rs.Write(in[off:end])...)
+		}
+		got = append(got, rs.Flush()...)
+
+		want := resample24kTo16k(in)
+		if len(got) != len(want) {
+			t.Errorf("chunk=%d: got %d bytes, want %d", chunk, len(got), len(want))
+			continue
+		}
+
+		g, w := samples(got), samples(want)
+		for i := range w {
+			// Both paths run the same kernel over the same samples, so the
+			// only expected difference is float rounding at the boundary.
+			if d := int(g[i]) - int(w[i]); d > 1 || d < -1 {
+				t.Errorf("chunk=%d: sample %d = %d, want %d", chunk, i, g[i], w[i])
+				break
+			}
+		}
+	}
+}
+
+// A chunk shorter than one output period must not emit a partial or misaligned
+// sample — it should hold the input until enough has arrived.
+func TestStreamResamplerHoldsShortChunks(t *testing.T) {
+	var rs streamResampler24to16
+	if out := rs.Write(pcm24k(1, 440)); len(out) != 0 {
+		t.Fatalf("one input sample produced %d bytes, want 0", len(out))
+	}
+}
+
+// Every emitted chunk must be int16-aligned; an odd length would desynchronise
+// the sample stream for everything downstream.
+func TestStreamResamplerEmitsAlignedChunks(t *testing.T) {
+	in := pcm24k(2400, 440)
+	var rs streamResampler24to16
+	for off := 0; off < len(in); off += 100 {
+		end := off + 100
+		if end > len(in) {
+			end = len(in)
+		}
+		if out := rs.Write(in[off:end]); len(out)%2 != 0 {
+			t.Fatalf("emitted %d bytes, want an even count", len(out))
+		}
+	}
+	if out := rs.Flush(); len(out)%2 != 0 {
+		t.Fatalf("flush emitted %d bytes, want an even count", len(out))
+	}
+}
+
+// Flush resets the resampler so one client can synthesize many utterances
+// without the previous one's tail leaking into the next.
+func TestStreamResamplerResetsAfterFlush(t *testing.T) {
+	in := pcm24k(2400, 440)
+	var rs streamResampler24to16
+
+	first := append(rs.Write(in), rs.Flush()...)
+	second := append(rs.Write(in), rs.Flush()...)
+
+	if len(first) != len(second) {
+		t.Fatalf("second utterance produced %d bytes, first produced %d", len(second), len(first))
+	}
+}


### PR DESCRIPTION
Adds `tts.provider = "mimo"` backed by Xiaomi's MiMo TTS, which brings a set of Chinese voices (茉莉, 冰糖, 苏打, 白桦 …) alongside English ones. Verified through a full Mandarin call: Deepgram in, MiMo out.

## Three ways this API differs from the providers already here

Each is a silent failure rather than an error if it is got wrong, so each has a test pinning it:

**The text goes in an assistant message.** The endpoint is shaped like a chat completion. Putting the text in a user message asks the model to reply to it instead of reading it aloud — the caller hears fluent audio of the wrong words, and nothing anywhere reports a problem.

**Authentication is an `api-key` header,** not the bearer token every other provider here uses.

**Failures are reported in an `error` object.** An out-of-credit account otherwise renders as an utterance of silence, which reads downstream as the agent simply having nothing to say.

## Resampling had to be reworked

MiMo always returns 24 kHz. The documented `sample_rate` field has no effect — a wav request for 16000 comes back stamped 24000 — so the conversion to the pipeline's 16 kHz happens here.

`resample24kTo16k` could not be reused directly. It treats its input as a whole utterance and lets the filter window run off both ends into implicit zeros, which is right for one buffer and wrong for a chunk of one: applied per event it zero-pads at every boundary, so a response arriving in eighteen pieces gets eighteen discontinuities the caller hears as clicks.

`streamResampler24to16` keeps the input tail each output sample still needs, so the filter sees a continuous signal across chunk boundaries and only the true end of the utterance gets edge treatment. Its tests assert that a chunked utterance and a whole one produce the same samples, across chunk sizes from 9600 bytes down to 2 — including an odd-sized case, which is not hypothetical: dropping a trailing byte shifts every following sample by one and turns the rest of the utterance into noise.

Writing those tests first was worth it. They caught two bugs in the initial implementation: `Flush` stopped as soon as the filter window reached the end rather than running to the output length the one-shot path produces (31 samples short), and odd-length chunks lost their trailing byte.

## Tests

`mimo_test.go` runs against an `httptest` stand-in, so it needs no key or network — the same approach as `grok_conn_test.go`. Twelve cases cover request shape (assistant role, `api-key` header, headerless pcm, voice/model defaults), streamed output matching one-shot byte for byte, `[DONE]` terminating the stream, provider errors and non-200s surfacing with their body, a malformed event not killing the utterance, and cancellation closing the channel.

I checked they earn their place by breaking the adapter five ways — user role, no resampling, bearer auth, ignoring `[DONE]`, ignoring the error object — and confirming each one turns a test red.

`go build ./...`, `go vet ./...` and `go test ./...` all pass.

## Notes

- The free tier currently covers `mimo-v2.5-tts`; the voiceclone and voicedesign models are paid and untested here.
- MiMo also exposes `mimo-v2.5-asr`, but it is a request/response call rather than a stream, so it does not fit the `stt.Client` interface without buffering and segmenting audio locally. Not attempted.
