### PR TITLE
fix(server): recover dropped connections instead of ending the call c…

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -6,6 +6,7 @@ public_ip = ""          # Public IP for ICE candidates when behind NAT (e.g., EC
 turn_secret = ""        # Shared secret for the built-in STUN/TURN server. Required when public_ip is set.
 jwt_secret = ""         # Shared secret for JWT auth on /whip. Leave empty to disable auth.
 api_key = ""            # API key required to call POST /token. Leave empty to allow unauthenticated token generation.
+session_grace_ms = 30000 # How long a session with no connected peers is kept before it is reaped. The window lets a client recover a dropped connection (ICE restart or redial) without losing the conversation.
 
 [plugins]
 directory = "./plugins"     # Required if you want plugins and skills loaded

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -66,6 +66,8 @@ StreamCore can run a complete speech-to-agent-to-speech pipeline, but that is on
 - Bidirectional Opus audio over WebRTC (`sendrecv`)
 - WHIP signaling ([RFC 9725](https://www.rfc-editor.org/rfc/rfc9725.html)) — one HTTP `POST` for SDP exchange, no persistent signaling socket
 - Full ICE gathering on both sides, no trickle ICE
+- ICE restart over `PATCH /whip/{sessionId}` — a network handover or NAT rebind is recovered on the same connection, so the conversation, the pipeline, and the LLM client all survive it
+- Idle sessions reaped after a configurable grace period, so a client that vanishes mid-call is collected without cutting short one that is reconnecting
 - Built-in STUN/TURN server using Pion (UDP **and TCP** 3478, relay range 50001–60000) — TCP so callers behind UDP-blocking firewalls still connect
 - Optional JWT auth on `/whip`, with `POST /token` issuing 1-hour tokens
 - `/health` endpoint and graceful shutdown with a forced-exit safety net

--- a/docs/capabilities.zh-CN.md
+++ b/docs/capabilities.zh-CN.md
@@ -66,6 +66,8 @@ StreamCore 可以跑通一条完整的「语音 → 智能体 → 语音」链�
 - 基于 WebRTC 的双向 Opus 音频（`sendrecv`）
 - WHIP 信令（[RFC 9725](https://www.rfc-editor.org/rfc/rfc9725.html)）—— 一次 HTTP `POST` 完成 SDP 交换，无需常驻信令连接
 - 双端完整 ICE 收集，不使用 trickle ICE
+- 通过 `PATCH /whip/{sessionId}` 支持 ICE 重启 —— 网络切换或 NAT 重新绑定可在同一条连接上恢复，对话、流水线与 LLM 客户端均得以保留
+- 空闲会话在可配置的宽限期后被回收，既能收走通话中途消失的客户端，又不会打断正在重连的客户端
 - 基于 Pion 的内置 STUN/TURN 服务（UDP **与 TCP** 3478，中转端口 50001–60000）—— 支持 TCP，因此处在封禁 UDP 的防火墙后的用户仍能接通
 - `/whip` 上可选的 JWT 鉴权，`POST /token` 签发有效期 1 小时的 token
 - `/health` 端点，以及带强制退出兜底的优雅关闭

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,7 @@ port = "8080"
 # turn_secret = ""     # Shared secret for the built-in STUN/TURN server (required when public_ip is set)
 # jwt_secret = ""      # Enables JWT auth on /whip and the POST /token endpoint
 # api_key = ""         # Required to call POST /token when set
+# session_grace_ms = 30000  # Grace period before a session with no peers is reaped (allows ICE restart / redial)
 
 [plugins]
 directory = "./plugins"

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -11,6 +11,7 @@ port = "8080"
 # turn_secret = ""     # Shared secret for the built-in STUN/TURN server (required when public_ip is set)
 # jwt_secret = ""      # Enables JWT auth on /whip and the POST /token endpoint
 # api_key = ""         # Required to call POST /token when set
+# session_grace_ms = 30000  # Grace period before a session with no peers is reaped (allows ICE restart / redial)
 
 [plugins]
 directory = "./plugins"

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -8,15 +8,64 @@ Signaling follows [RFC 9725](https://www.rfc-editor.org/rfc/rfc9725.html).
 
 | Step | Method | Path | Body | Response |
 |------|--------|------|------|----------|
-| 1 | `POST` | `/whip` | SDP offer (`application/sdp`) | `201 Created` with SDP answer, `Location: /whip/{sessionId}`, and `ETag` |
-| 2 | `DELETE` | `/whip/{sessionId}` | none | `200 OK` |
-| — | `OPTIONS` | `/whip` or `/whip/{sessionId}` | none | `204 No Content` with `Accept-Post: application/sdp` |
+| 1 | `POST` | `/whip` | SDP offer (`application/sdp`) | `201 Created` with SDP answer, `Location: /whip/{sessionId}`, `ETag`, and `Accept-Patch` |
+| 2 | `PATCH` | `/whip/{sessionId}` | ICE restart fragment (`application/trickle-ice-sdpfrag`) | `200 OK` with the server's fragment and a new `ETag` |
+| 3 | `DELETE` | `/whip/{sessionId}` | none | `200 OK` |
+| — | `OPTIONS` | `/whip` or `/whip/{sessionId}` | none | `204 No Content` with `Accept-Post: application/sdp` and `Accept-Patch: application/trickle-ice-sdpfrag` |
 
-`POST /whip` is rate limited per client IP (30 sessions per minute). Over the limit the server returns `429 Too Many Requests` with a `Retry-After` header. Each POST builds a peer connection and gathers ICE, so the endpoint is throttled even when auth is disabled.
+`POST /whip` is rate limited per client IP (30 sessions per minute); `PATCH` has its own bucket (60 restarts per minute) so a client recovering from a flapping network never eats into its budget for opening new sessions. Over either limit the server returns `429 Too Many Requests` with a `Retry-After` header. Each request builds or re-gathers ICE, so both are throttled even when auth is disabled.
 
 The client creates an SDP offer, gathers ICE candidates, and `POST`s it to `/whip`. The server creates a peer, gathers its own candidates, and returns the answer with a server-generated session ID. No trickle ICE, no persistent signaling socket.
 
-This implementation aligns with the core WHIP flow: `POST` with `application/sdp`, `201 Created` with the answer, `Location` for the session URL, `ETag` for the ICE session, `DELETE` for teardown, `OPTIONS` with `Accept-Post`, and full ICE gathering on both sides. Audio is `sendrecv`, with a DataChannel for bidirectional events.
+This implementation aligns with the core WHIP flow: `POST` with `application/sdp`, `201 Created` with the answer, `Location` for the session URL, `ETag` for the ICE session, `PATCH` for ICE restart, `DELETE` for teardown, `OPTIONS` with `Accept-Post`, and full ICE gathering on both sides. Audio is `sendrecv`, with a DataChannel for bidirectional events.
+
+### ICE restart
+
+A transient network event — a phone moving between Wi-Fi and cellular, a laptop changing networks, a NAT rebinding after an idle gap — breaks connectivity without ending the call. Recovering by `POST`ing a fresh offer would allocate a new session, a new pipeline, and a new LLM client, so the conversation history and the rolling summary would be gone and the greeting would replay. `PATCH` recovers the *same* connection instead: new ICE credentials and candidates, but the same `PeerConnection`, the same DTLS association, the same tracks, and the same running pipeline.
+
+The client re-gathers ICE (`pc.restartIce()` in a browser) and sends the resulting credentials and candidates to the session URL from the `Location` header:
+
+```http
+PATCH /whip/{sessionId} HTTP/1.1
+Content-Type: application/trickle-ice-sdpfrag
+If-Match: "<etag>"
+
+a=ice-ufrag:ZjRk
+a=ice-pwd:AYk4ZQlPQeZ1AyJEkxUFXA
+m=audio 9 UDP/TLS/RTP/SAVPF 111
+a=mid:0
+a=candidate:1 1 udp 2130706431 198.51.100.7 51000 typ host
+```
+
+The server replies `200 OK` with its own fragment and a rotated `ETag`:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/trickle-ice-sdpfrag
+ETag: "<new-etag>"
+
+a=ice-ufrag:MInq
+a=ice-pwd:9NAlFOwsD1owEQGZjnjqvSVU
+m=audio 9 UDP/TLS/RTP/SAVPF 111
+a=mid:0
+a=candidate:1 1 udp 2130706431 198.51.100.1 39132 typ host
+a=end-of-candidates
+```
+
+`If-Match` is optional but checked when present: it must carry the current `ETag` (or `*`), otherwise the server returns `412 Precondition Failed` with the current tag in the response. Other outcomes:
+
+| Status | Meaning |
+|--------|---------|
+| `404 Not Found` | The session has been reaped or never existed — redial with `POST`. |
+| `405 Method Not Allowed` | The fragment had candidates but no `ice-ufrag`/`ice-pwd`. Trickle ICE is optional per RFC 9725 §4.4.1 and is not implemented; gather fully, then patch. |
+| `409 Conflict` | The session exists but has no negotiated peer to restart. |
+| `415 Unsupported Media Type` | `Content-Type` was not `application/trickle-ice-sdpfrag`. |
+
+The `disconnected` connection state is transient and never tears a peer down on its own — ICE recovers from it unaided, and Pion escalates to `failed` (which does tear down) after roughly 25 seconds if it does not. While disconnected the server emits a `connection` event on the DataChannel so the client can surface "reconnecting…", and another when it recovers.
+
+### Session lifetime
+
+A session is removed when the client sends `DELETE`, or when it has had no connected peers for longer than `server.session_grace_ms` (30 seconds by default). The grace period is what leaves the door open for an ICE restart or a redial; the sweep is what stops a client that vanished mid-call — and therefore never sent `DELETE` — from leaking a session for the life of the process.
 
 ## Realtime events
 
@@ -28,6 +77,7 @@ The client must create a DataChannel labeled `events` before generating the offe
 | `response` | `{ "type": "response", "text": string }` | Streamed response text |
 | `state` | `{ "type": "state", "state": "listening" \| "thinking" \| "speaking" }` | Agent turn state, for UI indicators |
 | `timing` | `{ "type": "timing", "stage": string, "ms": number }` | Latency timings when `pipeline.debug = true` |
+| `connection` | `{ "type": "connection", "state": "reconnecting" \| "connected" }` | Transport dropped and is recovering, or has recovered |
 
 Timing stages today: `llm_first_token`, `tts_first_byte`.
 

--- a/docs/protocol.zh-CN.md
+++ b/docs/protocol.zh-CN.md
@@ -8,15 +8,64 @@
 
 | 步骤 | 方法 | 路径 | 请求体 | 响应 |
 |------|--------|------|------|----------|
-| 1 | `POST` | `/whip` | SDP offer（`application/sdp`） | `201 Created`，返回 SDP answer、`Location: /whip/{sessionId}` 与 `ETag` |
-| 2 | `DELETE` | `/whip/{sessionId}` | 无 | `200 OK` |
-| — | `OPTIONS` | `/whip` 或 `/whip/{sessionId}` | 无 | `204 No Content`，带 `Accept-Post: application/sdp` |
+| 1 | `POST` | `/whip` | SDP offer（`application/sdp`） | `201 Created`，返回 SDP answer、`Location: /whip/{sessionId}`、`ETag` 与 `Accept-Patch` |
+| 2 | `PATCH` | `/whip/{sessionId}` | ICE 重启片段（`application/trickle-ice-sdpfrag`） | `200 OK`，返回服务端片段与新的 `ETag` |
+| 3 | `DELETE` | `/whip/{sessionId}` | 无 | `200 OK` |
+| — | `OPTIONS` | `/whip` 或 `/whip/{sessionId}` | 无 | `204 No Content`，带 `Accept-Post: application/sdp` 与 `Accept-Patch: application/trickle-ice-sdpfrag` |
 
-`POST /whip` 按客户端 IP 限流（每分钟 30 个会话）。超出后服务返回 `429 Too Many Requests` 并带上 `Retry-After` 头。每次 POST 都会建立一个 peer connection 并收集 ICE，因此即使未开启鉴权，该端点也会被限流。
+`POST /whip` 按客户端 IP 限流（每分钟 30 个会话）；`PATCH` 使用独立计数（每分钟 60 次重启），因此网络频繁抖动的客户端不会消耗掉自己新建会话的额度。超出任一限制后服务返回 `429 Too Many Requests` 并带上 `Retry-After` 头。两者都会建立或重新收集 ICE，因此即使未开启鉴权也会被限流。
 
 客户端创建 SDP offer、收集 ICE 候选并 `POST` 到 `/whip`。服务端创建 peer、收集自己的候选，并连同服务端生成的会话 ID 一起返回 answer。不使用 trickle ICE，也没有常驻信令连接。
 
-本实现与 WHIP 的核心流程一致：以 `application/sdp` 发起 `POST`，用 `201 Created` 返回 answer，用 `Location` 给出会话 URL，用 `ETag` 标识 ICE 会话，用 `DELETE` 销毁，用 `OPTIONS` 返回 `Accept-Post`，并在双端做完整 ICE 收集。音频为 `sendrecv`，并带一个用于双向事件的 DataChannel。
+本实现与 WHIP 的核心流程一致：以 `application/sdp` 发起 `POST`，用 `201 Created` 返回 answer，用 `Location` 给出会话 URL，用 `ETag` 标识 ICE 会话，用 `PATCH` 做 ICE 重启，用 `DELETE` 销毁，用 `OPTIONS` 返回 `Accept-Post`，并在双端做完整 ICE 收集。音频为 `sendrecv`，并带一个用于双向事件的 DataChannel。
+
+### ICE 重启
+
+短暂的网络事件 —— 手机在 Wi-Fi 与蜂窝之间切换、笔记本更换网络、空闲后 NAT 重新绑定 —— 会中断连通性，但通话本身并未结束。若用重新 `POST` offer 的方式恢复，会分配新的会话、新的流水线和新的 LLM 客户端，对话历史与滚动摘要随之丢失，开场白也会重播。`PATCH` 恢复的是*同一条*连接：ICE 凭据与候选是新的，但 `PeerConnection`、DTLS 关联、媒体轨道以及正在运行的流水线都保持不变。
+
+客户端重新收集 ICE（浏览器中为 `pc.restartIce()`），并把得到的凭据与候选发送到 `Location` 头给出的会话 URL：
+
+```http
+PATCH /whip/{sessionId} HTTP/1.1
+Content-Type: application/trickle-ice-sdpfrag
+If-Match: "<etag>"
+
+a=ice-ufrag:ZjRk
+a=ice-pwd:AYk4ZQlPQeZ1AyJEkxUFXA
+m=audio 9 UDP/TLS/RTP/SAVPF 111
+a=mid:0
+a=candidate:1 1 udp 2130706431 198.51.100.7 51000 typ host
+```
+
+服务端返回 `200 OK`，带上自己的片段与轮换后的 `ETag`：
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/trickle-ice-sdpfrag
+ETag: "<new-etag>"
+
+a=ice-ufrag:MInq
+a=ice-pwd:9NAlFOwsD1owEQGZjnjqvSVU
+m=audio 9 UDP/TLS/RTP/SAVPF 111
+a=mid:0
+a=candidate:1 1 udp 2130706431 198.51.100.1 39132 typ host
+a=end-of-candidates
+```
+
+`If-Match` 可选，但只要携带就会校验：其值必须是当前 `ETag`（或 `*`），否则服务端返回 `412 Precondition Failed`，并在响应中给出当前的 tag。其他情况：
+
+| 状态码 | 含义 |
+|--------|------|
+| `404 Not Found` | 会话已被回收或从未存在 —— 用 `POST` 重新拨号。 |
+| `405 Method Not Allowed` | 片段只有候选、没有 `ice-ufrag`/`ice-pwd`。按 RFC 9725 §4.4.1，trickle ICE 是可选的且本服务未实现；请收集完整后再 PATCH。 |
+| `409 Conflict` | 会话存在，但没有已协商的 peer 可供重启。 |
+| `415 Unsupported Media Type` | `Content-Type` 不是 `application/trickle-ice-sdpfrag`。 |
+
+`disconnected` 连接状态是暂时的，本身绝不会拆毁 peer —— ICE 可以自行恢复；若无法恢复，Pion 会在约 25 秒后升级为 `failed`（该状态才会拆毁）。处于 disconnected 期间，服务端会在 DataChannel 上发出 `connection` 事件，客户端可据此提示“正在重连…”，恢复后再发一次。
+
+### 会话生命周期
+
+会话会在客户端发送 `DELETE` 时移除，或在没有已连接 peer 的时间超过 `server.session_grace_ms`（默认 30 秒）后被回收。这段宽限期正是为 ICE 重启或重新拨号留出的窗口；而定期清扫则确保通话中途消失、因而根本无法发送 `DELETE` 的客户端，不会让会话泄漏到进程结束。
 
 ## 实时事件
 
@@ -28,6 +77,7 @@
 | `response` | `{ "type": "response", "text": string }` | 流式回复文本 |
 | `state` | `{ "type": "state", "state": "listening" \| "thinking" \| "speaking" }` | 智能体轮次状态，用于 UI 指示 |
 | `timing` | `{ "type": "timing", "stage": string, "ms": number }` | `pipeline.debug = true` 时的时延数据 |
+| `connection` | `{ "type": "connection", "state": "reconnecting" \| "connected" }` | 传输已断开并正在恢复，或已恢复 |
 
 目前的 timing 阶段：`llm_first_token`、`tts_first_byte`。
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,6 +81,13 @@ type ServerConfig struct {
 	TurnSecret string `toml:"turn_secret"` // Shared secret for the built-in TURN server. Required when public_ip is set.
 	JWTSecret  string `toml:"jwt_secret"`  // Shared secret for HMAC-SHA256 JWT validation on /whip. Leave empty to disable auth.
 	APIKey     string `toml:"api_key"`     // API key required to call /token. Leave empty to allow unauthenticated token generation.
+
+	// SessionGraceMs is how long a session with no connected peers is kept
+	// before the reaper closes it. The window is what lets a client recover a
+	// dropped connection — via ICE restart or a redial — without losing the
+	// conversation. Too short and a network handover costs the call; too long
+	// and abandoned sessions pile up. Defaults to 30000.
+	SessionGraceMs int `toml:"session_grace_ms"`
 }
 
 // RealtimeConfig selects a speech-to-speech provider. When Provider is set,
@@ -313,6 +320,9 @@ func Load(path string) (*Config, error) {
 
 	// Apply defaults
 	setDefault(&cfg.Server.Port, "8080")
+	if cfg.Server.SessionGraceMs == 0 {
+		cfg.Server.SessionGraceMs = 30000
+	}
 	setDefault(&cfg.STT.Provider, "deepgram")
 	setDefault(&cfg.Deepgram.Model, "nova-3")
 	// 300ms keeps the historical snappy endpointing. utterance_end_ms has no

--- a/internal/peer/icerestart.go
+++ b/internal/peer/icerestart.go
@@ -1,0 +1,271 @@
+package peer
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pion/webrtc/v4"
+)
+
+// ICEFragmentContentType is the media type of an ICE restart / trickle body,
+// per RFC 8840 and RFC 9725 §4.4.
+const ICEFragmentContentType = "application/trickle-ice-sdpfrag"
+
+var (
+	// ErrNoICECredentials means the fragment carried candidates but no
+	// ice-ufrag / ice-pwd, i.e. it is a trickle-ICE update rather than a
+	// restart. Trickle is optional per RFC 9725 §4.4.1 and is not implemented.
+	ErrNoICECredentials = errors.New("sdpfrag carries no ICE credentials")
+
+	// ErrPeerClosed means the peer was torn down before the restart arrived.
+	ErrPeerClosed = errors.New("peer is closed")
+
+	// ErrNoRemoteDescription means the peer never completed an offer/answer,
+	// so there is nothing to restart against.
+	ErrNoRemoteDescription = errors.New("peer has no remote description")
+)
+
+// RestartICE applies a client's new ICE credentials and candidates to the
+// existing PeerConnection and returns the server's own sdpfrag in reply
+// (RFC 9725 §4.4.2).
+//
+// The whole point of routing recovery through ICE restart rather than a fresh
+// offer is that *this* PeerConnection survives: the DTLS association, the
+// transceivers, the remote track the pipeline is reading from, and every layer
+// above the transport are untouched. Only the ICE generation is replaced.
+//
+// Pion has no entry point for applying a restart from an SDP *fragment*, but
+// SetRemoteDescription does trigger one when a renegotiation offer changes the
+// remote ICE credentials. So the fragment is folded back into the stored remote
+// offer — new ufrag, new pwd, new candidates, everything else verbatim — and
+// that synthesised offer drives the restart. Carrying the media sections over
+// unchanged is not cosmetic: Pion only keeps an existing RTPReceiver across a
+// renegotiation when the SSRCs still match, and a recreated receiver would
+// detach the pipeline from its track.
+func (p *Peer) RestartICE(fragment string) (string, error) {
+	ufrag, pwd, candidates, err := ParseICEFragment(fragment)
+	if err != nil {
+		return "", err
+	}
+
+	p.restartMu.Lock()
+	defer p.restartMu.Unlock()
+
+	p.mu.Lock()
+	closed := p.closed
+	p.mu.Unlock()
+	if closed {
+		return "", ErrPeerClosed
+	}
+
+	remote := p.pc.RemoteDescription()
+	if remote == nil {
+		return "", ErrNoRemoteDescription
+	}
+
+	offer := rewriteICEForRestart(remote.SDP, ufrag, pwd, candidates)
+	if err := p.pc.SetRemoteDescription(webrtc.SessionDescription{
+		Type: webrtc.SDPTypeOffer,
+		SDP:  offer,
+	}); err != nil {
+		return "", fmt.Errorf("set restart offer: %w", err)
+	}
+
+	// The promise must be created after SetRemoteDescription: the restart is
+	// what reopens gathering, and a promise made before it would resolve
+	// against the previous generation's completed gather.
+	gatherDone := webrtc.GatheringCompletePromise(p.pc)
+
+	answer, err := p.pc.CreateAnswer(nil)
+	if err != nil {
+		return "", fmt.Errorf("create restart answer: %w", err)
+	}
+	if err := p.pc.SetLocalDescription(answer); err != nil {
+		return "", fmt.Errorf("set restart answer: %w", err)
+	}
+
+	select {
+	case <-gatherDone:
+	case <-time.After(5 * time.Second):
+		log.Printf("[peer:%s] ICE re-gathering timed out, replying with partial candidates", p.ID)
+	}
+
+	log.Printf("[peer:%s] ICE restart applied", p.ID)
+	return iceFragmentFromSDP(p.pc.LocalDescription().SDP), nil
+}
+
+// ParseICEFragment extracts the ICE credentials and candidates from an
+// `application/trickle-ice-sdpfrag` body. Credentials may appear at session or
+// media level; the first of each wins, which is what a bundled offer means
+// anyway. Returns ErrNoICECredentials when the body is trickle-only.
+func ParseICEFragment(fragment string) (ufrag, pwd string, candidates []string, err error) {
+	for _, line := range splitSDPLines(fragment) {
+		switch {
+		case strings.HasPrefix(line, "a=ice-ufrag:"):
+			if ufrag == "" {
+				ufrag = strings.TrimPrefix(line, "a=ice-ufrag:")
+			}
+		case strings.HasPrefix(line, "a=ice-pwd:"):
+			if pwd == "" {
+				pwd = strings.TrimPrefix(line, "a=ice-pwd:")
+			}
+		case strings.HasPrefix(line, "a=candidate:"):
+			candidates = append(candidates, strings.TrimPrefix(line, "a=candidate:"))
+		}
+	}
+
+	if ufrag == "" || pwd == "" {
+		return "", "", nil, ErrNoICECredentials
+	}
+	return ufrag, pwd, candidates, nil
+}
+
+// rewriteICEForRestart folds new ICE credentials and candidates into an
+// existing offer, leaving every other line — m-lines, payload types, SSRCs,
+// mids, the DTLS fingerprint — exactly as it was.
+//
+// Candidates land in the first media section because that is where Pion reads
+// them from when the offer is BUNDLEd, and they are the only place they can be:
+// candidates are media-level attributes.
+func rewriteICEForRestart(remoteSDP, ufrag, pwd string, candidates []string) string {
+	lines := splitSDPLines(remoteSDP)
+	out := make([]string, 0, len(lines)+len(candidates)+1)
+
+	mediaIndex := -1
+	inserted := false
+	insertCandidates := func() {
+		if inserted {
+			return
+		}
+		inserted = true
+		for _, c := range candidates {
+			out = append(out, "a=candidate:"+c)
+		}
+		if len(candidates) > 0 {
+			out = append(out, "a=end-of-candidates")
+		}
+	}
+
+	for _, line := range lines {
+		switch {
+		case strings.HasPrefix(line, "m="):
+			if mediaIndex == 0 {
+				// Leaving the first media section — the new candidates belong
+				// at its end, after the attributes it already carries.
+				insertCandidates()
+			}
+			mediaIndex++
+			out = append(out, line)
+		case strings.HasPrefix(line, "o="):
+			out = append(out, bumpSDPOrigin(line))
+		case strings.HasPrefix(line, "a=ice-ufrag:"):
+			out = append(out, "a=ice-ufrag:"+ufrag)
+		case strings.HasPrefix(line, "a=ice-pwd:"):
+			out = append(out, "a=ice-pwd:"+pwd)
+		case strings.HasPrefix(line, "a=candidate:"), line == "a=end-of-candidates":
+			// Previous ICE generation — dropped.
+		default:
+			out = append(out, line)
+		}
+	}
+	insertCandidates()
+
+	return strings.Join(out, "\r\n") + "\r\n"
+}
+
+// iceFragmentFromSDP renders the server's half of the restart as an sdpfrag:
+// the new credentials, then the bundle-master m-line with its mid and
+// candidates. Shaped after the response example in RFC 9725 §4.4.2.
+func iceFragmentFromSDP(localSDP string) string {
+	var (
+		ufrag, pwd string
+		mLine, mid string
+		candidates []string
+		mediaIndex = -1
+	)
+
+	for _, line := range splitSDPLines(localSDP) {
+		if strings.HasPrefix(line, "m=") {
+			mediaIndex++
+			if mediaIndex == 0 {
+				mLine = line
+			}
+			continue
+		}
+		// Session-level attributes (mediaIndex < 0) and the first media
+		// section's are both usable; later sections are BUNDLEd onto the first.
+		if mediaIndex > 0 {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "a=ice-ufrag:"):
+			if ufrag == "" {
+				ufrag = strings.TrimPrefix(line, "a=ice-ufrag:")
+			}
+		case strings.HasPrefix(line, "a=ice-pwd:"):
+			if pwd == "" {
+				pwd = strings.TrimPrefix(line, "a=ice-pwd:")
+			}
+		case strings.HasPrefix(line, "a=mid:"):
+			if mid == "" {
+				mid = strings.TrimPrefix(line, "a=mid:")
+			}
+		case strings.HasPrefix(line, "a=candidate:"):
+			candidates = append(candidates, strings.TrimPrefix(line, "a=candidate:"))
+		}
+	}
+
+	out := make([]string, 0, len(candidates)+5)
+	if ufrag != "" {
+		out = append(out, "a=ice-ufrag:"+ufrag)
+	}
+	if pwd != "" {
+		out = append(out, "a=ice-pwd:"+pwd)
+	}
+	if mLine != "" {
+		out = append(out, mLine)
+	}
+	if mid != "" {
+		out = append(out, "a=mid:"+mid)
+	}
+	for _, c := range candidates {
+		out = append(out, "a=candidate:"+c)
+	}
+	out = append(out, "a=end-of-candidates")
+
+	return strings.Join(out, "\r\n") + "\r\n"
+}
+
+// bumpSDPOrigin increments the session version in an `o=` line, which is how
+// JSEP marks a description as a new revision of the same session.
+func bumpSDPOrigin(line string) string {
+	fields := strings.Fields(strings.TrimPrefix(line, "o="))
+	if len(fields) < 6 {
+		return line
+	}
+	version, err := strconv.ParseUint(fields[2], 10, 64)
+	if err != nil {
+		return line
+	}
+	fields[2] = strconv.FormatUint(version+1, 10)
+	return "o=" + strings.Join(fields, " ")
+}
+
+// splitSDPLines splits an SDP or SDP fragment into lines, tolerating LF-only
+// bodies and dropping the blank line a trailing CRLF leaves behind.
+func splitSDPLines(sdp string) []string {
+	raw := strings.Split(sdp, "\n")
+	lines := make([]string, 0, len(raw))
+	for _, line := range raw {
+		line = strings.TrimRight(line, "\r")
+		if line == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}

--- a/internal/peer/icerestart_integration_test.go
+++ b/internal/peer/icerestart_integration_test.go
@@ -1,0 +1,181 @@
+package peer
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pion/webrtc/v4"
+)
+
+// newTestClient builds a browser-shaped offerer: one audio track, one
+// DataChannel, host candidates only so the test never waits on STUN.
+func newTestClient(t *testing.T) *webrtc.PeerConnection {
+	t.Helper()
+
+	pc, err := webrtc.NewAPI().NewPeerConnection(webrtc.Configuration{})
+	if err != nil {
+		t.Fatalf("create client peer connection: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	track, err := webrtc.NewTrackLocalStaticRTP(
+		webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeOpus, ClockRate: 48000, Channels: 2},
+		"audio", "client",
+	)
+	if err != nil {
+		t.Fatalf("create client track: %v", err)
+	}
+	if _, err := pc.AddTrack(track); err != nil {
+		t.Fatalf("add client track: %v", err)
+	}
+	if _, err := pc.CreateDataChannel(EventChannelLabel, nil); err != nil {
+		t.Fatalf("create client data channel: %v", err)
+	}
+	return pc
+}
+
+// clientOffer creates an offer, applies it, and waits for gathering so the SDP
+// carries candidates. With iceRestart set it is the offer a browser produces
+// after restartIce().
+func clientOffer(t *testing.T, pc *webrtc.PeerConnection, iceRestart bool) string {
+	t.Helper()
+
+	offer, err := pc.CreateOffer(&webrtc.OfferOptions{ICERestart: iceRestart})
+	if err != nil {
+		t.Fatalf("create client offer: %v", err)
+	}
+	gatherDone := webrtc.GatheringCompletePromise(pc)
+	if err := pc.SetLocalDescription(offer); err != nil {
+		t.Fatalf("set client local description: %v", err)
+	}
+	select {
+	case <-gatherDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("client ICE gathering timed out")
+	}
+	return pc.LocalDescription().SDP
+}
+
+func sdpICEUfrag(t *testing.T, sdp string) string {
+	t.Helper()
+	for _, line := range splitSDPLines(sdp) {
+		if strings.HasPrefix(line, "a=ice-ufrag:") {
+			return strings.TrimPrefix(line, "a=ice-ufrag:")
+		}
+	}
+	t.Fatalf("no ice-ufrag in:\n%s", sdp)
+	return ""
+}
+
+// TestRestartICEPreservesTheConnection is the acceptance test for the recovery
+// path: a client that has lost connectivity re-gathers ICE and PATCHes the
+// result, and everything above the transport — the PeerConnection, the tracks,
+// the channel the pipeline reads from — must come through untouched. If any of
+// it were rebuilt, the caller would hear the agent forget the conversation.
+func TestRestartICEPreservesTheConnection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds real peer connections and gathers ICE")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, err := New(ctx, "srv", "", TURNConfig{})
+	if err != nil {
+		t.Fatalf("create server peer: %v", err)
+	}
+	defer server.Close()
+
+	closed := make(chan struct{})
+	server.OnClose = func() { close(closed) }
+
+	client := newTestClient(t)
+
+	answerSDP, err := server.HandleOffer(clientOffer(t, client, false))
+	if err != nil {
+		t.Fatalf("HandleOffer: %v", err)
+	}
+	if err := client.SetRemoteDescription(webrtc.SessionDescription{
+		Type: webrtc.SDPTypeAnswer,
+		SDP:  answerSDP,
+	}); err != nil {
+		t.Fatalf("set client remote description: %v", err)
+	}
+
+	// Identity before the restart.
+	var (
+		pcBefore       = server.pc
+		trackBefore    = server.LocalTrack()
+		trackChBefore  = server.RemoteTrackCh
+		peerCtxBefore  = server.Context()
+		serverUfragOld = sdpICEUfrag(t, answerSDP)
+		clientUfragOld = sdpICEUfrag(t, client.LocalDescription().SDP)
+	)
+
+	// The client re-gathers, exactly as it would after a network handover, and
+	// sends the result as an sdpfrag.
+	fragment := iceFragmentFromSDP(clientOffer(t, client, true))
+
+	clientUfragNew := sdpICEUfrag(t, client.LocalDescription().SDP)
+	if clientUfragNew == clientUfragOld {
+		t.Fatal("client did not generate new ICE credentials")
+	}
+
+	answerFragment, err := server.RestartICE(fragment)
+	if err != nil {
+		t.Fatalf("server RestartICE: %v", err)
+	}
+
+	// The server answered with a new ICE generation of its own.
+	serverUfragNew := sdpICEUfrag(t, answerFragment)
+	if serverUfragNew == serverUfragOld {
+		t.Fatalf("server reused ICE ufrag %q across the restart", serverUfragNew)
+	}
+	if !strings.Contains(answerFragment, "a=ice-pwd:") {
+		t.Fatalf("answer fragment has no ice-pwd:\n%s", answerFragment)
+	}
+	if !strings.Contains(answerFragment, "a=candidate:") {
+		t.Fatalf("answer fragment has no candidates:\n%s", answerFragment)
+	}
+
+	// The server adopted the client's credentials.
+	if got := sdpICEUfrag(t, server.pc.RemoteDescription().SDP); got != clientUfragNew {
+		t.Fatalf("server remote ufrag = %q, want the client's new %q", got, clientUfragNew)
+	}
+
+	// Nothing above the transport was rebuilt.
+	if server.pc != pcBefore {
+		t.Fatal("PeerConnection was replaced by the restart")
+	}
+	if server.LocalTrack() != trackBefore {
+		t.Fatal("outbound track was replaced by the restart")
+	}
+	if server.RemoteTrackCh != trackChBefore {
+		t.Fatal("remote track channel was replaced by the restart")
+	}
+	if server.Context() != peerCtxBefore || peerCtxBefore.Err() != nil {
+		t.Fatal("peer context was replaced or cancelled by the restart")
+	}
+	if len(server.pc.GetTransceivers()) != len(pcBefore.GetTransceivers()) {
+		t.Fatal("transceiver set changed across the restart")
+	}
+
+	select {
+	case <-closed:
+		t.Fatal("peer was closed by the restart")
+	default:
+	}
+
+	// The reply is parseable as the restart fragment it claims to be, which is
+	// what the client folds back into its own remote description.
+	gotUfrag, gotPwd, gotCandidates, err := ParseICEFragment(answerFragment)
+	if err != nil {
+		t.Fatalf("server's own answer fragment does not parse: %v\n%s", err, answerFragment)
+	}
+	if gotUfrag != serverUfragNew || gotPwd == "" || len(gotCandidates) == 0 {
+		t.Fatalf("answer fragment round-trip lost content: %q / %q / %d candidates",
+			gotUfrag, gotPwd, len(gotCandidates))
+	}
+}

--- a/internal/peer/icerestart_test.go
+++ b/internal/peer/icerestart_test.go
@@ -1,0 +1,237 @@
+package peer
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// A minimal but realistic browser offer: session-level origin, one bundled
+// audio section with credentials, an SSRC, and a stale candidate.
+const testRemoteOffer = "v=0\r\n" +
+	"o=- 4611731400430051336 2 IN IP4 127.0.0.1\r\n" +
+	"s=-\r\n" +
+	"t=0 0\r\n" +
+	"a=group:BUNDLE 0 1\r\n" +
+	"m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n" +
+	"c=IN IP4 0.0.0.0\r\n" +
+	"a=mid:0\r\n" +
+	"a=ice-ufrag:oldU\r\n" +
+	"a=ice-pwd:oldPassword0000000000\r\n" +
+	"a=fingerprint:sha-256 AA:BB:CC\r\n" +
+	"a=candidate:1 1 udp 2130706431 192.0.2.10 41000 typ host\r\n" +
+	"a=end-of-candidates\r\n" +
+	"a=rtpmap:111 opus/48000/2\r\n" +
+	"a=ssrc:12345 cname:stream\r\n" +
+	"a=sendrecv\r\n" +
+	"m=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\n" +
+	"c=IN IP4 0.0.0.0\r\n" +
+	"a=mid:1\r\n" +
+	"a=ice-ufrag:oldU\r\n" +
+	"a=ice-pwd:oldPassword0000000000\r\n" +
+	"a=sctp-port:5000\r\n"
+
+func TestParseICEFragment(t *testing.T) {
+	frag := "a=ice-ufrag:newU\r\n" +
+		"a=ice-pwd:newPassword111111111\r\n" +
+		"m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n" +
+		"a=mid:0\r\n" +
+		"a=candidate:1 1 udp 2130706431 198.51.100.7 51000 typ host\r\n" +
+		"a=candidate:2 1 udp 1694498815 203.0.113.9 51000 typ srflx\r\n"
+
+	ufrag, pwd, candidates, err := ParseICEFragment(frag)
+	if err != nil {
+		t.Fatalf("ParseICEFragment: %v", err)
+	}
+	if ufrag != "newU" || pwd != "newPassword111111111" {
+		t.Fatalf("credentials = %q / %q", ufrag, pwd)
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("got %d candidates, want 2: %v", len(candidates), candidates)
+	}
+	if !strings.HasPrefix(candidates[0], "1 1 udp") {
+		t.Fatalf("candidate kept its a=candidate: prefix: %q", candidates[0])
+	}
+}
+
+func TestParseICEFragmentLFOnlyAndDuplicateCredentials(t *testing.T) {
+	// Some clients send LF-only bodies, and repeat the credentials at both
+	// session and media level. The first of each wins.
+	frag := "a=ice-ufrag:newU\n" +
+		"a=ice-pwd:newPassword111111111\n" +
+		"m=audio 9 UDP/TLS/RTP/SAVPF 111\n" +
+		"a=ice-ufrag:newU\n" +
+		"a=ice-pwd:newPassword111111111\n"
+
+	ufrag, pwd, candidates, err := ParseICEFragment(frag)
+	if err != nil {
+		t.Fatalf("ParseICEFragment: %v", err)
+	}
+	if ufrag != "newU" || pwd != "newPassword111111111" {
+		t.Fatalf("credentials = %q / %q", ufrag, pwd)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("got %d candidates, want 0", len(candidates))
+	}
+}
+
+func TestParseICEFragmentTrickleOnly(t *testing.T) {
+	// Candidates with no credentials is a trickle update, not a restart.
+	frag := "m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n" +
+		"a=mid:0\r\n" +
+		"a=candidate:1 1 udp 2130706431 198.51.100.7 51000 typ host\r\n"
+
+	if _, _, _, err := ParseICEFragment(frag); !errors.Is(err, ErrNoICECredentials) {
+		t.Fatalf("err = %v, want ErrNoICECredentials", err)
+	}
+}
+
+func TestParseICEFragmentUfragWithoutPwd(t *testing.T) {
+	if _, _, _, err := ParseICEFragment("a=ice-ufrag:newU\r\n"); !errors.Is(err, ErrNoICECredentials) {
+		t.Fatalf("err = %v, want ErrNoICECredentials", err)
+	}
+}
+
+func TestRewriteICEForRestart(t *testing.T) {
+	candidates := []string{
+		"1 1 udp 2130706431 198.51.100.7 51000 typ host",
+		"2 1 udp 1694498815 203.0.113.9 51000 typ srflx",
+	}
+	got := rewriteICEForRestart(testRemoteOffer, "newU", "newPassword111111111", candidates)
+	lines := splitSDPLines(got)
+
+	if strings.Contains(got, "oldU") || strings.Contains(got, "oldPassword0000000000") {
+		t.Fatalf("old credentials survived:\n%s", got)
+	}
+	// Both media sections carry the new credentials — the datachannel section
+	// is bundled onto the audio one and must agree with it.
+	if n := strings.Count(got, "a=ice-ufrag:newU"); n != 2 {
+		t.Fatalf("a=ice-ufrag:newU appears %d times, want 2:\n%s", n, got)
+	}
+	if n := strings.Count(got, "a=ice-pwd:newPassword111111111"); n != 2 {
+		t.Fatalf("a=ice-pwd appears %d times, want 2:\n%s", n, got)
+	}
+
+	if strings.Contains(got, "192.0.2.10") {
+		t.Fatalf("stale candidate survived:\n%s", got)
+	}
+	for _, c := range candidates {
+		if !strings.Contains(got, "a=candidate:"+c) {
+			t.Fatalf("missing new candidate %q:\n%s", c, got)
+		}
+	}
+
+	// Everything Pion matches transceivers and receivers on must survive
+	// verbatim, or the restart detaches the pipeline from its track.
+	for _, must := range []string{
+		"a=mid:0", "a=mid:1", "a=ssrc:12345 cname:stream",
+		"a=fingerprint:sha-256 AA:BB:CC", "a=rtpmap:111 opus/48000/2",
+		"a=group:BUNDLE 0 1", "m=application 9 UDP/DTLS/SCTP webrtc-datachannel",
+	} {
+		if !strings.Contains(got, must) {
+			t.Fatalf("rewrite dropped %q:\n%s", must, got)
+		}
+	}
+
+	// The origin advertises a new revision of the same session.
+	if !strings.Contains(got, "o=- 4611731400430051336 3 IN IP4 127.0.0.1") {
+		t.Fatalf("origin version not bumped:\n%s", got)
+	}
+
+	// Candidates belong to the first (bundle master) media section, which is
+	// the only place Pion reads them from.
+	audioStart, appStart := -1, -1
+	for i, line := range lines {
+		if strings.HasPrefix(line, "m=audio") {
+			audioStart = i
+		}
+		if strings.HasPrefix(line, "m=application") {
+			appStart = i
+		}
+	}
+	for i, line := range lines {
+		if strings.HasPrefix(line, "a=candidate:") && (i < audioStart || i > appStart) {
+			t.Fatalf("candidate at line %d is outside the first media section:\n%s", i, got)
+		}
+	}
+}
+
+func TestRewriteICEForRestartNoCandidates(t *testing.T) {
+	// A credentials-only restart is legal — the client may trickle later, or
+	// simply have nothing new to offer.
+	got := rewriteICEForRestart(testRemoteOffer, "newU", "newPassword111111111", nil)
+	if strings.Contains(got, "a=candidate:") {
+		t.Fatalf("expected no candidates:\n%s", got)
+	}
+	if strings.Contains(got, "a=end-of-candidates") {
+		t.Fatalf("end-of-candidates without candidates:\n%s", got)
+	}
+}
+
+func TestICEFragmentFromSDP(t *testing.T) {
+	answer := "v=0\r\n" +
+		"o=- 1 2 IN IP4 127.0.0.1\r\n" +
+		"s=-\r\n" +
+		"m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n" +
+		"a=mid:0\r\n" +
+		"a=ice-ufrag:srvU\r\n" +
+		"a=ice-pwd:srvPassword2222222222\r\n" +
+		"a=candidate:1 1 udp 2130706431 198.51.100.1 39132 typ host\r\n" +
+		"m=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\n" +
+		"a=mid:1\r\n" +
+		"a=ice-ufrag:srvU\r\n" +
+		"a=candidate:9 1 udp 1 10.0.0.1 1 typ host\r\n"
+
+	got := iceFragmentFromSDP(answer)
+
+	for _, must := range []string{
+		"a=ice-ufrag:srvU",
+		"a=ice-pwd:srvPassword2222222222",
+		"m=audio 9 UDP/TLS/RTP/SAVPF 111",
+		"a=mid:0",
+		"a=candidate:1 1 udp 2130706431 198.51.100.1 39132 typ host",
+		"a=end-of-candidates",
+	} {
+		if !strings.Contains(got, must) {
+			t.Fatalf("fragment missing %q:\n%s", must, got)
+		}
+	}
+	// Only the bundle master's section is described.
+	if strings.Contains(got, "m=application") || strings.Contains(got, "a=mid:1") {
+		t.Fatalf("fragment leaked a bundled section:\n%s", got)
+	}
+	if n := strings.Count(got, "a=candidate:"); n != 1 {
+		t.Fatalf("got %d candidates, want 1:\n%s", n, got)
+	}
+}
+
+func TestBumpSDPOrigin(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "increments the session version",
+			in:   "o=- 4611731400430051336 2 IN IP4 127.0.0.1",
+			want: "o=- 4611731400430051336 3 IN IP4 127.0.0.1",
+		},
+		{
+			name: "leaves a malformed origin alone",
+			in:   "o=- 123",
+			want: "o=- 123",
+		},
+		{
+			name: "leaves a non-numeric version alone",
+			in:   "o=- 123 abc IN IP4 127.0.0.1",
+			want: "o=- 123 abc IN IP4 127.0.0.1",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bumpSDPOrigin(tc.in); got != tc.want {
+				t.Fatalf("bumpSDPOrigin = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/peer/peer.go
+++ b/internal/peer/peer.go
@@ -50,8 +50,16 @@ type Peer struct {
 	// Start) so no messages are missed.
 	OnDataChannelMessage func(msg string)
 
+	// restartMu serialises ICE restarts so two concurrent PATCHes can't
+	// interleave SetRemoteDescription / CreateAnswer on the same connection.
+	restartMu sync.Mutex
+
 	closed bool
-	mu     sync.Mutex
+	// disconnected tracks whether the transport is currently in the transient
+	// disconnected state, so a return to connected can be reported as a
+	// recovery rather than as a fresh connect.
+	disconnected bool
+	mu           sync.Mutex
 }
 
 // Global UDPMux shared by all peers — created once on first use.
@@ -214,14 +222,64 @@ func New(ctx context.Context, id string, publicIP string, turnCfg TURNConfig) (*
 
 	pc.OnConnectionStateChange(func(state webrtc.PeerConnectionState) {
 		log.Printf("[peer:%s] connection state: %s", id, state.String())
-		if state == webrtc.PeerConnectionStateFailed ||
-			state == webrtc.PeerConnectionStateDisconnected ||
-			state == webrtc.PeerConnectionStateClosed {
-			go p.Close() // must not call pc.Close() from within a Pion callback
+
+		switch state {
+		case webrtc.PeerConnectionStateDisconnected:
+			// Transient — connectivity checks are failing right now, but the
+			// connection heals on its own for the events voice agents actually
+			// see: a phone moving between Wi-Fi and cellular, a laptop changing
+			// network, a NAT rebinding after an idle gap. Pion enters this
+			// state after ~5s of silence and only escalates to Failed at ~25s.
+			// Tearing down here throws away a call that was about to recover.
+			p.markDisconnected()
+			go p.SendEvent(connectionMsg{Type: "connection", State: "reconnecting"})
+		case webrtc.PeerConnectionStateConnected:
+			// Only announce a recovery — the first connect is not news.
+			if p.clearDisconnected() {
+				log.Printf("[peer:%s] recovered from disconnected", id)
+				go p.SendEvent(connectionMsg{Type: "connection", State: "connected"})
+			}
+		default:
+			if isTerminalState(state) {
+				go p.Close() // must not call pc.Close() from within a Pion callback
+			}
 		}
 	})
 
 	return p, nil
+}
+
+// connectionMsg is the DataChannel event that tells a client the transport
+// dropped and is being re-established, so it can surface "reconnecting…"
+// instead of a silent gap.
+type connectionMsg struct {
+	Type  string `json:"type"`
+	State string `json:"state"`
+}
+
+// isTerminalState reports whether a connection state means the peer is gone
+// for good. Disconnected is deliberately absent: it is recoverable, and
+// closing on it is what turns a 10-second network blip into a lost
+// conversation.
+func isTerminalState(state webrtc.PeerConnectionState) bool {
+	return state == webrtc.PeerConnectionStateFailed ||
+		state == webrtc.PeerConnectionStateClosed
+}
+
+func (p *Peer) markDisconnected() {
+	p.mu.Lock()
+	p.disconnected = true
+	p.mu.Unlock()
+}
+
+// clearDisconnected reports whether the peer was in the disconnected state and
+// resets the flag, so a recovery is announced exactly once.
+func (p *Peer) clearDisconnected() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	was := p.disconnected
+	p.disconnected = false
+	return was
 }
 
 // LocalTrack returns the outbound audio track for the pipeline to write to.

--- a/internal/peer/peer_test.go
+++ b/internal/peer/peer_test.go
@@ -1,6 +1,51 @@
 package peer
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/pion/webrtc/v4"
+)
+
+// The connection-state policy is the difference between a network blip and a
+// lost conversation, so pin every state rather than only the interesting ones.
+func TestIsTerminalState(t *testing.T) {
+	tests := []struct {
+		state webrtc.PeerConnectionState
+		want  bool
+	}{
+		{webrtc.PeerConnectionStateNew, false},
+		{webrtc.PeerConnectionStateConnecting, false},
+		{webrtc.PeerConnectionStateConnected, false},
+		// Transient: ICE recovers from this on its own after a Wi-Fi/cellular
+		// handover or a NAT rebind, and Pion escalates to Failed if it does not.
+		{webrtc.PeerConnectionStateDisconnected, false},
+		{webrtc.PeerConnectionStateFailed, true},
+		{webrtc.PeerConnectionStateClosed, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.state.String(), func(t *testing.T) {
+			if got := isTerminalState(tc.state); got != tc.want {
+				t.Fatalf("isTerminalState(%s) = %v, want %v", tc.state, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDisconnectedFlagReportsRecoveryOnce(t *testing.T) {
+	p := &Peer{ID: "test"}
+
+	if p.clearDisconnected() {
+		t.Fatal("a peer that never disconnected reported a recovery")
+	}
+
+	p.markDisconnected()
+	if !p.clearDisconnected() {
+		t.Fatal("recovery after a disconnect was not reported")
+	}
+	if p.clearDisconnected() {
+		t.Fatal("recovery reported twice for one disconnect")
+	}
+}
 
 func TestDetectOpusChannels(t *testing.T) {
 	tests := []struct {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1,13 +1,25 @@
 package session
 
 import (
+	"context"
 	"log"
 	"sync"
+	"time"
 
 	"github.com/streamcoreai/streamcore-server/internal/config"
 	"github.com/streamcoreai/streamcore-server/internal/plugin"
 	"github.com/streamcoreai/streamcore-server/internal/rag"
 )
+
+// DefaultSessionGraceMs is how long a session with no peers is kept before the
+// reaper closes it. Long enough for a client to complete an ICE restart or
+// redial after a network change, short enough that an abandoned session is not
+// a lasting leak.
+const DefaultSessionGraceMs = 30000
+
+// reapIntervalCap bounds how often the sweep runs. A short grace period should
+// still not spin the sweep, and a long one should not delay a reap by minutes.
+const reapIntervalCap = 10 * time.Second
 
 type Manager struct {
 	cfg       *config.Config
@@ -54,6 +66,70 @@ func (m *Manager) Remove(sessionID string) {
 		delete(m.sessions, sessionID)
 		log.Printf("[manager] removed session %s", sessionID)
 	}
+}
+
+// StartReaper runs a periodic sweep that closes sessions which have had no
+// peers for longer than the grace period, until ctx is cancelled.
+//
+// Peer teardown only reaches Session.removePeer, and DELETE is the only caller
+// of Remove — so without this sweep a client that disappears mid-call (no
+// DELETE, because it can't send one) leaves its Session, its context, and
+// everything hanging off them alive for the life of the process.
+func (m *Manager) StartReaper(ctx context.Context) {
+	grace := m.grace()
+	interval := grace / 3
+	if interval < time.Second {
+		interval = time.Second
+	}
+	if interval > reapIntervalCap {
+		interval = reapIntervalCap
+	}
+
+	log.Printf("[manager] session reaper started (grace %s, sweep %s)", grace, interval)
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case now := <-ticker.C:
+				m.reap(now)
+			}
+		}
+	}()
+}
+
+// reap closes every session that has been idle since before now-grace.
+func (m *Manager) reap(now time.Time) {
+	grace := m.grace()
+
+	m.mu.Lock()
+	var expired []*Session
+	for id, s := range m.sessions {
+		idle := s.IdleSince()
+		if idle.IsZero() || now.Sub(idle) < grace {
+			continue
+		}
+		expired = append(expired, s)
+		delete(m.sessions, id)
+	}
+	m.mu.Unlock()
+
+	// Closed outside the lock: teardown blocks on DTLS/ICE shutdown and must
+	// not stall a concurrent GetOrCreate.
+	for _, s := range expired {
+		log.Printf("[manager] reaping idle session %s", s.ID)
+		s.Close()
+	}
+}
+
+func (m *Manager) grace() time.Duration {
+	ms := DefaultSessionGraceMs
+	if m.cfg != nil && m.cfg.Server.SessionGraceMs > 0 {
+		ms = m.cfg.Server.SessionGraceMs
+	}
+	return time.Duration(ms) * time.Millisecond
 }
 
 func (m *Manager) CloseAll() {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1,0 +1,141 @@
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/streamcoreai/streamcore-server/internal/config"
+)
+
+func testManager(graceMs int) *Manager {
+	cfg := &config.Config{}
+	cfg.Server.SessionGraceMs = graceMs
+	return NewManager(cfg, nil, nil)
+}
+
+func TestReapCollectsSessionsIdlePastTheGrace(t *testing.T) {
+	m := testManager(1000)
+	s := m.GetOrCreate("gone")
+
+	// A client that drops off the network never sends DELETE, so the session
+	// sits at zero peers with nothing else to collect it.
+	if s.PeerCount() != 0 {
+		t.Fatalf("PeerCount = %d, want 0", s.PeerCount())
+	}
+
+	now := time.Now()
+	s.mu.Lock()
+	s.idleSince = now.Add(-2 * time.Second)
+	s.mu.Unlock()
+
+	m.reap(now)
+
+	if got := m.Get("gone"); got != nil {
+		t.Fatal("idle session survived the reap")
+	}
+	if s.ctx.Err() == nil {
+		t.Fatal("reaped session's context was not cancelled")
+	}
+}
+
+func TestReapKeepsSessionsInsideTheGrace(t *testing.T) {
+	// The grace window is the whole point: it is what leaves the door open for
+	// an ICE restart or a redial after a transport drop.
+	m := testManager(30000)
+	s := m.GetOrCreate("recovering")
+
+	now := time.Now()
+	s.mu.Lock()
+	s.idleSince = now.Add(-5 * time.Second)
+	s.mu.Unlock()
+
+	m.reap(now)
+
+	if m.Get("recovering") != s {
+		t.Fatal("session inside the grace window was reaped")
+	}
+	if s.ctx.Err() != nil {
+		t.Fatal("session inside the grace window had its context cancelled")
+	}
+}
+
+func TestReapSkipsSessionsWithPeers(t *testing.T) {
+	m := testManager(1000)
+	s := m.GetOrCreate("busy")
+
+	// Stand in for a live peer without building a PeerConnection: what reap
+	// reads is idleSince, which AddPeer zeroes.
+	s.mu.Lock()
+	s.peers["p1"] = nil
+	s.idleSince = time.Time{}
+	s.mu.Unlock()
+
+	m.reap(time.Now().Add(time.Hour))
+
+	if m.Get("busy") != s {
+		t.Fatal("session with a peer was reaped")
+	}
+}
+
+func TestRemovePeerStartsTheIdleClock(t *testing.T) {
+	m := testManager(1000)
+	s := m.GetOrCreate("draining")
+
+	s.mu.Lock()
+	s.peers["p1"] = nil
+	s.peers["p2"] = nil
+	s.idleSince = time.Time{}
+	s.mu.Unlock()
+
+	s.removePeer("p1")
+	if !s.IdleSince().IsZero() {
+		t.Fatal("idle clock started while a peer was still connected")
+	}
+
+	s.removePeer("p2")
+	if s.IdleSince().IsZero() {
+		t.Fatal("idle clock did not start when the last peer left")
+	}
+}
+
+func TestRemoveStaysIdempotent(t *testing.T) {
+	// Documented behaviour of the DELETE path — removing twice must not panic
+	// or report differently.
+	m := testManager(1000)
+	m.GetOrCreate("bye")
+
+	m.Remove("bye")
+	m.Remove("bye")
+	m.Remove("never-existed")
+
+	if m.Get("bye") != nil {
+		t.Fatal("session survived Remove")
+	}
+}
+
+func TestETagRotatesOnRestart(t *testing.T) {
+	m := testManager(1000)
+	s := m.GetOrCreate("abc")
+
+	if want := `"abc"`; s.ETag() != want {
+		t.Fatalf("initial ETag = %s, want %s", s.ETag(), want)
+	}
+
+	rotated := s.RotateETag()
+	if rotated == `"abc"` {
+		t.Fatal("ETag did not change after a restart")
+	}
+	if s.ETag() != rotated {
+		t.Fatalf("ETag() = %s, want the rotated %s", s.ETag(), rotated)
+	}
+}
+
+func TestStartReaperStopsWithContext(t *testing.T) {
+	m := testManager(1000)
+	ctx, cancel := context.WithCancel(context.Background())
+	m.StartReaper(ctx)
+	cancel()
+	// Nothing to assert beyond "does not panic or leak a ticker" — the sweep
+	// itself is covered by the reap tests, which are deterministic.
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"log"
 	"sync"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/streamcoreai/streamcore-server/internal/config"
 	"github.com/streamcoreai/streamcore-server/internal/peer"
 	"github.com/streamcoreai/streamcore-server/internal/pipeline"
@@ -22,6 +24,16 @@ type Session struct {
 
 	mu    sync.Mutex
 	peers map[string]*peer.Peer
+	// idleSince is when the session last dropped to zero peers, or the zero
+	// time while it has any. The Manager reaps sessions that stay idle past
+	// the grace period — without it, a client that vanishes without sending
+	// DELETE (which is exactly what a dropped connection is) leaves an empty
+	// Session in the map forever.
+	idleSince time.Time
+	// etag identifies the current ICE session (RFC 9725 §4.3.1). It rotates on
+	// every successful ICE restart so a client racing two restarts can tell
+	// which generation it is patching.
+	etag string
 }
 
 func NewSession(id string, cfg *config.Config, pluginMgr *plugin.Manager, ragClient rag.Client) *Session {
@@ -34,6 +46,10 @@ func NewSession(id string, cfg *config.Config, pluginMgr *plugin.Manager, ragCli
 		ctx:       ctx,
 		cancel:    cancel,
 		peers:     make(map[string]*peer.Peer),
+		// A session that is created and never gets a peer — a POST that fails
+		// between GetOrCreate and AddPeer — is idle from birth.
+		idleSince: time.Now(),
+		etag:      `"` + id + `"`,
 	}
 }
 
@@ -58,6 +74,7 @@ func (s *Session) AddPeer(peerID string, direction string) (*peer.Peer, error) {
 	}
 
 	s.peers[peerID] = p
+	s.idleSince = time.Time{}
 
 	// Wait for the remote track to arrive, then start the pipeline.
 	go func() {
@@ -100,6 +117,9 @@ func (s *Session) removePeer(peerID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.peers, peerID)
+	if len(s.peers) == 0 {
+		s.idleSince = time.Now()
+	}
 	log.Printf("[session:%s] peer %s removed, %d peers remaining", s.ID, peerID, len(s.peers))
 }
 
@@ -107,6 +127,32 @@ func (s *Session) PeerCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.peers)
+}
+
+// IdleSince returns when the session last dropped to zero peers, or the zero
+// time if it still has any. The grace period it starts is what keeps the door
+// open for an ICE restart or a client redial after a transport drop.
+func (s *Session) IdleSince() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.idleSince
+}
+
+// ETag returns the current ICE-session ETag, quoted and ready for the header.
+func (s *Session) ETag() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.etag
+}
+
+// RotateETag issues a new ICE-session ETag and returns it. Called after a
+// successful ICE restart: the previous tag now refers to a generation that no
+// longer exists, so a PATCH still carrying it is stale.
+func (s *Session) RotateETag() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.etag = `"` + uuid.NewString() + `"`
+	return s.etag
 }
 
 func (s *Session) Close() {

--- a/internal/signaling/handler.go
+++ b/internal/signaling/handler.go
@@ -1,6 +1,7 @@
 package signaling
 
 import (
+	"errors"
 	"io"
 	"log"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/streamcoreai/streamcore-server/internal/peer"
 	"github.com/streamcoreai/streamcore-server/internal/session"
 )
 
@@ -16,6 +18,7 @@ import (
 // RFC 9725. It handles two URL patterns:
 //
 //	POST   /whip                   – Session setup (SDP offer/answer), returns sessionId
+//	PATCH  /whip/{sessionId}       – ICE restart (application/trickle-ice-sdpfrag)
 //	DELETE /whip/{sessionId}       – Session teardown
 //	OPTIONS (any)                  – CORS preflight
 //
@@ -27,8 +30,19 @@ import (
 // abusive burst.
 const defaultWhipRateLimit = 30
 
+// defaultRestartRateLimit caps ICE restarts per client IP per minute, on its
+// own bucket so a client recovering from a flapping network never eats into
+// its budget for opening new sessions. A restart re-gathers candidates, so it
+// is not free, but a device hopping networks legitimately fires several.
+const defaultRestartRateLimit = 60
+
+// maxICEFragmentBytes bounds a PATCH body. An sdpfrag is credentials plus a
+// handful of candidate lines; anything near this is not one.
+const maxICEFragmentBytes = 64 * 1024
+
 func NewWHIPHandler(sm *session.Manager) http.HandlerFunc {
 	limiter := newWidgetRateLimiter(defaultWhipRateLimit, time.Minute)
+	restartLimiter := newWidgetRateLimiter(defaultRestartRateLimit, time.Minute)
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Parse path segment: /whip or /whip/{sessionId}
@@ -39,6 +53,8 @@ func NewWHIPHandler(sm *session.Manager) http.HandlerFunc {
 		case http.MethodOptions:
 			// RFC 9725 §4.2: MUST support OPTIONS for CORS.
 			w.Header().Set("Accept-Post", "application/sdp")
+			// RFC 9725 §4.4: advertises that ICE restart is available here.
+			w.Header().Set("Accept-Patch", peer.ICEFragmentContentType)
 			w.WriteHeader(http.StatusNoContent)
 
 		case http.MethodPost:
@@ -49,6 +65,19 @@ func NewWHIPHandler(sm *session.Manager) http.HandlerFunc {
 				return
 			}
 			handleWHIPPost(w, r, sm)
+
+		case http.MethodPatch:
+			if trimmed == "" {
+				http.Error(w, "session URL required: /whip/{sessionId}", http.StatusBadRequest)
+				return
+			}
+			if ok, retryAfter := restartLimiter.Allow(clientIP(r)); !ok {
+				w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+				log.Printf("[whip] rate limited ICE restart from %s", clientIP(r))
+				http.Error(w, "too many ICE restart requests", http.StatusTooManyRequests)
+				return
+			}
+			handleWHIPPatch(w, r, sm, trimmed)
 
 		case http.MethodDelete:
 			if trimmed == "" {
@@ -115,9 +144,81 @@ func handleWHIPPost(w http.ResponseWriter, r *http.Request, sm *session.Manager)
 	// RFC 9725 §4.3.1: ETag identifying the ICE session.
 	w.Header().Set("Content-Type", "application/sdp")
 	w.Header().Set("Location", sessionURL)
-	w.Header().Set("ETag", `"`+sessionID+`"`)
+	w.Header().Set("ETag", ses.ETag())
+	// RFC 9725 §4.4: tells the client it can recover a dropped connection with
+	// an ICE restart instead of redialling and losing the conversation.
+	w.Header().Set("Accept-Patch", peer.ICEFragmentContentType)
 	w.WriteHeader(http.StatusCreated)
 	w.Write([]byte(answerSDP))
+}
+
+// handleWHIPPatch implements RFC 9725 §4.4.2 ICE restart.
+//
+// The client sends its new ICE credentials and candidates as an sdpfrag; the
+// server applies them to the *existing* PeerConnection and replies with its
+// own. Nothing above the transport is disturbed — same session, same pipeline,
+// same conversation — which is the entire reason to recover this way rather
+// than let the client POST a fresh offer and start over.
+func handleWHIPPatch(w http.ResponseWriter, r *http.Request, sm *session.Manager, sessionID string) {
+	ct := r.Header.Get("Content-Type")
+	if !strings.HasPrefix(ct, peer.ICEFragmentContentType) {
+		w.Header().Set("Accept-Patch", peer.ICEFragmentContentType)
+		http.Error(w, "Content-Type must be "+peer.ICEFragmentContentType, http.StatusUnsupportedMediaType)
+		return
+	}
+
+	ses := sm.Get(sessionID)
+	if ses == nil {
+		http.Error(w, "unknown session", http.StatusNotFound)
+		return
+	}
+
+	// RFC 9725 §4.4.2: If-Match carries the ETag of the ICE session being
+	// restarted. A stale tag means another restart landed first and this one is
+	// patching a generation that no longer exists.
+	if match := r.Header.Get("If-Match"); match != "" && match != "*" && match != ses.ETag() {
+		w.Header().Set("ETag", ses.ETag())
+		http.Error(w, "ETag does not match the current ICE session", http.StatusPreconditionFailed)
+		return
+	}
+
+	// The peer is registered under the session ID — see handleWHIPPost.
+	p := ses.GetPeer(sessionID)
+	if p == nil {
+		http.Error(w, "session has no peer", http.StatusNotFound)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxICEFragmentBytes))
+	if err != nil {
+		http.Error(w, "failed to read ICE fragment", http.StatusBadRequest)
+		return
+	}
+
+	answerFragment, err := p.RestartICE(string(body))
+	switch {
+	case errors.Is(err, peer.ErrNoICECredentials):
+		// Trickle-only PATCH. RFC 9725 §4.4.1 makes trickle ICE optional and
+		// 405 is the prescribed way to decline it; the client falls back to
+		// gathering fully before it patches.
+		w.Header().Set("Accept-Patch", peer.ICEFragmentContentType)
+		http.Error(w, "trickle ICE is not supported; send an ICE restart fragment", http.StatusMethodNotAllowed)
+		return
+	case errors.Is(err, peer.ErrPeerClosed), errors.Is(err, peer.ErrNoRemoteDescription):
+		http.Error(w, "session is not restartable", http.StatusConflict)
+		return
+	case err != nil:
+		log.Printf("[whip] ICE restart error for %s: %v", sessionID, err)
+		http.Error(w, "failed to restart ICE", http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("[whip] ICE restart for session %s", sessionID)
+
+	w.Header().Set("Content-Type", peer.ICEFragmentContentType)
+	w.Header().Set("ETag", ses.RotateETag())
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(answerFragment))
 }
 
 // handleWHIPDelete implements RFC 9725 §4.2 session teardown.

--- a/internal/signaling/handler_test.go
+++ b/internal/signaling/handler_test.go
@@ -1,0 +1,188 @@
+package signaling
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/streamcoreai/streamcore-server/internal/config"
+	"github.com/streamcoreai/streamcore-server/internal/peer"
+	"github.com/streamcoreai/streamcore-server/internal/session"
+)
+
+const restartFragment = "a=ice-ufrag:newU\r\n" +
+	"a=ice-pwd:newPassword111111111\r\n" +
+	"m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n" +
+	"a=mid:0\r\n" +
+	"a=candidate:1 1 udp 2130706431 198.51.100.7 51000 typ host\r\n"
+
+func testHandler(t *testing.T) (http.HandlerFunc, *session.Manager) {
+	t.Helper()
+	sm := session.NewManager(&config.Config{}, nil, nil)
+	t.Cleanup(sm.CloseAll)
+	return NewWHIPHandler(sm), sm
+}
+
+func patch(t *testing.T, h http.HandlerFunc, path, contentType, ifMatch, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPatch, path, strings.NewReader(body))
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	if ifMatch != "" {
+		req.Header.Set("If-Match", ifMatch)
+	}
+	rec := httptest.NewRecorder()
+	h(rec, req)
+	return rec
+}
+
+func TestPatchWithoutSessionID(t *testing.T) {
+	h, _ := testHandler(t)
+	rec := patch(t, h, "/whip", peer.ICEFragmentContentType, "", restartFragment)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestPatchRejectsWrongContentType(t *testing.T) {
+	h, sm := testHandler(t)
+	sm.GetOrCreate("s1")
+
+	rec := patch(t, h, "/whip/s1", "application/sdp", "", restartFragment)
+	if rec.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("status = %d, want 415", rec.Code)
+	}
+	if got := rec.Header().Get("Accept-Patch"); got != peer.ICEFragmentContentType {
+		t.Fatalf("Accept-Patch = %q, want %q", got, peer.ICEFragmentContentType)
+	}
+}
+
+func TestPatchUnknownSession(t *testing.T) {
+	h, _ := testHandler(t)
+	rec := patch(t, h, "/whip/nope", peer.ICEFragmentContentType, "", restartFragment)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestPatchStaleIfMatchIsRejected(t *testing.T) {
+	h, sm := testHandler(t)
+	s := sm.GetOrCreate("s1")
+
+	// The client is patching the ICE session that a previous restart replaced.
+	s.RotateETag()
+
+	rec := patch(t, h, "/whip/s1", peer.ICEFragmentContentType, `"s1"`, restartFragment)
+	if rec.Code != http.StatusPreconditionFailed {
+		t.Fatalf("status = %d, want 412", rec.Code)
+	}
+	if got := rec.Header().Get("ETag"); got != s.ETag() {
+		t.Fatalf("ETag = %q, want the current %q", got, s.ETag())
+	}
+}
+
+func TestPatchMatchingIfMatchPassesThePrecondition(t *testing.T) {
+	h, sm := testHandler(t)
+	s := sm.GetOrCreate("s1")
+
+	// No peer was ever added, so this stops at the peer lookup — the point is
+	// that a matching ETag does not trip the precondition.
+	rec := patch(t, h, "/whip/s1", peer.ICEFragmentContentType, s.ETag(), restartFragment)
+	if rec.Code == http.StatusPreconditionFailed {
+		t.Fatal("a matching If-Match was rejected")
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (session has no peer)", rec.Code)
+	}
+}
+
+func TestPatchWildcardIfMatchPassesThePrecondition(t *testing.T) {
+	h, sm := testHandler(t)
+	s := sm.GetOrCreate("s1")
+	s.RotateETag()
+
+	rec := patch(t, h, "/whip/s1", peer.ICEFragmentContentType, "*", restartFragment)
+	if rec.Code == http.StatusPreconditionFailed {
+		t.Fatal("If-Match: * was rejected")
+	}
+}
+
+func TestPatchTrickleOnlyIsDeclined(t *testing.T) {
+	h, sm := testHandler(t)
+	s := sm.GetOrCreate("s1")
+	if _, err := s.AddPeer("s1", ""); err != nil {
+		t.Fatalf("AddPeer: %v", err)
+	}
+
+	// Candidates but no credentials: a trickle update. Trickle ICE is optional
+	// per RFC 9725 §4.4.1 and 405 is how a server declines it.
+	trickle := "m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n" +
+		"a=mid:0\r\n" +
+		"a=candidate:1 1 udp 2130706431 198.51.100.7 51000 typ host\r\n"
+
+	rec := patch(t, h, "/whip/s1", peer.ICEFragmentContentType, "", trickle)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+	if got := rec.Header().Get("Accept-Patch"); got != peer.ICEFragmentContentType {
+		t.Fatalf("Accept-Patch = %q, want %q", got, peer.ICEFragmentContentType)
+	}
+}
+
+func TestPatchOnPeerWithoutNegotiation(t *testing.T) {
+	h, sm := testHandler(t)
+	s := sm.GetOrCreate("s1")
+	if _, err := s.AddPeer("s1", ""); err != nil {
+		t.Fatalf("AddPeer: %v", err)
+	}
+
+	// A well-formed restart against a peer that never completed offer/answer
+	// has nothing to restart, which is a conflict rather than a server fault.
+	rec := patch(t, h, "/whip/s1", peer.ICEFragmentContentType, "", restartFragment)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", rec.Code)
+	}
+}
+
+func TestOptionsAdvertisesICERestart(t *testing.T) {
+	h, _ := testHandler(t)
+	req := httptest.NewRequest(http.MethodOptions, "/whip", nil)
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+	if got := rec.Header().Get("Accept-Post"); got != "application/sdp" {
+		t.Fatalf("Accept-Post = %q", got)
+	}
+	if got := rec.Header().Get("Accept-Patch"); got != peer.ICEFragmentContentType {
+		t.Fatalf("Accept-Patch = %q, want %q", got, peer.ICEFragmentContentType)
+	}
+}
+
+func TestDeleteStaysIdempotent(t *testing.T) {
+	h, sm := testHandler(t)
+	sm.GetOrCreate("s1")
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodDelete, "/whip/s1", nil)
+		rec := httptest.NewRecorder()
+		h(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("DELETE #%d status = %d, want 200", i+1, rec.Code)
+		}
+	}
+}
+
+func TestUnsupportedMethodStillReturns405(t *testing.T) {
+	h, _ := testHandler(t)
+	req := httptest.NewRequest(http.MethodPut, "/whip/s1", nil)
+	rec := httptest.NewRecorder()
+	h(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -98,6 +98,10 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	// Sessions are only removed explicitly by DELETE, which a client that
+	// dropped off the network can never send. The reaper collects those.
+	sm.StartReaper(ctx)
+
 	go func() {
 		log.Printf("Voice agent server listening on :%s", cfg.Server.Port)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
@@ -131,9 +135,9 @@ func main() {
 func corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
-		w.Header().Set("Access-Control-Expose-Headers", "Location, ETag")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, If-Match")
+		w.Header().Set("Access-Control-Expose-Headers", "Location, ETag, Accept-Patch")
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
 			return


### PR DESCRIPTION
This pull request introduces ICE restart support to the signaling protocol and server, allowing clients to recover from network changes (like switching networks or NAT rebinding) without losing their session or conversation state. It also adds a configurable session grace period to prevent premature teardown of sessions during temporary disconnects, and updates documentation (including Chinese translations) to describe these new features. The most significant changes are grouped below.

**ICE Restart Support and Protocol Enhancements:**

* Added support for ICE restart via a new `PATCH /whip/{sessionId}` endpoint, enabling clients to recover from network handovers or NAT rebinding on the same session without losing conversation or pipeline state. This includes new request/response flows, error handling, and SDP fragment parsing and rewriting. (`internal/peer/icerestart.go`, `docs/protocol.md`, `docs/protocol.zh-CN.md`, [[1]](diffhunk://#diff-22634edea93be238f46f99eeaab282be9ba965bcaad98e987cb2557cda2c3195L11-R68) [[2]](diffhunk://#diff-22634edea93be238f46f99eeaab282be9ba965bcaad98e987cb2557cda2c3195R80) [[3]](diffhunk://#diff-93859aa9820f5ea91721f2a6c09dfe4fa6532e7a64e07697845496704499f457L11-R68) [[4]](diffhunk://#diff-93859aa9820f5ea91721f2a6c09dfe4fa6532e7a64e07697845496704499f457R80) [[5]](diffhunk://#diff-3bb86da8ba2541a3eba8dfbec03184e7c1bc7529063efa681dc8c9746771387bR1-R271)
* Updated protocol documentation to detail the ICE restart flow, new rate limits for `PATCH`, and the new `connection` event for signaling reconnecting/connected states to clients. (`docs/protocol.md`, `docs/protocol.zh-CN.md`, [[1]](diffhunk://#diff-22634edea93be238f46f99eeaab282be9ba965bcaad98e987cb2557cda2c3195L11-R68) [[2]](diffhunk://#diff-22634edea93be238f46f99eeaab282be9ba965bcaad98e987cb2557cda2c3195R80) [[3]](diffhunk://#diff-93859aa9820f5ea91721f2a6c09dfe4fa6532e7a64e07697845496704499f457L11-R68) [[4]](diffhunk://#diff-93859aa9820f5ea91721f2a6c09dfe4fa6532e7a64e07697845496704499f457R80)

**Session Lifetime and Grace Period:**

* Introduced a configurable `session_grace_ms` option (default 30 seconds) that determines how long a session with no connected peers is kept before being reaped, allowing time for ICE restart or redial without losing the session. (`internal/config/config.go`, `config.toml.example`, `docs/configuration.md`, `docs/configuration.zh-CN.md`, [[1]](diffhunk://#diff-514f3c6049dd26198894991be37accf7786d0b38e3a1fc21f201c14be271b642R9) [[2]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R14) [[3]](diffhunk://#diff-d1e97b5eeb786f7481b6488bb3cdbfbe9f3ac0904f3e329374ac7b60553092b2R14) [[4]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR84-R90) [[5]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR323-R325)

**Documentation and Capability Updates:**

* Updated English and Chinese capabilities documentation to reflect ICE restart support and session reaping after a grace period, making the new behavior clear to users and developers. (`docs/capabilities.md`, `docs/capabilities.zh-CN.md`, [[1]](diffhunk://#diff-9c150cbd3345abc014a68998d0d7e7fb531fc7844e719d795dea9ecac02993a6R69-R70) [[2]](diffhunk://#diff-baae98065ae47c402473ae953d4af04545d88bc943cc7b19db66722151836db4R69-R70)

These changes together make the system more robust against transient network failures and clarify the protocol and configuration for both users and developers.…loses #38