### PR TITLE
test(config): guard example field coverage

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,13 +1,87 @@
 package config
 
 import (
+	"bufio"
 	"bytes"
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
+	"regexp"
+	"sort"
 	"strings"
 	"testing"
 )
+
+var (
+	exampleSectionPattern = regexp.MustCompile(`^\s*#?\s*\[([A-Za-z0-9_.-]+)\]\s*(?:#.*)?$`)
+	exampleKeyPattern     = regexp.MustCompile(`^\s*#?\s*([A-Za-z0-9_]+)\s*=`)
+)
+
+func configPaths(typ reflect.Type, prefix string) []string {
+	var paths []string
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		name := field.Tag.Get("toml")
+		if name == "" || name == "-" {
+			continue
+		}
+		path := name
+		if prefix != "" {
+			path = prefix + "." + name
+		}
+		if field.Type.Kind() == reflect.Struct {
+			paths = append(paths, configPaths(field.Type, path)...)
+			continue
+		}
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+func documentedConfigPaths(t *testing.T, path string) map[string]struct{} {
+	t.Helper()
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open config example: %v", err)
+	}
+	defer file.Close()
+
+	documented := make(map[string]struct{})
+	section := ""
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if match := exampleSectionPattern.FindStringSubmatch(line); match != nil {
+			section = match[1]
+			continue
+		}
+		if section == "" {
+			continue
+		}
+		if match := exampleKeyPattern.FindStringSubmatch(line); match != nil {
+			documented[section+"."+match[1]] = struct{}{}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("read config example: %v", err)
+	}
+	return documented
+}
+
+func TestConfigExampleDocumentsEveryField(t *testing.T) {
+	documented := documentedConfigPaths(t, filepath.Join("..", "..", "config.toml.example"))
+	var missing []string
+	for _, path := range configPaths(reflect.TypeOf(Config{}), "") {
+		if _, ok := documented[path]; !ok {
+			missing = append(missing, path)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Fatalf("config.toml.example does not document: %s", strings.Join(missing, ", "))
+	}
+}
 
 // writeConfig writes a TOML file and returns its path.
 func writeConfig(t *testing.T, body string) string {


### PR DESCRIPTION
Closes #29

## What changed

- Reflect over `Config` and collect every full dotted TOML path.
- Parse active and commented sections/keys from `config.toml.example`.
- Fail with a sorted list of fields that are not documented by the example.

## Scope correction

Current `main` already contains the commented `[pgvector]` block and its fields from `9c533b4c`, so this PR deliberately does not duplicate Part 1. The remaining drift guard was confirmed with the maintainer in the issue thread.

## Why

`config.toml.example` is the copyable configuration reference. This test makes a newly added config field fail loudly until the example documents it, while preserving the project's intentionally commented optional settings.

## Validation

```text
go test ./internal/config
PASS

go vet ./internal/config
PASS

git diff --check
PASS
```

The branch was rebased onto current `upstream/main`. The only conflict was the import block in `internal/config/config_test.go`; the resolution preserves both upstream's new unknown-key tests and this PR's example-drift test, and the focused checks above were rerun after resolution.
