### PR TITLE
Allow the openai provider to target any OpenAI-compatible endpoint

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -39,7 +39,7 @@ provider = "deepgram"   # Supported: deepgram, openai, assemblyai, vibevoice
 provider = "openai"     # Supported: openai, ollama, agent
 
 [tts]
-provider = "cartesia"   # Supported: cartesia, deepgram, elevenlabs, speechify, vibevoice
+provider = "cartesia"   # Supported: cartesia, deepgram, elevenlabs, mimo, minimax, speechify, vibevoice
 
 # Provider credentials
 
@@ -93,6 +93,13 @@ keyterms = []           # Bias the decoder toward domain words
 api_key = ""            # Required for LLM, and for OpenAI STT if selected
 model = "gpt-4o-mini"
 system_prompt = "You are a helpful AI voice assistant. Keep your responses concise and conversational."
+base_url = ""           # Optional. Any endpoint speaking OpenAI's protocol — DeepSeek
+                        # (https://api.deepseek.com/v1, model deepseek-chat), Moonshot
+                        # (https://api.moonshot.cn/v1), Qwen, MiniMax. Empty targets OpenAI.
+                        # Prefer a non-reasoning model here: reasoning models emit their
+                        # thinking before the answer, and on a voice call that is dead air.
+                        # Note this is unrelated to [ollama] base_url, which speaks Ollama's
+                        # own protocol — the two are not interchangeable
 
 [ollama]
 base_url = "http://localhost:11434"  # Ollama server URL

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -225,6 +225,13 @@ type OpenAIConfig struct {
 	APIKey       string `toml:"api_key"`
 	Model        string `toml:"model"`
 	SystemPrompt string `toml:"system_prompt"`
+	// BaseURL points the client at an OpenAI-compatible endpoint other than
+	// OpenAI's own — DeepSeek, Moonshot, Qwen and MiniMax all speak the same
+	// protocol and differ only by host and model name. Empty uses OpenAI.
+	//
+	// This is not the same as the ollama provider's base_url, which speaks
+	// Ollama's own /api/chat protocol; the two are not interchangeable.
+	BaseURL string `toml:"base_url"`
 }
 
 type OllamaConfig struct {

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -47,7 +47,7 @@ func NewClient(cfg *config.Config) (Client, error) {
 		if cfg.OpenAI.APIKey == "" {
 			return nil, fmt.Errorf("llm provider %q requires [openai] api_key to be set", cfg.LLM.Provider)
 		}
-		return NewOpenAIClient(cfg.OpenAI.APIKey, cfg.OpenAI.Model, cfg.OpenAI.SystemPrompt), nil
+		return NewOpenAIClient(cfg.OpenAI.APIKey, cfg.OpenAI.Model, cfg.OpenAI.SystemPrompt, cfg.OpenAI.BaseURL), nil
 	case "ollama":
 		return NewOllamaClient(cfg.Ollama.BaseURL, cfg.Ollama.Model, cfg.Ollama.SystemPrompt)
 	case "agent":

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -25,7 +25,19 @@ type openaiClient struct {
 	toolNameMap  map[string]string // sanitized name → original name
 }
 
-func NewOpenAIClient(apiKey, model, systemPrompt string) Client {
+// resolveOpenAIBaseURL normalises a configured endpoint, returning "" when the
+// caller should keep the library default (OpenAI itself).
+//
+// The trailing slash matters: the SDK joins paths onto this string, so
+// "https://host/v1/" would request "https://host/v1//chat/completions", which
+// most gateways answer with a 404 rather than a redirect.
+func resolveOpenAIBaseURL(baseURL string) string {
+	return strings.TrimRight(strings.TrimSpace(baseURL), "/")
+}
+
+// NewOpenAIClient creates a chat client for OpenAI or any endpoint speaking
+// its protocol. An empty baseURL targets OpenAI itself.
+func NewOpenAIClient(apiKey, model, systemPrompt, baseURL string) Client {
 	// Keep a warm connection pool so turns within a call (and the first turn
 	// after an idle gap) reuse an established TLS+HTTP/2 connection instead of
 	// paying a fresh handshake on the live audio path.
@@ -37,6 +49,9 @@ func NewOpenAIClient(apiKey, model, systemPrompt string) Client {
 	}
 	cfg := openai.DefaultConfig(apiKey)
 	cfg.HTTPClient = &http.Client{Transport: transport, Timeout: 60 * time.Second}
+	if resolved := resolveOpenAIBaseURL(baseURL); resolved != "" {
+		cfg.BaseURL = resolved
+	}
 
 	c := &openaiClient{
 		client:       openai.NewClientWithConfig(cfg),
@@ -49,7 +64,8 @@ func NewOpenAIClient(apiKey, model, systemPrompt string) Client {
 
 	// Prime the connection pool in the background: ListModels is unbilled and
 	// establishes the TLS+H2 connection the first real turn will reuse. Errors
-	// are non-fatal (offline/dev) — this is best-effort warmup only.
+	// are non-fatal (offline/dev, or a compatible endpoint that does not
+	// implement /models) — this is best-effort warmup only.
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()

--- a/internal/llm/openai_baseurl_test.go
+++ b/internal/llm/openai_baseurl_test.go
@@ -1,0 +1,112 @@
+package llm
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeOpenAICompatible stands in for a third-party endpoint speaking OpenAI's
+// protocol. It records the path it was called on and replies with a minimal
+// streamed completion.
+type fakeOpenAICompatible struct {
+	server *httptest.Server
+
+	// Guarded because the client fires a background ListModels warmup whose
+	// request races the one the test makes.
+	mu      sync.Mutex
+	gotPath string
+	gotAuth string
+}
+
+func newFakeOpenAICompatible(t *testing.T) *fakeOpenAICompatible {
+	t.Helper()
+	f := &fakeOpenAICompatible{}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The warmup call is deliberately not recorded: it would overwrite the
+		// path under assertion with /v1/models.
+		if strings.HasSuffix(r.URL.Path, "/models") {
+			io.WriteString(w, `{"object":"list","data":[]}`)
+			return
+		}
+
+		f.mu.Lock()
+		f.gotPath = r.URL.Path
+		f.gotAuth = r.Header.Get("Authorization")
+		f.mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n")
+		io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func (f *fakeOpenAICompatible) recorded() (path, auth string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.gotPath, f.gotAuth
+}
+
+// A configured base URL has to actually redirect traffic. Without this the
+// client silently keeps talking to api.openai.com, and the failure surfaces as
+// an authentication error against a key that belongs to a different provider —
+// which reads like a bad key rather than an ignored setting.
+func TestOpenAIBaseURLRedirectsRequests(t *testing.T) {
+	f := newFakeOpenAICompatible(t)
+
+	c := NewOpenAIClient("test-key", "deepseek-chat", "sys", f.server.URL+"/v1")
+	if _, err := c.Chat(context.Background(), "hello", nil, nil); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	path, auth := f.recorded()
+	if path != "/v1/chat/completions" {
+		t.Errorf("request path = %q, want /v1/chat/completions", path)
+	}
+	if auth != "Bearer test-key" {
+		t.Errorf("Authorization = %q, want the key forwarded", auth)
+	}
+}
+
+// A trailing slash in the configured URL must not produce a doubled separator:
+// "https://host/v1//chat/completions" is a 404 on most gateways.
+func TestOpenAIBaseURLTrimsTrailingSlash(t *testing.T) {
+	f := newFakeOpenAICompatible(t)
+
+	c := NewOpenAIClient("k", "m", "sys", f.server.URL+"/v1/")
+	if _, err := c.Chat(context.Background(), "hello", nil, nil); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	path, _ := f.recorded()
+	if strings.Contains(path, "//") {
+		t.Errorf("request path = %q, want no doubled slash", path)
+	}
+	if path != "/v1/chat/completions" {
+		t.Errorf("request path = %q, want /v1/chat/completions", path)
+	}
+}
+
+// An unset or blank base URL must resolve to "", which is what leaves the SDK
+// pointing at OpenAI — existing deployments are untouched by this option.
+func TestResolveOpenAIBaseURL(t *testing.T) {
+	cases := map[string]string{
+		"":                             "",
+		"   ":                          "",
+		"https://api.deepseek.com/v1":  "https://api.deepseek.com/v1",
+		"https://api.deepseek.com/v1/": "https://api.deepseek.com/v1",
+		"https://api.moonshot.cn/v1//": "https://api.moonshot.cn/v1",
+		"  https://host/v1  ":          "https://host/v1",
+	}
+	for in, want := range cases {
+		if got := resolveOpenAIBaseURL(in); got != want {
+			t.Errorf("resolveOpenAIBaseURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Adds `[openai] base_url`, so the provider can be pointed at DeepSeek, Moonshot, Qwen, MiniMax, or any other host speaking OpenAI's protocol:

```toml
[llm]
provider = "openai"

[openai]
base_url = "https://api.deepseek.com/v1"
api_key = "sk-..."
model = "deepseek-chat"
```

The client already had the field — `DefaultConfig`'s value was simply never overridden, so there was no way for the option to reach it. Empty keeps the current behaviour exactly.

## Why the ollama provider does not already cover this

`[ollama] base_url` speaks Ollama's own `/api/chat` protocol, via the official Ollama SDK. None of the hosted Chinese providers accept that — they are all OpenAI-shaped. So "point it at a compatible endpoint" was reachable only for self-hosted Ollama, not for the providers people actually mean when they ask.

## A note the docs now make explicit: prefer a non-reasoning model

Reasoning models emit their thinking ahead of the answer. A chat UI renders that as a spinner; a voice call renders it as dead air, which is the one thing a conversational agent cannot afford.

Measured while testing this:

| model | first content token | thinking |
|---|---|---|
| `deepseek-chat` | **0.52 s** streamed | none |
| MiniMax `M2` | ~1.5 s | 60-90 chars, inside `content` |
| MiniMax `M2.5` | ~4.6 s | 862 chars of English reasoning for a 52-char answer |

MiniMax is worth calling out because it has no way out: all eight of its models reason, and none of `reasoning_effort`, `enable_thinking`, `thinking: {type: disabled}`, `chat_template_kwargs` or three other candidates changed that — each was accepted without error and ignored. Its thinking arrives inside `content` wrapped in `<think>` tags, so a voice agent pointed at it reads the reasoning aloud.

Handling that (stripping `<think>` from a token stream, without swallowing the answer when the closing tag never arrives) is a separate concern from this change, and I have left it out rather than bundle it. The config comment steers people to a non-reasoning model, which avoids the problem entirely.

## Trailing slash

`resolveOpenAIBaseURL` trims it because the SDK joins paths onto this string: `https://host/v1/` would request `https://host/v1//chat/completions`, which most gateways answer with a 404 rather than a redirect. Easy to configure by accident, and the resulting error says nothing about the cause.

## Tests

Three cases in `openai_baseurl_test.go`, running against an `httptest` stand-in — no key, no network:

- a configured base URL actually redirects the request, and forwards the key
- a trailing slash does not produce a doubled separator
- blank and whitespace-only values resolve to "", leaving the SDK on OpenAI

The fake deliberately does not record the `/models` request: `NewOpenAIClient` fires a background `ListModels` warmup, and it raced the assertion — the first version of this test passed alone and failed under `go test ./...`. Worth knowing about that warmup generally, since a compatible endpoint without `/models` will log one `connection warmup skipped` line per client.

## Also in here

`config.toml.example` listed `cartesia, deepgram, elevenlabs, speechify, vibevoice` for `tts.provider`, omitting `minimax` and `mimo`. The drift test only checks that fields are documented, not that a comment's enumeration is complete, so it did not catch this.

## Verification

- End to end on a Mandarin call — Deepgram in, `deepseek-chat`, MiMo out — replies landing about a second after the transcript finalised, across several turns.
- `go build ./...`, `go vet ./...`, `go test ./...` and `go test -race ./internal/llm/` all pass.
