### PR TITLE
added roadmaps and the missing translations for chinese docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ One Go binary. Bring your own agent.
 [![Discord](https://img.shields.io/badge/join%20us%20on-discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/xKGFaGWawT)
 [![Follow @jasonshen_](https://img.shields.io/badge/follow-%40jasonshen__-000000?logo=x&logoColor=white)](https://x.com/jasonshen_)
 
-[**Quick start**](#quick-start) · [**Docs**](./docs/) · [**Demo**](#demo) · [**SDKs**](#sdks-and-examples) · [**Discord**](https://discord.gg/xKGFaGWawT) · [简体中文](./README.zh-CN.md)
+[**Quick start**](#quick-start) · [**Docs**](./docs/) · [**Demo**](#demo) · [**SDKs**](#sdks-and-examples) · [**Roadmap**](./docs/roadmap.md) · [**Discord**](https://discord.gg/xKGFaGWawT) · [简体中文](./README.zh-CN.md)
 
 </div>
 
@@ -71,7 +71,19 @@ Docker, TURN ports, and production notes: [Quick start guide](./docs/quickstart.
 | **Sessions & events** | Server-generated session IDs, multi-peer sessions, DataChannel events for transcript, response, state, and per-turn latency |
 | **Reach** | Browser, mobile, backend, CLI, [SIP telephony](https://github.com/streamcoreai/sip-server), and [ESP32](https://github.com/streamcoreai/esp32) endpoints |
 
-Full capability list and what is *not* built yet: [Capabilities](./docs/capabilities.md) · [Roadmap](./docs/roadmap.md).
+Full capability list: [Capabilities](./docs/capabilities.md).
+
+## Not built yet
+
+Listed so the table above stays honest — these are real gaps today, not soon-shipping promises:
+
+- [ ] **Horizontal scaling** — session state is in-memory and single-process
+- [ ] **Session reconnection** — no ICE restart; a dropped connection means a new session
+- [ ] **Metrics export** — `/health` and timing events exist, no Prometheus/OpenTelemetry
+- [ ] **HTTP agent endpoint** — bring-your-own-agent needs a small Go file today, not config
+- [ ] **Persistent memory** across sessions
+
+Full TODO list, including ecosystem items: [Roadmap / TODO](./docs/roadmap.md). Want one of these? Say so in [Discord](https://discord.gg/xKGFaGWawT) — demand reorders the list.
 
 ## Bring your own agent
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,7 +17,7 @@
 [![Discord](https://img.shields.io/badge/join%20us%20on-discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/xKGFaGWawT)
 [![Follow @jasonshen_](https://img.shields.io/badge/follow-%40jasonshen__-000000?logo=x&logoColor=white)](https://x.com/jasonshen_)
 
-[**快速开始**](#快速开始) · [**文档**](./docs/) · [**演示**](#演示) · [**SDK**](#sdk-与示例) · [**Discord**](https://discord.gg/xKGFaGWawT) · [English](./README.md)
+[**快速开始**](#快速开始) · [**文档**](./docs/README.zh-CN.md) · [**演示**](#演示) · [**SDK**](#sdk-与示例) · [**路线图**](./docs/roadmap.zh-CN.md) · [**Discord**](https://discord.gg/xKGFaGWawT) · [English](./README.md)
 
 </div>
 
@@ -39,7 +39,7 @@ StreamCore 正是处理这一切的那一层。它掌管用户与你的 AI 之�
 
 ## 快速开始
 
-**两个终端、五分钟，你就能跟它说上话。** 需要 Go 1.25+（或 Docker），以及 STT、LLM、TTS 服务商的 API key。没有 key？可以用 Ollama + VibeVoice [完全本地运行](./docs/quickstart.md#fully-local-no-api-keys)。
+**两个终端、五分钟，你就能跟它说上话。** 需要 Go 1.25+（或 Docker），以及 STT、LLM、TTS 服务商的 API key。没有 key？可以用 Ollama + VibeVoice [完全本地运行](./docs/quickstart.zh-CN.md#完全本地运行无需-api-key)。
 
 ```bash
 cp config.toml.example config.toml   # 填入你的服务商凭据
@@ -57,7 +57,7 @@ cd examples/typescript && npm install && npm run dev
 
 打开 [http://localhost:3000](http://localhost:3000) 开始说话。
 
-Docker、TURN 端口与生产部署注意事项见[快速开始指南](./docs/quickstart.md)（英文）。
+Docker、TURN 端口与生产部署注意事项见[快速开始指南](./docs/quickstart.zh-CN.md)。
 
 ## 你会得到什么
 
@@ -71,7 +71,19 @@ Docker、TURN 端口与生产部署注意事项见[快速开始指南](./docs/qu
 | **会话与事件** | 服务端生成会话 ID、多 peer 会话，DataChannel 推送转写、回复、状态与每轮延迟 |
 | **接入范围** | 浏览器、移动端、后端服务、CLI、[SIP 电话](https://github.com/streamcoreai/sip-server) 与 [ESP32](https://github.com/streamcoreai/esp32) 设备 |
 
-完整能力清单与尚未实现的部分：[Capabilities](./docs/capabilities.md) · [Roadmap](./docs/roadmap.md)。
+完整能力清单：[能力清单](./docs/capabilities.zh-CN.md)。
+
+## 尚未实现
+
+列在这里是为了让上面的表格保持诚实 —— 这些是当前真实存在的空缺，而不是即将交付的承诺：
+
+- [ ] **水平扩展** —— 会话状态在内存中，单进程
+- [ ] **会话重连** —— 没有 ICE restart，连接断开即意味着新会话
+- [ ] **指标导出** —— 有 `/health` 与时延事件，但没有 Prometheus/OpenTelemetry
+- [ ] **HTTP 智能体端点** —— 目前接入自有智能体需要写一个很小的 Go 文件，而不是改配置
+- [ ] **跨会话的持久记忆**
+
+完整 TODO 清单（含生态相关项）：[路线图 / TODO](./docs/roadmap.zh-CN.md)。想要其中某一项？在 [Discord](https://discord.gg/xKGFaGWawT) 说一声 —— 需求会改变优先级。
 
 ## 接入你自己的智能体
 
@@ -82,24 +94,25 @@ StreamCore 位于「提示词 + 工具」类框架的下一层：媒体链路。
 3. **你的代码** —— 实现一个很小的 Go 接口，整条媒体链路无需改动
 4. **内置运行时** —— 或直接使用 StreamCore 可选的智能体运行时（工具、技能、RAG、对话历史）
 
-详情与代码：[Bring your own agent](./docs/bring-your-own-agent.md) · [Agent runtime](./docs/agent-runtime.md)。
+详情与代码：[接入你自己的智能体](./docs/bring-your-own-agent.zh-CN.md) · [智能体运行时](./docs/agent-runtime.zh-CN.md)。
 
-服务商：Deepgram、AssemblyAI、OpenAI、Cartesia、ElevenLabs、MiniMax、Speechify、Ollama、VibeVoice（本地）、xAI Grok Voice（语音到语音），检索支持 pgvector / Supabase。见 [Providers](./docs/providers.md)。
+服务商：Deepgram、AssemblyAI、OpenAI、Cartesia、ElevenLabs、MiniMax、Speechify、Ollama、VibeVoice（本地）、xAI Grok Voice（语音到语音），检索支持 pgvector / Supabase。见[服务商](./docs/providers.zh-CN.md)。
 
 ## 文档
 
-文档目前仅提供英文版。
-
 | 页面 | 内容 |
 |------|--------------|
-| [Quick start](./docs/quickstart.md) | Docker、TURN 端口、接入客户端、接入自有后端、完全本地运行 |
-| [Capabilities](./docs/capabilities.md) | 当前具备的能力、支持的端点、AI 集成 |
-| [Bring your own agent](./docs/bring-your-own-agent.md) | 掌控智能体的四种方式，含 `llm.Client` 接口 |
-| [Agent runtime](./docs/agent-runtime.md) | 插件、技能、RAG、文档入库 |
-| [Providers](./docs/providers.md) | Grok 语音到语音、MiniMax、本地 VibeVoice 及各服务商注意事项 |
-| [Configuration](./docs/configuration.md) | 完整带注释的 `config.toml` 参考 |
-| [Protocol](./docs/protocol.md) | WHIP 信令、DataChannel 事件、鉴权 |
-| [Architecture](./docs/architecture.md) | 媒体流转、为什么用 Go、包结构 |
+| [快速开始](./docs/quickstart.zh-CN.md) | Docker、TURN 端口、接入客户端、接入自有后端、完全本地运行 |
+| [能力清单](./docs/capabilities.zh-CN.md) | 当前具备的能力、支持的端点、AI 集成 |
+| [接入你自己的智能体](./docs/bring-your-own-agent.zh-CN.md) | 掌控智能体的四种方式，含 `llm.Client` 接口 |
+| [智能体运行时](./docs/agent-runtime.zh-CN.md) | 插件、技能、RAG、文档入库 |
+| [服务商](./docs/providers.zh-CN.md) | Grok 语音到语音、MiniMax、本地 VibeVoice 及各服务商注意事项 |
+| [配置](./docs/configuration.zh-CN.md) | 完整带注释的 `config.toml` 参考 |
+| [协议](./docs/protocol.zh-CN.md) | WHIP 信令、DataChannel 事件、鉴权 |
+| [架构](./docs/architecture.zh-CN.md) | 媒体流转、为什么用 Go、包结构 |
+| [路线图 / TODO](./docs/roadmap.zh-CN.md) | **尚未实现**部分的清单 |
+
+英文版文档见 [docs/](./docs/)。
 
 ## SDK 与示例
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
+**English** | [简体中文](./README.zh-CN.md)
+
 # StreamCore documentation
 
 | Page | What's in it |
@@ -10,6 +12,6 @@
 | [Configuration](./configuration.md) | Full annotated `config.toml` reference |
 | [Protocol](./protocol.md) | WHIP signaling, DataChannel events, auth |
 | [Architecture](./architecture.md) | Media flow, why Go, package layout |
-| [Roadmap](./roadmap.md) | What is deliberately not built yet |
+| [Roadmap / TODO](./roadmap.md) | Checklist of what is **not** built yet, grouped by area |
 
 Deploying on AWS EC2: [`infrastructure/aws/ec2`](../infrastructure/aws/ec2/). Contributing: [CONTRIBUTING.md](../CONTRIBUTING.md). Security: [SECURITY.md](../SECURITY.md).

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,0 +1,17 @@
+[English](./README.md) | **简体中文**
+
+# StreamCore 文档
+
+| 页面 | 内容 |
+|------|--------------|
+| [快速开始](./quickstart.zh-CN.md) | 前置条件、Docker 与 TURN 端口、接入客户端、把自有后端接进对话、完全本地运行 |
+| [能力清单](./capabilities.zh-CN.md) | 当前具备的能力、支持的端点、AI 集成 |
+| [接入你自己的智能体](./bring-your-own-agent.zh-CN.md) | 把智能体留在自有技术栈中的四种方式，含 `llm.Client` 接口 |
+| [智能体运行时](./agent-runtime.zh-CN.md) | 可选的内置智能体：插件、技能、RAG、文档入库 |
+| [服务商](./providers.zh-CN.md) | STT / LLM / TTS 选项、Grok 语音到语音、MiniMax、本地 VibeVoice |
+| [配置](./configuration.zh-CN.md) | 完整带注释的 `config.toml` 参考 |
+| [协议](./protocol.zh-CN.md) | WHIP 信令、DataChannel 事件、鉴权 |
+| [架构](./architecture.zh-CN.md) | 媒体流转、为什么用 Go、包结构 |
+| [路线图 / TODO](./roadmap.zh-CN.md) | **尚未实现**部分的清单，按领域分组 |
+
+部署到 AWS EC2：[`infrastructure/aws/ec2`](../infrastructure/aws/ec2/)。参与贡献：[CONTRIBUTING.md](../CONTRIBUTING.md)。安全：[SECURITY.md](../SECURITY.md)。

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -1,3 +1,5 @@
+**English** | [简体中文](./agent-runtime.zh-CN.md)
+
 # Optional agent runtime
 
 Everything here is opt-in. Skip this page entirely if your agent lives in your own stack — see [Bring your own agent](./bring-your-own-agent.md).

--- a/docs/agent-runtime.zh-CN.md
+++ b/docs/agent-runtime.zh-CN.md
@@ -1,0 +1,168 @@
+[English](./agent-runtime.md) | **简体中文**
+
+# 可选的智能体运行时
+
+本页内容全部是可选的。如果你的智能体住在自己的技术栈里，可以整页跳过 —— 见[接入你自己的智能体](./bring-your-own-agent.zh-CN.md)。
+
+当你确实希望由 StreamCore 来跑这段对话时，它会提供带对话历史的 LLM 编排、工具、行为技能与内联检索。
+
+一旦启用内置运行时，有两项行为会自动生效：
+
+- **滚动摘要。** 长通话会超出模型的历史窗口。较早的轮次会在后台被摘要并作为上下文注入，因此第一分钟提到的事实在第十分钟依然有效。
+- **低置信度处理。** 当语音识别报告置信度较低时，会提示智能体请对方重复一遍，而不是靠猜；若连续多轮如此则会升级处理。
+
+## 插件与技能
+
+插件赋予智能体**能力**，技能塑造它的**行为**。
+
+- 插件调用 API、数据库、日历、CRM、工作流与内部工具
+- 技能定义语气、性格、护栏、品牌调性与流程引导
+
+插件以 Python、TypeScript 或 JavaScript 进程的形式运行，通过 JSON-RPC 通信。技能是注入系统提示词的 Markdown 文件。示例插件与技能在 [`plugins/`](../plugins/) 下。若想完全避免 IPC，可以用 `pluginMgr.RegisterNative(...)` 注册原生 Go 工具。
+
+### 插件清单字段参考
+
+| 字段 | 类型 | 必填 | 说明 |
+|-------|------|----------|-------------|
+| `name` | string | 是 | LLM 调用时使用的唯一工具名（如 `weather.get`） |
+| `description` | string | 是 | 工具的功能说明 —— 会展示给 LLM |
+| `version` | int | 是 | 清单版本 |
+| `language` | string | 是 | `python`、`typescript` 或 `javascript` |
+| `entrypoint` | string | 是 | 要运行的文件（如 `main.py`、`index.ts`） |
+| `parameters` | object | 是 | 描述工具参数的 JSON Schema |
+| `confirmation_required` | bool | 否 | 执行前让智能体先向用户确认（默认 `false`） |
+| `thinking_sound` | bool | 否 | 工具运行期间播放轻柔的循环提示音，有 500 毫秒宽限期（默认 `false`） |
+
+### 内置插件
+
+| 插件 | 语言 | 说明 |
+|--------|----------|-------------|
+| `math.calculate` | TypeScript | 计算数学表达式 |
+| `weather.get` | TypeScript | 查询某地当前天气 |
+| `time.get` | Python | 查询任意时区的当前日期/时间 |
+| `vision.analyze` | TypeScript | 分析来自设备摄像头的图像 |
+| `gmail` | TypeScript | 通过 Gmail 读写邮件（OAuth2）—— 见 [Gmail 插件 README](../plugins/plugins/gmail/README.md) |
+
+### 内置技能
+
+| 技能 | 说明 |
+|-------|-------------|
+| `tool-savvy` | 引导智能体使用工具而不是猜测 |
+| `friendly-conversationalist` | 温暖、自然的对话性格 |
+| `polite-assistant` | 简洁而礼貌的语音交互风格 |
+| `concise-responder` | 让回复保持简短，适合口头表达 |
+| `error-recovery` | 在语音对话中优雅地处理错误 |
+| `vision-assistant` | 启用基于摄像头的图像分析 |
+| `gmail-assistant` | 逐封处理邮件，带回复与确认流程 |
+
+插件 SDK：`@streamcore/plugin`（TypeScript）、`streamcore-plugin`（Python）。
+
+## 检索（RAG）
+
+RAG 内联运行在媒体流水线中：服务端对用户这一轮做 embedding，从你的向量库检索 top-k 片段，并在调用 LLM 之前注入 —— 只有一次 LLM 调用，没有工具调用的往返。
+
+有两点让检索不落在关键路径上。不含实义词的轮次（「好的」「谢谢」）会被跳过，因为没有可供向量检索锚定的内容。另外，当 `pipeline.rag_prefetch = true` 时，检索会在轮次合并窗口内推测性地开始，于是 embedding 与向量检索的往返与流水线本来就要等待的时间重叠，而不是叠加在它之上。
+
+| 服务商 | 后端 | 配置段 |
+|----------|---------|----------------|
+| `pgvector` | 启用 pgvector 扩展的 PostgreSQL | `[pgvector]` |
+| `supabase` | Supabase（通过 HTTP 调用 Postgres RPC） | `[supabase]` |
+
+两者都使用 OpenAI embedding（默认 `text-embedding-3-small`），因此必须设置 `[openai].api_key`。省略 `[rag]` 段即可完全关闭检索。
+
+### pgvector 配置
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE documents (
+    id SERIAL PRIMARY KEY,
+    content TEXT NOT NULL,
+    embedding vector(1536),
+    source TEXT
+);
+```
+
+```toml
+[rag]
+provider = "pgvector"
+
+[pgvector]
+connection_string = "postgres://user:pass@localhost:5432/mydb"
+```
+
+### Supabase 配置
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE documents (
+    id SERIAL PRIMARY KEY,
+    content TEXT NOT NULL,
+    embedding vector(1536),
+    source TEXT,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE OR REPLACE FUNCTION match_documents(
+    query_embedding vector(1536),
+    match_count int DEFAULT 3
+)
+RETURNS TABLE (content text, similarity float)
+LANGUAGE plpgsql AS $$
+BEGIN
+    RETURN QUERY
+    SELECT d.content, 1 - (d.embedding <=> query_embedding) AS similarity
+    FROM documents d
+    ORDER BY d.embedding <=> query_embedding
+    LIMIT match_count;
+END;
+$$;
+
+ALTER TABLE documents ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow read access to documents"
+ON documents FOR SELECT TO authenticated, anon USING (true);
+
+CREATE POLICY "Allow insert access to documents"
+ON documents FOR INSERT TO authenticated, anon WITH CHECK (true);
+
+CREATE POLICY "Allow update access to documents"
+ON documents FOR UPDATE TO authenticated, anon USING (true);
+```
+
+```toml
+[rag]
+provider = "supabase"
+
+[supabase]
+url = "https://xxx.supabase.co"
+api_key = "your-service-role-key"
+function = "match_documents"
+table = "documents"
+```
+
+### 文档入库
+
+服务端只负责查询时的检索。向量库的内容由 `streamcore-cli` 填充 —— 那是一个独立的 Go 二进制，会读取本服务的 `config.toml`。
+
+> **`streamcore-cli` 尚未公开。** `github.com/streamcoreai/streamcore-cli` 目前返回 404，因此下面的 clone 会失败。这里记录的参数与行为在它发布时是准确的 —— 在那之前，如果你需要文档入库，请在 [Discord](https://discord.gg/xKGFaGWawT) 里问一声。
+
+```bash
+git clone https://github.com/streamcoreai/streamcore-cli
+cd streamcore-cli && go build -o streamcore-cli .
+
+# 支持 .txt、.md、.csv、.pdf、.docx、.xlsx
+streamcore-cli ingest docs/faq.pdf product-catalog.xlsx notes.md
+streamcore-cli ingest --provider supabase --config ../server/config.toml data.csv
+streamcore-cli ingest --chunk-size 256 --chunk-overlap 32 manual.docx
+```
+
+CLI 会从服务端的 `config.toml` 读取服务商凭据，因此没有任何东西需要配置两遍。
+
+| 参数 | 默认值 | 说明 |
+|------|---------|-------------|
+| `--config` | 自动探测 | 服务端 `config.toml` 的路径 |
+| `--provider` | 取自配置 | 覆盖 RAG 服务商（`pgvector`、`supabase`） |
+| `--chunk-size` | 512 | 目标分块大小（词数） |
+| `--chunk-overlap` | 64 | 分块之间的重叠（词数） |

--- a/docs/architecture.zh-CN.md
+++ b/docs/architecture.zh-CN.md
@@ -1,6 +1,6 @@
-**English** | [简体中文](./architecture.zh-CN.md)
+[English](./architecture.md) | **简体中文**
 
-# Architecture and implementation
+# 架构与实现
 
 ```text
 ┌─────────────────────┐                    ┌─────────────────────────────────────┐
@@ -23,23 +23,23 @@
 └─────────────────────┘                    └─────────────────────────────────────┘
 ```
 
-**Media flow.** Microphone audio arrives over WebRTC, is decoded to PCM in 20 ms frames, run through VAD, and streamed to STT. Final transcripts go to the model layer; streamed output is split on sentence boundaries and handed to TTS as it arrives, so synthesis starts before generation finishes. Synthesized PCM is encoded back to Opus and written to the RTP stream. Transcript, response, and state text travel over the DataChannel in parallel.
+**媒体流转。** 麦克风音频通过 WebRTC 到达，按 20 毫秒一帧解码为 PCM，经过 VAD，再流式送往 STT。final 转写交给模型层；模型的流式输出按句边界切分，边到达边交给 TTS，因此合成在生成结束之前就已开始。合成出的 PCM 重新编码为 Opus 并写回 RTP 流。转写、回复与状态文本则并行地走 DataChannel。
 
-**Why Go.** The latency-sensitive path is implemented in Go with [Pion](https://github.com/pion/webrtc): goroutines per stage, bounded channels between them, and no GC-heavy buffering in the hot loop. RTP read, Opus decode, VAD, STT streaming, orchestration, TTS, Opus encode, and RTP write are each their own stage. This is an implementation choice in service of predictable turn latency — the surface you build against is the SDKs and the event protocol, in whatever language you prefer.
+**为什么用 Go。** 时延敏感的链路用 Go 加 [Pion](https://github.com/pion/webrtc) 实现：每个阶段一个 goroutine，阶段之间用有界 channel 连接，热路径上没有 GC 压力大的缓冲。RTP 读取、Opus 解码、VAD、STT 流式、编排、TTS、Opus 编码与 RTP 写出各自独立成一个阶段。这是为了可预测的每轮时延而做的实现选择 —— 你真正面对的接口是 SDK 与事件协议，语言可以任选。
 
-## Package layout
+## 包结构
 
-| Package | Responsibility |
+| 包 | 职责 |
 |---------|----------------|
-| [`internal/signaling`](../internal/signaling/) | WHIP handler, SDP exchange, session URLs |
-| [`internal/peer`](../internal/peer/) | Pion peer connection, tracks, DataChannel |
-| [`internal/session`](../internal/session/) | Session manager, multi-peer lifecycle |
-| [`internal/pipeline`](../internal/pipeline/) | Inbound/outbound audio, agent loop, barge-in, thinking sound |
-| [`internal/audio`](../internal/audio/) | Opus codec, RTP framing |
-| [`internal/vad`](../internal/vad/) | Energy-based voice activity detection |
-| [`internal/stt`](../internal/stt/), [`internal/tts`](../internal/tts/), [`internal/llm`](../internal/llm/) | Provider adapters |
-| [`internal/plugin`](../internal/plugin/) | Plugin runtime, native tools, skills |
-| [`internal/rag`](../internal/rag/) | Retrieval and embeddings |
-| [`internal/turn`](../internal/turn/) | Built-in STUN/TURN server |
+| [`internal/signaling`](../internal/signaling/) | WHIP 处理器、SDP 交换、会话 URL |
+| [`internal/peer`](../internal/peer/) | Pion peer connection、轨道、DataChannel |
+| [`internal/session`](../internal/session/) | 会话管理器、多 peer 生命周期 |
+| [`internal/pipeline`](../internal/pipeline/) | 入向/出向音频、智能体循环、barge-in、思考音 |
+| [`internal/audio`](../internal/audio/) | Opus 编解码、RTP 组包 |
+| [`internal/vad`](../internal/vad/) | 基于能量的语音活动检测 |
+| [`internal/stt`](../internal/stt/)、[`internal/tts`](../internal/tts/)、[`internal/llm`](../internal/llm/) | 服务商适配层 |
+| [`internal/plugin`](../internal/plugin/) | 插件运行时、原生工具、技能 |
+| [`internal/rag`](../internal/rag/) | 检索与 embedding |
+| [`internal/turn`](../internal/turn/) | 内置 STUN/TURN 服务 |
 
-Wire-level details: [Protocol reference](./protocol.md).
+线上协议细节见[协议参考](./protocol.zh-CN.md)。

--- a/docs/bring-your-own-agent.md
+++ b/docs/bring-your-own-agent.md
@@ -1,3 +1,5 @@
+**English** | [简体中文](./bring-your-own-agent.zh-CN.md)
+
 # Bring your own agent
 
 Most agent frameworks start with prompts, tools, and model orchestration. StreamCore starts one layer lower: the realtime media path — transport, codecs, speech streaming, turn-taking, interruption, network traversal, session state, and communication with AI services.

--- a/docs/bring-your-own-agent.zh-CN.md
+++ b/docs/bring-your-own-agent.zh-CN.md
@@ -1,0 +1,53 @@
+[English](./bring-your-own-agent.md) | **简体中文**
+
+# 接入你自己的智能体
+
+大多数智能体框架从提示词、工具与模型编排开始。StreamCore 从更下面一层开始：实时媒体链路 —— 传输、编解码、流式语音、轮次控制、插话打断、网络穿透、会话状态，以及与 AI 服务之间的通信。
+
+你的智能体不必住在 StreamCore 里。有四种受支持的方式让智能体始终归你。
+
+## 1. 把智能体放在一次工具调用之后
+
+插件（Python、TypeScript、JavaScript，走 JSON-RPC）与原生 Go 工具让对话可以调用你已有的后端 —— 你的 API、你的编排、你的数据。StreamCore 负责把结果以语音流式播报出去。
+
+完整示例见[快速开始 → 接入你自己的后端](./quickstart.zh-CN.md#接入你自己的后端)。
+
+## 2. 把模型层指向你自己的基础设施
+
+`llm.provider = "ollama"` 配合自定义的 `base_url`，可以指向任何你运行的、兼容 Ollama 的端点，包括你自己做路由或模型编排的那一层。
+
+```toml
+[llm]
+provider = "ollama"
+
+[ollama]
+base_url = "https://models.internal.example.com"
+model = "your-model"
+```
+
+## 3. 直接实现 LLM 接口
+
+模型层是 [`internal/llm/llm.go`](../internal/llm/llm.go) 中一个很小的 Go 接口：
+
+```go
+type Client interface {
+    Chat(ctx context.Context, userText string, onChunk func(string), onSentence func(string)) (string, error)
+    // OneShot is a single non-streaming call, independent of conversation
+    // state. Used for background work such as the rolling summary.
+    OneShot(ctx context.Context, system, user string) (string, error)
+    SetTools(tools []ToolDefinition)
+    SetToolHandler(handler func(ctx context.Context, call ToolCall) (string, error))
+    AppendSystemPrompt(text string)
+    Reset()
+}
+```
+
+针对你的智能体服务实现它，在 `NewClient` 中注册，整条媒体链路 —— 传输、VAD、barge-in、TTS 分块、事件 —— 都无需改动即可工作。
+
+## 4. 使用 StreamCore 可选的内置智能体运行时
+
+如果你需要，LLM 编排、工具、技能、RAG 与对话历史都是开箱即用的。见[智能体运行时](./agent-runtime.zh-CN.md)。
+
+---
+
+一个无需写 Go 代码的通用 HTTP / 兼容 OpenAI 的智能体端点还在[路线图](./roadmap.zh-CN.md)上；今天的方式 3 只是一个小文件，而不是 fork 整个项目。

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,3 +1,5 @@
+**English** | [简体中文](./capabilities.zh-CN.md)
+
 # Capabilities
 
 What the media runtime does today. Anything not here is in [Roadmap](./roadmap.md), not in the product yet.

--- a/docs/capabilities.zh-CN.md
+++ b/docs/capabilities.zh-CN.md
@@ -1,0 +1,118 @@
+[English](./capabilities.md) | **简体中文**
+
+# 能力清单
+
+媒体运行时**今天**具备的能力。不在本页的内容都在[路线图](./roadmap.zh-CN.md)里，尚未进入产品。
+
+可以用 StreamCore 构建：
+
+- 语音智能体
+- 实时副驾
+- 同声传译
+- AI 主持的音频体验
+- 嵌入式语音设备
+- 电话与通信应用
+- 定制的实时 AI 产品
+
+## StreamCore 解决的问题
+
+做一个智能体 demo 很容易，围绕它搭出可靠的实时媒体基础设施则不然。
+
+当原型要变成产品时，难点都不在提示词上：
+
+| 问题 | StreamCore 今天做了什么 |
+|---------|----------------------------|
+| WebRTC 连接 | 基于 Pion 的 peer、完整 ICE 收集、通过一次 HTTP POST 完成的 WHIP 信令 |
+| NAT 穿透 | 内置 STUN/TURN 服务 —— 无需额外的 coturn 容器 |
+| 音频传输 | 双向 Opus over RTP，编解码由框架处理 |
+| 轮次控制 | 自适应 VAD 跟踪每通电话的噪声基线，并用去抖把说话人句中的停顿合并为同一轮 |
+| 插话打断 | 使用更快 VAD 配置的 barge-in：先压低智能体音量，过滤掉 "嗯嗯"、"好的" 这类回应词，确认打断后取消进行中的 LLM 与 TTS |
+| 流式服务商集成 | 流式 STT、流式 LLM 与分块流式 TTS，合成尚未结束音频就已开始播放 —— 端到端打通 |
+| 会话状态 | 服务端生成的会话 ID、多 peer 会话、生命周期与销毁 |
+| 实时事件 | DataChannel 事件：转写、回复、智能体状态与时延数据 |
+| 客户端集成 | TypeScript、React Native、Python、Go、Rust SDK |
+| 电话 | SIP 网桥组件，在 PCMU ↔ Opus 之间转码并通过 WHIP 接入 |
+| 鉴权 | `/whip` 上可选的 JWT 鉴权，配合短期 token 端点 |
+| 时延可见性 | DataChannel 时延事件，以及日志中每轮的时延分解（端点检测、合并、embedding、向量检索、LLM、TTS） |
+
+## 它的位置
+
+```text
+┌───────────────────────────────────────────────┐
+│              Applications                     │
+│ Voice agents · Copilots · Translation · Rooms │
+└───────────────────────┬───────────────────────┘
+                        │ SDKs and realtime events
+┌───────────────────────▼───────────────────────┐
+│           StreamCore Media Runtime            │
+│                                               │
+│ WebRTC · RTP · Opus · Sessions · Interruption │
+│ VAD · Streaming audio · Network traversal     │
+└───────────────┬───────────────────┬───────────┘
+                │                   │
+       ┌────────▼────────┐  ┌───────▼──────────┐
+       │ AI and speech   │  │ Application and  │
+       │ services        │  │ agent backends   │
+       │ STT · TTS · LLM │  │ Tools · APIs     │
+       └─────────────────┘  └──────────────────┘
+```
+
+StreamCore 可以跑通一条完整的「语音 → 智能体 → 语音」链路，但那只是它的用法之一。
+
+## 实时媒体能力
+
+**传输与连接**
+
+- 基于 WebRTC 的双向 Opus 音频（`sendrecv`）
+- WHIP 信令（[RFC 9725](https://www.rfc-editor.org/rfc/rfc9725.html)）—— 一次 HTTP `POST` 完成 SDP 交换，无需常驻信令连接
+- 双端完整 ICE 收集，不使用 trickle ICE
+- 基于 Pion 的内置 STUN/TURN 服务（UDP **与 TCP** 3478，中转端口 50001–60000）—— 支持 TCP，因此处在封禁 UDP 的防火墙后的用户仍能接通
+- `/whip` 上可选的 JWT 鉴权，`POST /token` 签发有效期 1 小时的 token
+- `/health` 端点，以及带强制退出兜底的优雅关闭
+
+**媒体链路**
+
+- Opus 解码 → PCM → 处理流水线 → PCM → Opus 编码 → RTP
+- 基于能量的 VAD，起止帧数可配置，并自适应每通电话的噪声基线，因此安静线路上的轻声用户与路边嘈杂环境中的用户都能被正确识别
+- 使用更快 VAD 配置的 barge-in：用户抢话时智能体音量随即压低，若判定只是回应词则恢复
+- 轮次去抖，把连续的 final 转写合并，让「我想…嗯…订个位」只被回答一次，而不是两次
+- 按句边界分块，使 TTS 在 LLM 生成结束前就开始；再按 chunk 级流式播放，使一句话尚未合成完就已出声
+- 可选的逐句表达标签 —— 模型可以在句首加上 `[warm]`、`[empathetic]`、`[calm]` 或 `[excited]`，它们会映射到服务商的音色控制参数，并且永远不会被读出来
+- 思考音 —— 在慢速工具运行期间通过 RTP 播放的可选提示音（500 毫秒宽限期）
+
+**会话与事件**
+
+- 服务端生成的会话 ID，内存态会话管理器
+- 单个会话可包含多个 peer，每个 peer 有入向或出向方向
+- DataChannel 上的 `events` 通道，推送 `transcript`、`response`、`state` 与 `timing`
+- 当 `pipeline.debug = true` 时记录每轮时延分解，区分端点检测、轮次合并、embedding、向量检索、LLM 与 TTS
+- 客户端发来的 DataChannel 消息会被路由进流水线（目前用于摄像头图像分片）
+
+**客户端**
+
+- TypeScript（`@streamcore/js-sdk`）、Python（`streamcore`）、Go（`github.com/streamcoreai/go-sdk`）、Rust
+- React Native / Expo（`@streamcore/react-native-sdk`）—— 已完成，尚未发布到 npm
+
+## 支持的端点
+
+| 端点类型 | 状态 | 方式 |
+|---------------|--------|-----|
+| 浏览器 | 可用 | TypeScript SDK over WHIP |
+| 移动端 | 可用 | React Native / Expo SDK（peer 依赖 `react-native-webrtc`） |
+| 后端服务 / worker | 可用 | Go、Python 或 Rust SDK |
+| CLI 与 TUI | 可用 | Go 与 Rust 示例 |
+| 电话（SIP） | 可用 | [`sip-server`](https://github.com/streamcoreai/sip-server) 在 PCMU/RTP ↔ Opus/WHIP 之间转换，支持呼入与呼出 |
+| 嵌入式设备 | 实验性 | [`esp32`](https://github.com/streamcoreai/esp32) 中的 ESP32-S3 固件直接使用 WHIP |
+
+## AI 集成
+
+| AI 集成 | 服务商 |
+|----------------|-----------|
+| 流式 STT | Deepgram、AssemblyAI、OpenAI、VibeVoice（本地） |
+| LLM | OpenAI、Ollama（本地或自托管） |
+| 流式 TTS | Cartesia、Deepgram、ElevenLabs、MiniMax、Speechify、VibeVoice（本地） |
+| 语音到语音 | xAI Grok Voice（用一个模型取代 STT + LLM + TTS） |
+| 检索 | pgvector、Supabase |
+| 自定义工具 | Python / TypeScript / JavaScript 插件，原生 Go 工具 |
+
+凭据与各服务商的注意事项见[服务商](./providers.zh-CN.md)。

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -1,8 +1,8 @@
-**English** | [简体中文](./configuration.zh-CN.md)
+[English](./configuration.md) | **简体中文**
 
-# Configuration reference
+# 配置参考
 
-Start from [`config.toml.example`](../config.toml.example):
+从 [`config.toml.example`](../config.toml.example) 开始（下面代码块中的注释与该文件保持一致，故保留英文）：
 
 ```toml
 [server]
@@ -120,21 +120,21 @@ voice = "en-Emma_woman"
 # table = "documents"
 ```
 
-Notes:
+说明：
 
-- `server.public_ip` plus `server.turn_secret` enables the built-in Pion STUN/TURN server, replacing an external coturn container. TURN listens on UDP and TCP 3478 and relays media on UDP 50001–60000.
-- `plugins.directory` is required for plugins and skills to load; omit it and discovery is skipped.
-- `pipeline.barge_in` lets users interrupt the agent while it is speaking. Agent audio ducks as soon as the caller starts talking over it and recovers if the interruption turns out to be a backchannel.
-- `pipeline.greeting` plays when a session connects. `pipeline.greeting_outgoing` is used for outbound SIP calls when present.
-- `pipeline.debug = true` emits timing events over the DataChannel and logs a per-turn latency breakdown.
-- `pipeline.turn_merge_ms` is how long a final transcript is held so a continuation can merge into the same turn. Raise it if the agent answers callers halfway through a sentence; lower it if replies feel sluggish. The wait extends automatically when the text ends mid-dictation or on a dangling word.
-- `pipeline.user_speech_quiet_ms` is how long the caller must be quiet before the agent starts speaking.
-- `pipeline.rag_prefetch` overlaps retrieval with the turn-merge window. Off by default; it issues a speculative embedding + search that is discarded if the turn text changes.
-- `pipeline.readback_bargein_guard_enabled` keeps weak corrections and backchannels from cutting off a confirmation readback. Only explicit commands (stop, cancel, hang up) interrupt. Off by default.
-- `deepgram.endpointing` and `deepgram.utterance_end_ms` tune when a turn is considered finished upstream; the turn-merge debounce runs on top of them.
-- `deepgram.tts_model` picks the Aura voice; STT (`model`) and TTS (`tts_model`) share the one API key. Voices are named `[family]-[voice]-[language]` — see [Deepgram's voice list](https://developers.deepgram.com/docs/tts-models).
-- `cartesia.max_concurrency` should match your plan's TTS concurrency limit — Cartesia counts active generations, not calls, and returns 429 past the limit.
-- `minimax.base_url` selects the region. Leave it unset for the global endpoint; mainland-China accounts must point it at `https://api.minimaxi.com/v1`, since keys do not work across the two platforms.
-- `minimax.model` must match your plan: a Token Plan key (`sk-cp-`) only covers `speech-2.8-hd`, while any other model bills pay-as-you-go and errors with `2056` on a zero balance.
+- `server.public_ip` 加上 `server.turn_secret` 会启用内置的 Pion STUN/TURN 服务，取代外部 coturn 容器。TURN 监听 UDP 与 TCP 3478，并在 UDP 50001–60000 上中转媒体。
+- `plugins.directory` 是插件与技能加载的必要条件；不设置则跳过发现流程。
+- `pipeline.barge_in` 允许用户在智能体说话时打断。用户一开口抢话，智能体音量立即压低；若判定只是回应词则恢复。
+- `pipeline.greeting` 在会话连接时播放。存在 `pipeline.greeting_outgoing` 时，它用于 SIP 外呼。
+- `pipeline.debug = true` 会通过 DataChannel 发出时延事件，并在日志中记录每轮的时延分解。
+- `pipeline.turn_merge_ms` 是一条 final 转写被暂留多久，以便后续内容合并进同一轮。如果智能体总在用户话说到一半时抢答，就调高；如果回复显得迟钝，就调低。当文本结束在半句话或悬空词上时，等待会自动延长。
+- `pipeline.user_speech_quiet_ms` 是用户需要安静多久，智能体才开始说话。
+- `pipeline.rag_prefetch` 让检索与轮次合并窗口重叠。默认关闭；它会发出一次推测性的 embedding + 检索，若该轮文本发生变化则丢弃。
+- `pipeline.readback_bargein_guard_enabled` 可避免弱纠正与回应词打断智能体的确认复述。只有明确的命令（stop、cancel、hang up）才会打断。默认关闭。
+- `deepgram.endpointing` 与 `deepgram.utterance_end_ms` 调节上游认定一轮结束的时机；轮次合并去抖运行在它们之上。
+- `deepgram.tts_model` 选择 Aura 音色；STT（`model`）与 TTS（`tts_model`）共用同一个 API key。音色命名规则为 `[family]-[voice]-[language]` —— 见 [Deepgram 音色列表](https://developers.deepgram.com/docs/tts-models)。
+- `cartesia.max_concurrency` 应与你套餐的 TTS 并发上限一致 —— Cartesia 统计的是进行中的生成数而不是通话数，超限会返回 429。
+- `minimax.base_url` 用于选择区域。留空即使用全球端点；中国大陆账号必须指向 `https://api.minimaxi.com/v1`，因为两个平台的 key 不通用。
+- `minimax.model` 必须与你的套餐匹配：Token Plan 的 key（`sk-cp-`）只覆盖 `speech-2.8-hd`，其他模型走按量计费，余额为零时报错 `2056`。
 
-Provider-specific behaviour and caveats: [Providers](./providers.md).
+各服务商的具体行为与注意事项见[服务商](./providers.zh-CN.md)。

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,3 +1,5 @@
+**English** | [简体中文](./protocol.zh-CN.md)
+
 # Protocol reference
 
 ## WHIP signaling

--- a/docs/protocol.zh-CN.md
+++ b/docs/protocol.zh-CN.md
@@ -1,0 +1,38 @@
+[English](./protocol.md) | **简体中文**
+
+# 协议参考
+
+## WHIP 信令
+
+信令遵循 [RFC 9725](https://www.rfc-editor.org/rfc/rfc9725.html)。
+
+| 步骤 | 方法 | 路径 | 请求体 | 响应 |
+|------|--------|------|------|----------|
+| 1 | `POST` | `/whip` | SDP offer（`application/sdp`） | `201 Created`，返回 SDP answer、`Location: /whip/{sessionId}` 与 `ETag` |
+| 2 | `DELETE` | `/whip/{sessionId}` | 无 | `200 OK` |
+| — | `OPTIONS` | `/whip` 或 `/whip/{sessionId}` | 无 | `204 No Content`，带 `Accept-Post: application/sdp` |
+
+`POST /whip` 按客户端 IP 限流（每分钟 30 个会话）。超出后服务返回 `429 Too Many Requests` 并带上 `Retry-After` 头。每次 POST 都会建立一个 peer connection 并收集 ICE，因此即使未开启鉴权，该端点也会被限流。
+
+客户端创建 SDP offer、收集 ICE 候选并 `POST` 到 `/whip`。服务端创建 peer、收集自己的候选，并连同服务端生成的会话 ID 一起返回 answer。不使用 trickle ICE，也没有常驻信令连接。
+
+本实现与 WHIP 的核心流程一致：以 `application/sdp` 发起 `POST`，用 `201 Created` 返回 answer，用 `Location` 给出会话 URL，用 `ETag` 标识 ICE 会话，用 `DELETE` 销毁，用 `OPTIONS` 返回 `Accept-Post`，并在双端做完整 ICE 收集。音频为 `sendrecv`，并带一个用于双向事件的 DataChannel。
+
+## 实时事件
+
+客户端必须在生成 offer 之前创建一个标签为 `events` 的 DataChannel。服务端会发送：
+
+| 类型 | 载荷 | 说明 |
+|------|---------|-------------|
+| `transcript` | `{ "type": "transcript", "text": string, "final": boolean }` | 用户转写更新 |
+| `response` | `{ "type": "response", "text": string }` | 流式回复文本 |
+| `state` | `{ "type": "state", "state": "listening" \| "thinking" \| "speaking" }` | 智能体轮次状态，用于 UI 指示 |
+| `timing` | `{ "type": "timing", "stage": string, "ms": number }` | `pipeline.debug = true` 时的时延数据 |
+
+目前的 timing 阶段：`llm_first_token`、`tts_first_byte`。
+
+客户端在同一通道上发送的消息会被路由进流水线 —— 目前用于 `vision.analyze` 插件消费的摄像头图像分片。
+
+## 鉴权
+
+设置 `server.jwt_secret` 后，`/whip` 会要求 `Authorization: Bearer <jwt>`。设置该项时，服务还会暴露 `POST /token`，签发有效期 1 小时的 HS256 token。再设置 `server.api_key`，则 `/token` 本身也要求 `Authorization: Bearer <api_key>`，这样只有你的后端才能签发会话 token。两者默认都为空，即关闭鉴权。

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,3 +1,5 @@
+**English** | [简体中文](./providers.zh-CN.md)
+
 # Provider integrations
 
 | Role | Providers | Required credentials |

--- a/docs/providers.zh-CN.md
+++ b/docs/providers.zh-CN.md
@@ -1,0 +1,151 @@
+[English](./providers.md) | **简体中文**
+
+# 服务商集成
+
+| 角色 | 服务商 | 所需凭据 |
+|------|-----------|----------------------|
+| STT | `deepgram`、`assemblyai`、`openai`、`vibevoice` | Deepgram API key、AssemblyAI API key、OpenAI API key，或一个本地 VibeVoice ASR 服务 |
+| LLM | `openai`、`ollama` | OpenAI API key，或你自己掌控的 Ollama 实例 |
+| TTS | `cartesia`、`deepgram`、`elevenlabs`、`minimax`、`speechify`、`vibevoice` | 对应服务商的 API key，或一个本地 VibeVoice TTS 服务 |
+| 语音到语音 | `grok` | xAI API key —— 一并取代 STT、LLM 与 TTS |
+| RAG（可选） | `pgvector`、`supabase` | Postgres 连接串或 Supabase URL + key，另需 OpenAI key 用于 embedding |
+
+注意：
+
+- `stt.provider = "openai"` 使用 Whisper 式的最终转写，而不是流式中间结果。
+- `llm.provider = "ollama"` 通过 `base_url` 指向任何兼容 Ollama 的端点 —— 本地或你自己的基础设施均可。
+- `stt.provider = "vibevoice"` 与 `tts.provider = "vibevoice"` 使用本地模型；请先启动 Python 边车进程。
+- `tts.provider = "minimax"` 覆盖 40+ 语言，是中文场景下最强的选项。区域与套餐相关的坑见 [MiniMax TTS](#minimax-tts)。
+- `realtime.provider = "grok"` 切换到语音到语音模式，并完全忽略 `[stt]`、`[llm]` 与 `[tts]`。
+
+所有 key 与可调项都在[配置参考](./configuration.zh-CN.md)里。
+
+## 语音到语音（Grok Voice）
+
+设置 `realtime.provider` 会把三段式的 STT → LLM → TTS 链路换成单个模型：它接收用户音频，并直接以音频回答。转写、推理与合成在一跳内完成，从而消除了经典链路中主导每轮时延的那两次交接。
+
+```toml
+[realtime]
+provider = "grok"
+
+[grok]
+api_key = "xai-..."
+model = "grok-voice-think-fast-2.0"   # 或 "grok-voice-latest"
+voice = "eve"
+reasoning_effort = "high"             # "none" 用细腻度换时延
+system_prompt = "You are a helpful assistant on a phone call. Keep it short."
+```
+
+流水线两端仍是同一条 Opus/RTP 链路，中间以单个 `runRealtime` 循环取代 `runInbound` + `runAgent`。音频以 16 kHz PCM 通过二进制 WebSocket 帧协商 —— 正是流水线的原生采样率，因此音频路径上既不重采样也不做 base64 编码。
+
+### 模型
+
+| `model` | 说明 | 价格 |
+|---|---|---|
+| `grok-voice-think-fast-2.0` | 最新、能力最强。默认开启推理 | $0.08 / 分钟（$4.80 / 小时） |
+| `grok-voice-think-fast-1.0` | 上一代，更便宜 | $0.05 / 分钟（$3.00 / 小时） |
+| `grok-voice-latest` | 始终指向最新模型的别名 —— 当前为 `grok-voice-think-fast-2.0` | 跟随其解析到的模型 |
+
+两个模型的文本输入都另计 $0.004 每次。生产环境请固定带版本的名称：`grok-voice-latest` 会在 xAI 发布新模型时改变指向，从而在运行中的部署下悄悄改变行为与价格。
+
+为这些模型写提示词时要注意两点：
+
+- **`system_prompt` 要短。** 它们足够强，把为更弱模型写的长篇 GPT 时代提示词原样搬过来反而会变差。xAI 自己的建议是：删掉那些绕过缺陷的提示技巧与边缘情况补丁。
+- **推理默认开启。** `reasoning_effort = "high"` 对多步指令、语气细腻度与含糊问题有帮助。当智能体的任务很简单时，设为 `"none"` 可降低时延。
+
+模型并不知道自己被部署在什么产品里 —— 如果你希望它自报家门（「你是 StreamCore 助手」），那属于 `system_prompt` 的内容。
+
+### 音色
+
+`voice` 接受一个小写的内置音色 ID（默认 `eve`），或通过 xAI Custom Voices API 克隆的自定义音色 ID。用 `GET /v1/tts/voices` 获取当前可用列表。这些音色与 TTS API 共用，因此 xAI TTS 音色表里的任何一个在这里都可用。
+
+### 该模式下有什么变化
+
+| 能力 | 行为 |
+|---|---|
+| 轮次检测与插话打断 | 完全由模型的服务端 VAD 掌管，见下文 |
+| 插件、技能、视觉、车控 | 注册为 function tool；两种模式下运行的是同一批 handler |
+| RAG | 以 `knowledge_search` 工具的形式暴露，由模型按需调用，而不是注入到每次提示中 |
+| 托管搜索 | `web_search` 与 `x_search` 在 xAI 侧运行，无需本地插件 |
+| 滚动摘要、误解检测 | 不使用 —— 它们作用于模型根本不产出的 STT 转写 |
+| 表达标签（`[warm]`、`[calm]`） | 不使用 —— 韵律由模型自己控制 |
+| 插件 `thinking_sound` | 不播放 —— 它会与仍在出向队列中排空的模型音频交叠。每通电话记录一次日志 |
+
+### 插话打断与轮次检测
+
+检测打断的是模型，而不是服务端。Grok 的 VAD 判定用户插话后会停止生成，并发送 `input_audio_buffer.speech_started`；服务端唯一要做的是丢弃本地已经缓冲的音频，因为模型无法收回已经排在这里的帧。
+
+这意味着**在 realtime 模式下 `[pipeline] barge_in` 不起作用**。它只被 `runInbound` 读取，而后者根本不运行。本地能量 VAD、回应词抑制窗口、`readback_bargein_guard_enabled` 与音量压低同理 —— 这里的打断是硬切断，而不是先压低再恢复。仍然建议保留 `barge_in = true`，这样切回经典链路时设置依然正确。
+
+调优转移到 `[grok]`：
+
+| 设置 | 什么时候用 |
+|---|---|
+| `vad_threshold`（0.1–0.9，默认 0.85） | 噪音、咳嗽或「嗯嗯」把智能体打断了，就调高它。这是软件层回应词抑制在此模式下最接近的替代品 |
+| `silence_duration_ms` | 用户说到一半被切断，就调高它以容纳更长的停顿 |
+| `prefix_padding_ms`（默认 333） | 一轮开头的第一个词被吃掉了，就调高它 |
+| `idle_timeout_ms` | 你希望智能体在静默后主动接话。不设置则关闭该检查 |
+
+没有办法在保留自动轮次控制的同时关闭打断：`turn_detection` 只能是 `server_vad` 或 `null`，而 `null` 意味着服务端必须自己决定每一轮何时结束并显式请求每次回复。请改为调阈值。
+
+### 转写
+
+`transcription = true` 会单独跑一遍转写，纯粹是为了让客户端收到用于展示的 `transcript` 事件 —— 模型本身直接听音频，并不需要它。如果你的客户端不展示转写，关掉它可以省下这部分费用。
+
+这些转写是累积式的，并且分片到达：一次更新可能会修订它先前已经发出的词，而一个说到一半停顿的用户会为同一个问题产生多个 finalised 分片。服务端会把它们合并为一轮，并在模型开始回复时提交，因此一次口头发言只渲染成一条消息。设置 `[pipeline] debug = true` 可以把每个服务商事件连同其转写载荷一起记录下来。
+
+### 成本
+
+计费按音频的墙钟分钟数而不是 token 计算，这改变了它与自行拼装链路之间的经济账 —— 通话空闲时间照样计费，因此 `idle_timeout_ms` 与及时挂断在这里比经典模式更重要。费率见上面的模型表。
+
+## MiniMax TTS
+
+MiniMax 的 T2A v2 API，走 SSE，覆盖 40+ 语言，中文音色阵容很强。它是唯一一个能按你要求的采样率输出 PCM 的托管服务商，因此服务端直接请求 16 kHz 单声道 —— 流水线的原生采样率 —— 送进编码器之前无需任何重采样。
+
+```toml
+[tts]
+provider = "minimax"
+
+[minimax]
+api_key = ""
+voice_id = "English_Graceful_Lady"   # 或 "Chinese (Mandarin)_News_Anchor"
+model = "speech-2.6-turbo"
+# base_url = "https://api.minimax.io/v1"
+```
+
+有三件事必须弄对：
+
+- **区域。** `base_url` 默认指向全球端点 `https://api.minimax.io/v1`。在中国大陆平台注册的账号必须改为 `https://api.minimaxi.com/v1` —— 两个平台的 key 不通用，用错主机会直接鉴权失败，而不会自动回退。
+- **模型与套餐。** `speech-2.6-turbo` 是低时延档位，也是实时音频链路上正确的默认值；`-hd` 系列音质更好，但会增加数百毫秒。Token Plan 的 key（`sk-cp-`）只覆盖 `speech-2.8-hd` —— 其他任何模型都会走按量计费，余额为零时报错 `2056`。
+- **错误以 HTTP 200 返回。** MiniMax 把鉴权与配额失败放在 200 响应体的 `base_resp.status_code` 字段里。客户端会检查它，因此这些问题会以真实错误的形式暴露，而不是变成静默的空音频。
+
+表达标签映射到 MiniMax 的情绪枚举：`[warm]` 与 `[excited]` 变成 `happy`，`[calm]` 与 `[empathetic]` 变成 `calm`。`[empathetic]` 刻意落在 `calm` 而不是 `sad` —— 后者在道歉与坏消息场景下会过头，听起来像在难过。没有情绪映射的标签仍会通过语速生效，语速被限制在 MiniMax 的 0.5–2.0 范围内。
+
+## 本地 VibeVoice 配置
+
+VibeVoice 提供完全本地、无需 API key 的 STT 与 TTS：识别用 [VibeVoice-ASR](https://huggingface.co/mlx-community/VibeVoice-ASR-4bit)，合成用 [VibeVoice-Realtime-0.5B](https://huggingface.co/mlx-community/VibeVoice-Realtime-0.5B-6bit)，通过两个轻量 Python 边车进程运行。在 Apple Silicon 上使用 [mlx-audio](https://github.com/Blaizzy/mlx-audio)（MLX）；在 Linux/Windows 上自动回退到 PyTorch。
+
+```bash
+# Apple Silicon (MLX)
+pip install mlx-audio numpy websockets fastapi uvicorn
+# 或 PyTorch（Linux / CUDA）
+pip install torch transformers librosa numpy websockets fastapi uvicorn
+
+python external/vibeVoice/vibeVoiceAsr/server.py   # ws://127.0.0.1:8200
+python external/vibeVoice/vibeVoiceTTS/server.py   # http://127.0.0.1:8300
+```
+
+```toml
+[stt]
+provider = "vibevoice"
+
+[tts]
+provider = "vibevoice"
+
+[vibevoice]
+asr_url = "ws://127.0.0.1:8200"
+tts_url = "http://127.0.0.1:8300"
+voice = "en-Emma_woman"
+```
+
+ASR 服务通过 WebSocket 接收实时 PCM 并输出 JSON 转写事件。TTS 服务接收 HTTP POST 并返回裸 PCM。

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,3 +1,5 @@
+**English** | [简体中文](./quickstart.zh-CN.md)
+
 # Quick start
 
 Everything needed to get a realtime voice session running locally, plus the

--- a/docs/quickstart.zh-CN.md
+++ b/docs/quickstart.zh-CN.md
@@ -1,0 +1,166 @@
+[English](./quickstart.md) | **简体中文**
+
+# 快速开始
+
+在本地跑通一次实时语音会话所需的全部步骤，以及 Docker 与完全本地运行两种变体。
+
+## 前置条件
+
+使用 Docker：只需 Docker。本地开发没有 Compose 文件 —— Compose 仅用于 [`infrastructure/aws/ec2`](../infrastructure/aws/ec2/) 中的 EC2 部署。
+
+本地开发：
+
+- Go 1.25+ —— 与 [`go.mod`](../go.mod) 中的 `go` 指令一致；CI 与 Docker 构建使用同一工具链
+- Node.js 20+ 与 npm
+- Python 3.10+（用于 Python 插件或示例）
+- Rust 1.87+（用于 Rust SDK 或示例）
+
+## 运行媒体运行时
+
+```bash
+cp config.toml.example config.toml
+# 在 config.toml 中填入你的服务商凭据
+
+go run .
+```
+
+或使用 Docker：
+
+```bash
+docker build -t streamcore-server .
+docker run --rm -p 8080:8080 -v "$(pwd)/config.toml:/config.toml:ro" streamcore-server
+```
+
+服务监听 `:8080`，客户端连接 `http://localhost:8080/whip`。
+
+上面只发布了信令端口，本地浏览器客户端仅需这一个。如果你设置了 `server.public_ip` 与 `server.turn_secret`，内置的 STUN/TURN 服务（[`internal/turn`](../internal/turn/)）还会监听 UDP **与** TCP 3478，并在 UDP 50001–60000 上中转媒体，因此这些端口也必须可达：
+
+```bash
+docker run --rm \
+  -p 8080:8080 \
+  -p 3478:3478/udp -p 3478:3478/tcp \
+  -p 50001-60000:50001-60000/udp \
+  -v "$(pwd)/config.toml:/config.toml:ro" \
+  streamcore-server
+```
+
+在 Linux 上，建议用 `--network host` 而不是发布这一整段端口：Docker 会为每个发布的端口启动一个用户态代理，一万个 UDP 端口会让容器启动变慢，并给每个中转包多加一跳。EC2 部署使用 `network_mode: host` 正是这个原因。
+
+## 接入一个客户端
+
+```bash
+git clone https://github.com/streamcoreai/examples.git
+cd examples/typescript
+npm install
+npm run dev
+```
+
+打开 [http://localhost:3000](http://localhost:3000)。它默认连接 `http://localhost:8080/whip`。
+
+## 接入你自己的后端
+
+StreamCore 的意义在于智能体归你。最快的路径是做一个调用你自己服务的工具 —— 你的后端在干活的同时，智能体还在继续说话。
+
+```bash
+mkdir -p plugins/plugins/orders-lookup
+```
+
+`plugins/plugins/orders-lookup/plugin.yaml`
+
+```yaml
+name: orders.lookup
+description: Look up an order by ID in the company order system
+version: 1
+language: python
+entrypoint: main.py
+thinking_sound: true
+parameters:
+  type: object
+  properties:
+    order_id:
+      type: string
+      description: The customer's order ID
+  required:
+    - order_id
+```
+
+`plugins/plugins/orders-lookup/main.py`
+
+```python
+import os, requests
+from streamcoreai_plugin import StreamCoreAIPlugin
+
+plugin = StreamCoreAIPlugin()
+
+@plugin.on_execute
+def handle(params):
+    r = requests.get(
+        f"{os.environ['BACKEND_URL']}/orders/{params['order_id']}",
+        timeout=10,
+    )
+    r.raise_for_status()
+    order = r.json()
+    return f"Order {order['id']} is {order['status']}, arriving {order['eta']}."
+
+plugin.run()
+```
+
+重启服务。你的后端就已经成为一次实时语音会话的一部分，而它周围每一毫秒的媒体链路都由 StreamCore 负责。
+
+如果你想掌控整段对话，而不只是一次工具调用，见[接入你自己的智能体](./bring-your-own-agent.zh-CN.md)。
+
+## 完全本地运行，无需 API key
+
+用 Ollama 跑 LLM、用 VibeVoice 跑 STT/TTS，全部在你自己的硬件上运行。
+
+**1. 安装并启动 Ollama**
+
+```bash
+brew install ollama            # macOS；Linux 见 https://ollama.ai
+ollama serve
+ollama pull gpt-oss:20b
+```
+
+**2. 启动 VibeVoice 边车进程**
+
+```bash
+# Apple Silicon (MLX)
+pip install mlx-audio numpy websockets fastapi uvicorn
+# 或 Linux / CUDA
+# pip install torch transformers librosa numpy websockets fastapi uvicorn
+
+python external/vibeVoice/vibeVoiceAsr/server.py   # ws://127.0.0.1:8200
+python external/vibeVoice/vibeVoiceTTS/server.py   # http://127.0.0.1:8300
+```
+
+**3. 配置并运行**
+
+```toml
+[stt]
+provider = "vibevoice"
+
+[llm]
+provider = "ollama"
+
+[tts]
+provider = "vibevoice"
+
+[ollama]
+base_url = "http://localhost:11434"
+model = "gpt-oss:20b"
+
+[vibevoice]
+asr_url = "ws://127.0.0.1:8200"
+tts_url = "http://127.0.0.1:8300"
+voice = "en-Emma_woman"
+```
+
+```bash
+go run .
+```
+
+完全本地的实时语音，不依赖任何外部 API。模型与边车进程的细节见[服务商 → 本地 VibeVoice 配置](./providers.zh-CN.md#本地-vibevoice-配置)。
+
+---
+
+下一步：[配置参考](./configuration.zh-CN.md) · [服务商](./providers.zh-CN.md) · [智能体运行时](./agent-runtime.zh-CN.md)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,11 +1,29 @@
-# Roadmap
+**English** | [简体中文](./roadmap.zh-CN.md)
 
-Not built yet — listed here so the [capability tables](./capabilities.md) stay honest:
+# Roadmap / TODO
 
-- **Horizontal scaling.** Session state is in-memory and single-process. Multi-instance deployments need sticky routing or external session coordination today.
-- **Session reconnection.** There is no ICE restart or resume path; a dropped connection means a new session.
-- **Metrics and observability.** `/health` and DataChannel timing events exist; there is no Prometheus/OpenTelemetry export.
-- **HTTP agent endpoint.** A configurable OpenAI-compatible or webhook-style agent backend, so [bring-your-own-agent](./bring-your-own-agent.md) needs no Go code.
-- **Persistent memory** across sessions.
-- **Broader examples** proving the positioning: realtime translator, AI-hosted voice room, browser copilot, embedded device, SIP application, and a raw audio-processing app with no LLM at all.
-- **Embedded client hardening.** The ESP32-S3 firmware in [`esp32`](https://github.com/streamcoreai/esp32) connects over WHIP but is not production-ready.
+Everything on this page is **not built yet**. It lives here so the [capability tables](./capabilities.md) stay honest — if a feature is listed on this page, do not plan around it today.
+
+Want one of these? Say so in [Discord](https://discord.gg/xKGFaGWawT) or open an issue — demand reorders this list. Contributions welcome; see [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Production hardening
+
+- [ ] **Horizontal scaling.** Session state is in-memory and single-process. Multi-instance deployments need sticky routing or external session coordination today.
+- [ ] **Session reconnection.** There is no ICE restart or resume path; a dropped connection means a new session.
+- [ ] **Metrics and observability.** `/health` and DataChannel timing events exist; there is no Prometheus/OpenTelemetry export.
+
+## Bring-your-own-agent
+
+- [ ] **HTTP agent endpoint.** A configurable OpenAI-compatible or webhook-style agent backend, so [bring-your-own-agent](./bring-your-own-agent.md) needs no Go code. Today the equivalent is implementing one small Go interface.
+- [ ] **Persistent memory across sessions.** The rolling summary lives and dies with a call.
+
+## Ecosystem
+
+- [ ] **Broader examples** proving the positioning: realtime translator, AI-hosted voice room, browser copilot, embedded device, SIP application, and a raw audio-processing app with no LLM at all.
+- [ ] **Embedded client hardening.** The ESP32-S3 firmware in [`esp32`](https://github.com/streamcoreai/esp32) connects over WHIP but is not production-ready.
+- [ ] **`streamcore-cli` release.** Document ingestion for RAG is written against a binary that is not public yet — see [Agent runtime → Ingesting documents](./agent-runtime.md#ingesting-documents).
+- [ ] **React Native SDK on npm.** `@streamcore/react-native-sdk` is built and usable from source, but unpublished.
+
+---
+
+Already shipped and supported: [Capabilities](./capabilities.md).

--- a/docs/roadmap.zh-CN.md
+++ b/docs/roadmap.zh-CN.md
@@ -1,0 +1,29 @@
+[English](./roadmap.md) | **简体中文**
+
+# 路线图 / TODO
+
+本页列出的全部内容都是**尚未实现**的。把它们放在这里，是为了让[能力清单](./capabilities.zh-CN.md)保持诚实 —— 只要出现在本页，就不要按它来做今天的规划。
+
+需要其中某一项？在 [Discord](https://discord.gg/xKGFaGWawT) 说一声或提一个 issue —— 需求会改变这份清单的顺序。欢迎贡献代码，见 [CONTRIBUTING.md](../CONTRIBUTING.md)。
+
+## 生产环境加固
+
+- [ ] **水平扩展。** 会话状态保存在内存中且为单进程。目前多实例部署需要粘性路由或外部会话协调。
+- [ ] **会话重连。** 没有 ICE restart，也没有恢复路径；连接断开就意味着一个新会话。
+- [ ] **指标与可观测性。** 已有 `/health` 与 DataChannel 时延事件，但没有 Prometheus/OpenTelemetry 导出。
+
+## 接入自有智能体
+
+- [ ] **HTTP 智能体端点。** 一个可配置的、兼容 OpenAI 或 webhook 形式的智能体后端，让[接入自有智能体](./bring-your-own-agent.zh-CN.md)完全不需要写 Go 代码。目前的等价做法是实现一个很小的 Go 接口。
+- [ ] **跨会话的持久记忆。** 滚动摘要随通话开始、随通话结束。
+
+## 生态
+
+- [ ] **更多示例**，以印证产品定位：实时翻译、AI 主持的语音房间、浏览器副驾、嵌入式设备、SIP 应用，以及一个完全不含 LLM 的纯音频处理应用。
+- [ ] **嵌入式客户端加固。** [`esp32`](https://github.com/streamcoreai/esp32) 中的 ESP32-S3 固件已能通过 WHIP 连接，但尚未达到生产可用。
+- [ ] **`streamcore-cli` 发布。** RAG 的文档入库文档所依赖的二进制程序尚未公开 —— 见[智能体运行时 → 文档入库](./agent-runtime.zh-CN.md#文档入库)。
+- [ ] **React Native SDK 发布到 npm。** `@streamcore/react-native-sdk` 已完成、可从源码使用，但尚未发布。
+
+---
+
+已经交付并受支持的部分：[能力清单](./capabilities.zh-CN.md)。


### PR DESCRIPTION
This pull request significantly improves multilingual documentation support and clarifies the project's current capabilities and roadmap. It introduces full Simplified Chinese documentation, adds clear language selectors to all major docs, and reorganizes README files to better distinguish between implemented features and planned items. The changes also ensure that references to documentation are language-appropriate and up-to-date.

**Documentation Internationalization and Structure:**

* Added complete Simplified Chinese documentation, including `docs/README.zh-CN.md` and translations of all major docs (capabilities, agent runtime, providers, configuration, protocol, architecture, roadmap) with language selectors at the top of each file for easy navigation between English and Chinese. [[1]](diffhunk://#diff-6336dd9fc5b4f4350f9870c912bf453ca3578905bb60d5d2c0903eb9f64e4764R1-R17) [[2]](diffhunk://#diff-0526535a2dcafee4334abf004a6f8d01057899c8e2029a41b6be31f935b03ab1R1-R168) [[3]](diffhunk://#diff-8a5fc86c65cb8faa8a3bed922104b0391550973c86028cb91bf72ab6ce3633bfR1-R45) [[4]](diffhunk://#diff-c9deb5efe8f32f9a990cfeddf192a49735182c7cfd1989dccbcbb6a0311b7ab7R1-R53)
* Updated all documentation pages (English and Chinese) to include a language selector at the top, improving discoverability and user experience for both language audiences. [[1]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R1-R2) [[2]](diffhunk://#diff-a9835e1e3d1e76e68f37b24e31f1f46b963aa8a7d849ac8019798dd479abc6f0R1-R2) [[3]](diffhunk://#diff-e1025d02cdf88a9784f92a7b9489589108dfa3dc6f4e2c7d6eb954ad2f862415R1-R2) [[4]](diffhunk://#diff-9c150cbd3345abc014a68998d0d7e7fb531fc7844e719d795dea9ecac02993a6R1-R2)

**README Improvements and Clarity:**

* Reorganized both English (`README.md`) and Chinese (`README.zh-CN.md`) READMEs to:
  - Add links to the roadmap and capabilities docs.
  - Clearly separate features that are implemented from those that are not yet built, listing real gaps under a "Not built yet" section. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L74-R86) [[3]](diffhunk://#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987L20-R20) [[4]](diffhunk://#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987L42-R42) [[5]](diffhunk://#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987L60-R60) [[6]](diffhunk://#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987L74-R86)
  - Update documentation links throughout to point to the correct language-specific files.

**Content Synchronization and Updates:**

* Synchronized tables of contents and feature lists across English and Chinese documentation, ensuring parity and accuracy of information. [[1]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L13-R15) [[2]](diffhunk://#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987L85-R115)
* Added and updated references to new and existing documentation files, ensuring all links are accurate and up-to-date in both languages. [[1]](diffhunk://#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987L85-R115) [[2]](diffhunk://#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987L74-R86)

These changes make the project more accessible to a global audience and provide clearer guidance on current and planned capabilities.