### PR TITLE
fix(config): warn about unknown keys

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,10 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 )
@@ -294,8 +297,17 @@ func Load(path string) (*Config, error) {
 
 	cfg := &Config{}
 	if _, err := os.Stat(path); err == nil {
-		if _, err := toml.DecodeFile(path, cfg); err != nil {
+		metadata, err := toml.DecodeFile(path, cfg)
+		if err != nil {
 			return nil, fmt.Errorf("failed to parse %s: %w", path, err)
+		}
+		if undecoded := metadata.Undecoded(); len(undecoded) > 0 {
+			keys := make([]string, len(undecoded))
+			for i, key := range undecoded {
+				keys[i] = key.String()
+			}
+			sort.Strings(keys)
+			log.Printf("Warning: unknown config key(s): %s — check for a typo", strings.Join(keys, ", "))
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"bytes"
+	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -14,6 +17,60 @@ func writeConfig(t *testing.T, body string) string {
 		t.Fatalf("write config: %v", err)
 	}
 	return path
+}
+
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var output bytes.Buffer
+	originalOutput := log.Writer()
+	originalFlags := log.Flags()
+	originalPrefix := log.Prefix()
+	log.SetOutput(&output)
+	log.SetFlags(0)
+	log.SetPrefix("")
+	t.Cleanup(func() {
+		log.SetOutput(originalOutput)
+		log.SetFlags(originalFlags)
+		log.SetPrefix(originalPrefix)
+	})
+	return &output
+}
+
+func TestLoadWarnsAboutUnknownKeys(t *testing.T) {
+	logs := captureLogs(t)
+	path := writeConfig(t, `
+[pipeline]
+unknown_option = true
+
+[cartesia]
+api_ke = "test-key"
+`)
+
+	if _, err := Load(path); err != nil {
+		t.Fatalf("config with unknown keys rejected: %v", err)
+	}
+	const want = "Warning: unknown config key(s): cartesia.api_ke, pipeline.unknown_option — check for a typo"
+	if got := strings.TrimSpace(logs.String()); got != want {
+		t.Fatalf("warning = %q, want %q", got, want)
+	}
+}
+
+func TestLoadDoesNotWarnAboutKnownKeys(t *testing.T) {
+	logs := captureLogs(t)
+	path := writeConfig(t, `
+[pipeline]
+barge_in = true
+
+[cartesia]
+api_key = "test-key"
+`)
+
+	if _, err := Load(path); err != nil {
+		t.Fatalf("valid config rejected: %v", err)
+	}
+	if got := logs.String(); got != "" {
+		t.Fatalf("valid config logged an unexpected warning: %q", got)
+	}
 }
 
 // Defaults must be applied before validation runs, or a config that simply


### PR DESCRIPTION
## What breaks today

A misspelled or misplaced TOML key is silently ignored, so the server can start with a default the operator did not intend.

## What this changes

- retain `toml.MetaData` after decoding and warn about every undecoded key
- sort and print full dotted paths without logging config values or failing startup
- add regressions for multiple unknown keys and for a valid config that must stay silent

## Validation

- `gofmt -l .` (no output)
- `go build ./...`
- `go vet ./...`
- `go test -race ./...`

Closes #24

I used Codex as a coding assistant after reading `AGENTS.md`, `CONTRIBUTING.md`, `README.md`, and `config.toml.example`, then reviewed and tested the resulting patch.