### PR TITLE
added resourceId

### DIFF
--- a/docs/bring-your-own-agent.md
+++ b/docs/bring-your-own-agent.md
@@ -31,6 +31,7 @@ Each request is JSON:
 ```json
 {
   "session_id": "9f2c…",
+  "resource_id": "user_8891",
   "type": "chat",
   "text": "what the caller said",
   "system": "skill text appended by the server, if any"
@@ -38,6 +39,10 @@ Each request is JSON:
 ```
 
 `session_id` is stable for the conversation and rotates on reset. `type` is `"chat"` for a user turn, or `"oneshot"` for stateless background transforms such as the rolling summary (then `system` and `text` carry the transform's prompt pair).
+
+`resource_id` identifies **who** is on the call, where `session_id` identifies **which call**. Use it to scope memory to the person: keyed on `session_id` alone, an agent starts over every time someone rings back. It is omitted entirely when the deployment asserts no identity, so treat its absence as anonymous rather than as an empty user.
+
+It comes from a signed JWT claim minted by your backend, or from a trusted server-side caller — [sip-server](../../sip-server/README.md) sets it to the far end's phone number — and never from the browser. It also survives a reset and a reconnect unchanged: the conversation may start over, but the person on the line has not changed. See [Protocol → Caller identity](./protocol.md#caller-identity) for how to assert it.
 
 ### What your agent sends back
 
@@ -78,6 +83,8 @@ data: [DONE]
 ```
 
 Whichever shape you pick, the concatenated text is exactly what the caller hears — reply with plain conversational words, not markdown. `"oneshot"` requests are answered the same way (buffered JSON is fine there; the result is used internally, never spoken). A complete agent is ~10 lines of Flask or Express: read `text`, look up `session_id`, return words.
+
+**Runnable example:** [`examples/bring-your-own-agent`](../../examples/bring-your-own-agent) implements this endpoint twice — Node and Python, both dependency-free — with streaming, barge-in cancellation, `oneshot` handling, and separate memory for the conversation and the person. Start it with `node agent.mjs`, point `[agent] url` at it, and call in.
 
 ## 3. Point the model layer at your own infrastructure
 

--- a/docs/bring-your-own-agent.zh-CN.md
+++ b/docs/bring-your-own-agent.zh-CN.md
@@ -31,6 +31,7 @@ timeout_ms = 60000      # 单轮总预算，含流式返回回复的时间
 ```json
 {
   "session_id": "9f2c…",
+  "resource_id": "user_8891",
   "type": "chat",
   "text": "用户这一轮说的话",
   "system": "服务端追加的技能文本（如有）"
@@ -38,6 +39,10 @@ timeout_ms = 60000      # 单轮总预算，含流式返回回复的时间
 ```
 
 `session_id` 在整段对话中保持不变，重置时轮换。`type` 为 `"chat"` 表示一轮用户对话；`"oneshot"` 表示无状态的后台变换（如滚动摘要），此时 `system` 与 `text` 携带该变换的提示词。
+
+`resource_id` 标识通话里的**是谁**，而 `session_id` 标识的是**哪一通**。用它把记忆划到人身上：只按 `session_id` 划分的话，对方每次打回来 agent 都要从头认识一遍。部署未提供身份时该字段会被整个省略，因此请把「不存在」当作匿名，而不是当作一个空用户。
+
+它来自你的后端签发的 JWT claim，或来自受信任的服务端调用方——[sip-server](../../sip-server/README.zh-CN.md) 会填入对端的电话号码——绝不会来自浏览器。它也会原封不动地跨过重置与重连：对话可以从头开始，但线那头的人没有变。如何签发见[协议 → 通话方身份](./protocol.zh-CN.md#通话方身份)。
 
 ### 你的智能体需要怎么回复
 
@@ -78,6 +83,8 @@ data: [DONE]
 ```
 
 无论选哪种格式，拼接后的文本就是来电者听到的内容 —— 请返回口语化的纯文字，不要 markdown。`"oneshot"` 请求用同样的方式回复（用缓冲的 JSON 即可，结果只做内部使用、不会播报）。一个完整的智能体只需约 10 行 Flask 或 Express：读取 `text`，按 `session_id` 查会话，返回文字。
+
+**可运行示例：**[`examples/bring-your-own-agent`](../../examples/bring-your-own-agent) 用 Node 与 Python 各实现了一份该端点，均零依赖，涵盖流式返回、插话取消、`oneshot` 处理，以及对话与人两层独立记忆。用 `node agent.mjs` 启动，把 `[agent] url` 指过去，打进来即可。
 
 ## 3. 把模型层指向你自己的基础设施
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -150,3 +150,25 @@ Messages the client sends on the same channel are routed into the pipeline — c
 ## Auth
 
 Set `server.jwt_secret` to require `Authorization: Bearer <jwt>` on `/whip`. When it is set, the server also exposes `POST /token`, which issues an HS256 token valid for one hour. Set `server.api_key` to require `Authorization: Bearer <api_key>` on `/token` itself, so only your backend can mint session tokens. Both are empty by default, which disables auth.
+
+### Caller identity
+
+`POST /token` accepts an optional body naming who the token is for:
+
+```json
+{ "resource_id": "user_8891" }
+```
+
+The value is signed into the token as its `sub` claim, and `/whip` forwards it to an external agent as `resource_id` (see [Bring your own agent](./bring-your-own-agent.md)). Where `session_id` scopes one conversation, this scopes the person across all of them — it is what lets an agent recognise a caller who hung up yesterday and rang back today.
+
+Mint it here rather than sending it from the client: `/token` is called by your backend, which holds the API key and already knows which user is signed in, while `/whip` is called by the browser. A page cannot forge a claim it never signs.
+
+Server-side clients that dial `/whip` directly without a token endpoint may instead send:
+
+```http
+X-StreamCore-Resource-Id: +14155550123
+```
+
+The header is consulted **only** when the request carries no signed claim, so it can never override one. It is also absent from the CORS `Access-Control-Allow-Headers` list, which means browsers cannot send it at all — it exists for trusted server-side callers such as [sip-server](../../sip-server/README.md), which sets it to the number a call came from.
+
+Identity is optional throughout. A deployment that asserts none simply omits `resource_id` from agent requests, and the agent falls back to session-scoped memory.

--- a/docs/protocol.zh-CN.md
+++ b/docs/protocol.zh-CN.md
@@ -142,3 +142,25 @@ Content-Type: application/sdp
 ## 鉴权
 
 设置 `server.jwt_secret` 后，`/whip` 会要求 `Authorization: Bearer <jwt>`。设置该项时，服务还会暴露 `POST /token`，签发有效期 1 小时的 HS256 token。再设置 `server.api_key`，则 `/token` 本身也要求 `Authorization: Bearer <api_key>`，这样只有你的后端才能签发会话 token。两者默认都为空，即关闭鉴权。
+
+### 通话方身份
+
+`POST /token` 接受一个可选的请求体，用于标明这个 token 属于谁：
+
+```json
+{ "resource_id": "user_8891" }
+```
+
+该值会作为 `sub` claim 签进 token，`/whip` 再以 `resource_id` 字段转发给外部 agent（参见[自带 agent](./bring-your-own-agent.zh-CN.md)）。`session_id` 划定的是一次对话，而它划定的是跨越所有对话的那个人——正是它让 agent 能认出昨天挂断、今天又打回来的来电者。
+
+请在这里签发，而不要让客户端自行上报：`/token` 由你的后端调用，它持有 API key，本来就知道当前登录的是哪个用户；而 `/whip` 是由浏览器调用的。页面无法伪造一个它签不出来的 claim。
+
+没有 token 端点、直接拨 `/whip` 的服务端客户端可以改为发送：
+
+```http
+X-StreamCore-Resource-Id: +14155550123
+```
+
+该请求头**仅在**请求不带已签名 claim 时才会被采纳，因此永远无法覆盖 claim。它同时也不在 CORS 的 `Access-Control-Allow-Headers` 列表中，这意味着浏览器根本发不出这个头——它是留给受信任的服务端调用方的，例如 [sip-server](../../sip-server/README.zh-CN.md)，它会把来电号码填进去。
+
+身份始终是可选的。不提供身份的部署只会在 agent 请求中省略 `resource_id`，agent 退回到按会话划定记忆。

--- a/internal/llm/agent.go
+++ b/internal/llm/agent.go
@@ -26,11 +26,16 @@ import (
 // Request (POST <url>, application/json):
 //
 //	{
-//	  "session_id": "9f2c…",   // stable for the conversation; rotates on Reset
-//	  "type":       "chat",    // "chat" for a user turn, "oneshot" for a stateless transform
-//	  "text":       "…",       // the transcribed user turn (or the oneshot user text)
-//	  "system":     "…"        // skill text appended by the server; oneshot system prompt
+//	  "session_id":  "9f2c…",  // stable for the conversation; rotates on Reset
+//	  "resource_id": "…",      // who is on the call; omitted when unknown
+//	  "type":        "chat",   // "chat" for a user turn, "oneshot" for a stateless transform
+//	  "text":        "…",      // the transcribed user turn (or the oneshot user text)
+//	  "system":      "…"       // skill text appended by the server; oneshot system prompt
 //	}
+//
+// session_id scopes one conversation, resource_id the person behind it, so an
+// agent can remember a caller between calls. It comes from a verified JWT claim
+// or a trusted server-side caller, and survives a resume unchanged.
 //
 // Accepted responses, by Content-Type:
 //
@@ -43,6 +48,10 @@ type agentClient struct {
 	apiKey string
 	http   *http.Client
 
+	// Fixed for the life of the client. Unlike sessionID, a Reset leaves it
+	// alone: the conversation starts over, the caller has not changed.
+	resourceID string
+
 	mu          sync.Mutex
 	sessionID   string
 	extraSystem string // accumulated skill text, forwarded on every turn
@@ -50,8 +59,8 @@ type agentClient struct {
 
 // NewAgentClient returns a Client that proxies turns to an external agent
 // endpoint. timeoutMs bounds a whole turn including streaming the reply;
-// zero means 60s.
-func NewAgentClient(url, apiKey string, timeoutMs int) Client {
+// zero means 60s. An empty resourceID is omitted from every request.
+func NewAgentClient(url, apiKey string, timeoutMs int, resourceID string) Client {
 	if timeoutMs <= 0 {
 		timeoutMs = 60000
 	}
@@ -62,10 +71,11 @@ func NewAgentClient(url, apiKey string, timeoutMs int) Client {
 		IdleConnTimeout:     90 * time.Second,
 	}
 	return &agentClient{
-		url:       url,
-		apiKey:    apiKey,
-		http:      &http.Client{Transport: transport, Timeout: time.Duration(timeoutMs) * time.Millisecond},
-		sessionID: newAgentSessionID(),
+		url:        url,
+		apiKey:     apiKey,
+		http:       &http.Client{Transport: transport, Timeout: time.Duration(timeoutMs) * time.Millisecond},
+		sessionID:  newAgentSessionID(),
+		resourceID: resourceID,
 	}
 }
 
@@ -76,19 +86,21 @@ func newAgentSessionID() string {
 }
 
 type agentRequest struct {
-	SessionID string `json:"session_id"`
-	Type      string `json:"type"`
-	Text      string `json:"text"`
-	System    string `json:"system,omitempty"`
+	SessionID  string `json:"session_id"`
+	ResourceID string `json:"resource_id,omitempty"`
+	Type       string `json:"type"`
+	Text       string `json:"text"`
+	System     string `json:"system,omitempty"`
 }
 
 func (c *agentClient) Chat(ctx context.Context, userText string, onChunk func(string), onSentence func(string)) (string, error) {
 	c.mu.Lock()
 	req := agentRequest{
-		SessionID: c.sessionID,
-		Type:      "chat",
-		Text:      userText,
-		System:    c.extraSystem,
+		SessionID:  c.sessionID,
+		ResourceID: c.resourceID,
+		Type:       "chat",
+		Text:       userText,
+		System:     c.extraSystem,
 	}
 	c.mu.Unlock()
 
@@ -106,10 +118,11 @@ func (c *agentClient) OneShot(ctx context.Context, system, user string) (string,
 	c.mu.Unlock()
 
 	out, err := c.do(ctx, agentRequest{
-		SessionID: sessionID,
-		Type:      "oneshot",
-		Text:      user,
-		System:    system,
+		SessionID:  sessionID,
+		ResourceID: c.resourceID,
+		Type:       "oneshot",
+		Text:       user,
+		System:     system,
 	}, nil, nil)
 	if err != nil {
 		return "", err

--- a/internal/llm/agent_test.go
+++ b/internal/llm/agent_test.go
@@ -1,0 +1,116 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// captureAgent stands in for an external agent, recording what it is sent and
+// replying with a fixed line.
+type captureAgent struct {
+	srv      *httptest.Server
+	requests []agentRequest
+}
+
+func newCaptureAgent(t *testing.T) *captureAgent {
+	t.Helper()
+
+	c := &captureAgent{}
+	c.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req agentRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Errorf("agent received unparseable body %q: %v", body, err)
+		}
+		c.requests = append(c.requests, req)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"text":"ok."}`))
+	}))
+	t.Cleanup(c.srv.Close)
+	return c
+}
+
+func (c *captureAgent) client(resourceID string) Client {
+	return NewAgentClient(c.srv.URL, "", 0, resourceID)
+}
+
+func TestChatForwardsTheResourceID(t *testing.T) {
+	agent := newCaptureAgent(t)
+	client := agent.client("user_8891")
+
+	if _, err := client.Chat(context.Background(), "hello", nil, nil); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	if len(agent.requests) != 1 {
+		t.Fatalf("agent saw %d requests, want 1", len(agent.requests))
+	}
+	if got := agent.requests[0].ResourceID; got != "user_8891" {
+		t.Fatalf("resource_id = %q, want user_8891", got)
+	}
+}
+
+// The rolling summary uses the same endpoint, so it needs the resource too.
+func TestOneShotForwardsTheResourceID(t *testing.T) {
+	agent := newCaptureAgent(t)
+	client := agent.client("user_8891")
+
+	if _, err := client.OneShot(context.Background(), "summarise", "the call"); err != nil {
+		t.Fatalf("OneShot: %v", err)
+	}
+
+	if got := agent.requests[0].ResourceID; got != "user_8891" {
+		t.Fatalf("resource_id = %q, want user_8891", got)
+	}
+}
+
+// Omit the field entirely when anonymous. An empty string would pool every
+// anonymous caller into one shared resource.
+func TestResourceIDIsOmittedWhenUnknown(t *testing.T) {
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"text":"ok."}`))
+	}))
+	defer srv.Close()
+
+	client := NewAgentClient(srv.URL, "", 0, "")
+	if _, err := client.Chat(context.Background(), "hello", nil, nil); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if _, present := fields["resource_id"]; present {
+		t.Fatalf("resource_id present in an anonymous request: %s", body)
+	}
+}
+
+// Reset drops the history, not the person.
+func TestResetRotatesTheSessionButKeepsTheResource(t *testing.T) {
+	agent := newCaptureAgent(t)
+	client := agent.client("user_8891")
+
+	if _, err := client.Chat(context.Background(), "first", nil, nil); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	client.Reset()
+	if _, err := client.Chat(context.Background(), "second", nil, nil); err != nil {
+		t.Fatalf("Chat after reset: %v", err)
+	}
+
+	before, after := agent.requests[0], agent.requests[1]
+	if before.SessionID == after.SessionID {
+		t.Fatal("session_id survived a Reset")
+	}
+	if after.ResourceID != "user_8891" {
+		t.Fatalf("resource_id after reset = %q, want user_8891", after.ResourceID)
+	}
+}

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -41,7 +41,10 @@ type Client interface {
 }
 
 // NewClient returns an LLM client for the configured provider.
-func NewClient(cfg *config.Config) (Client, error) {
+//
+// resourceID is who is on the call, empty when nobody was identified. Only the
+// "agent" provider uses it; the others keep the conversation in-process.
+func NewClient(cfg *config.Config, resourceID string) (Client, error) {
 	switch cfg.LLM.Provider {
 	case "openai":
 		if cfg.OpenAI.APIKey == "" {
@@ -54,7 +57,7 @@ func NewClient(cfg *config.Config) (Client, error) {
 		if cfg.Agent.URL == "" {
 			return nil, fmt.Errorf("llm provider %q requires [agent] url to be set", cfg.LLM.Provider)
 		}
-		return NewAgentClient(cfg.Agent.URL, cfg.Agent.APIKey, cfg.Agent.TimeoutMs), nil
+		return NewAgentClient(cfg.Agent.URL, cfg.Agent.APIKey, cfg.Agent.TimeoutMs, resourceID), nil
 	default:
 		return nil, fmt.Errorf("unknown llm provider %q (supported: openai, ollama, agent)", cfg.LLM.Provider)
 	}

--- a/internal/pipeline/conversation.go
+++ b/internal/pipeline/conversation.go
@@ -39,10 +39,14 @@ type ConversationState struct {
 
 // NewConversationState builds the durable half of a call.
 //
+// resourceID is who is on the call, empty when nobody was identified. It lives
+// on the conversation rather than the Pipeline so it survives a redial, same as
+// the message history.
+//
 // In realtime mode no LLM client is constructed: the speech-to-speech provider
 // replaces STT, LLM, and TTS at once, and building one would demand API keys
 // for a provider this deployment does not use.
-func NewConversationState(cfg *config.Config) (*ConversationState, error) {
+func NewConversationState(cfg *config.Config, resourceID string) (*ConversationState, error) {
 	state := &ConversationState{
 		Log:                  &TranscriptLog{},
 		rollingSummary:       &atomic.Value{},
@@ -50,7 +54,7 @@ func NewConversationState(cfg *config.Config) (*ConversationState, error) {
 	}
 
 	if !cfg.RealtimeEnabled() {
-		client, err := llm.NewClient(cfg)
+		client, err := llm.NewClient(cfg, resourceID)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -193,7 +193,9 @@ func New(
 		return nil, err
 	}
 	if conv == nil {
-		if conv, err = NewConversationState(cfg); err != nil {
+		// No identity here: a Session always builds the conversation itself and
+		// passes it in, so reaching this means there is no session.
+		if conv, err = NewConversationState(cfg, ""); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/session/identity_test.go
+++ b/internal/session/identity_test.go
@@ -1,0 +1,50 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/streamcoreai/streamcore-server/internal/config"
+)
+
+func identitySession(t *testing.T) *Session {
+	t.Helper()
+	return NewSession("s1", &config.Config{}, nil, nil)
+}
+
+func TestResourceIDIsEmptyUntilAsserted(t *testing.T) {
+	s := identitySession(t)
+	if got := s.ResourceID(); got != "" {
+		t.Fatalf("resource id = %q, want empty", got)
+	}
+}
+
+func TestSetResourceIDBindsTheCaller(t *testing.T) {
+	s := identitySession(t)
+	s.SetResourceID("user_8891")
+	if got := s.ResourceID(); got != "user_8891" {
+		t.Fatalf("resource id = %q, want user_8891", got)
+	}
+}
+
+// A resume runs the same WHIP path, calling this again mid-conversation. If the
+// second call won, a redial could hand the call to someone else.
+func TestSetResourceIDDoesNotOverwrite(t *testing.T) {
+	s := identitySession(t)
+	s.SetResourceID("user_8891")
+	s.SetResourceID("someone_else")
+
+	if got := s.ResourceID(); got != "user_8891" {
+		t.Fatalf("resource id = %q, want user_8891", got)
+	}
+}
+
+// An anonymous redial must not clear an identity already set.
+func TestSetResourceIDIgnoresEmpty(t *testing.T) {
+	s := identitySession(t)
+	s.SetResourceID("user_8891")
+	s.SetResourceID("")
+
+	if got := s.ResourceID(); got != "user_8891" {
+		t.Fatalf("resource id = %q, want user_8891", got)
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -51,6 +51,31 @@ type Session struct {
 	// a live conversation should be neither. Single-use — every resume issues
 	// a fresh one.
 	resumeToken string
+
+	// resourceID is who is on the call, from a verified JWT claim or a trusted
+	// server-side caller. Empty when the deployment offers no identity. An
+	// external agent uses it to scope memory to the person; the session ID only
+	// covers this one call.
+	resourceID string
+}
+
+// SetResourceID binds an identity to the session once. Later calls are ignored
+// so a redial cannot hand an in-flight conversation to someone else.
+func (s *Session) SetResourceID(resourceID string) {
+	if resourceID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.resourceID == "" {
+		s.resourceID = resourceID
+	}
+}
+
+func (s *Session) ResourceID() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.resourceID
 }
 
 // newResumeToken returns a high-entropy single-use token. crypto/rand rather
@@ -168,7 +193,8 @@ func (s *Session) conversation() (*pipeline.ConversationState, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.conv == nil {
-		conv, err := pipeline.NewConversationState(s.cfg)
+		// Read the field directly, not ResourceID() — the mutex is already held.
+		conv, err := pipeline.NewConversationState(s.cfg, s.resourceID)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/signaling/handler.go
+++ b/internal/signaling/handler.go
@@ -184,6 +184,11 @@ func handleWHIPPost(w http.ResponseWriter, r *http.Request, sm *session.Manager)
 		log.Printf("[whip] creating session %s", ses.ID)
 	}
 
+	// Must happen before AddPeer, which builds the conversation and the LLM
+	// client that forwards the identity. SetResourceID does not overwrite, so a
+	// resumed session keeps whoever it started with.
+	ses.SetResourceID(resolveResourceID(r))
+
 	sessionID := ses.ID
 	peerID := sessionID
 	p, err := ses.AddPeer(peerID, direction)

--- a/internal/signaling/identity.go
+++ b/internal/signaling/identity.go
@@ -1,0 +1,35 @@
+package signaling
+
+import (
+	"context"
+	"net/http"
+)
+
+// Set by trusted server-side callers only; sip-server puts the calling number
+// here. Not in the CORS allow-list, so browsers can't send it.
+const ResourceIDHeader = "X-StreamCore-Resource-Id"
+
+type resourceIDKey struct{}
+
+// WithResourceID attaches an identity that has already been verified. Today
+// that means the JWT middleware, after checking the signature.
+func WithResourceID(ctx context.Context, resourceID string) context.Context {
+	if resourceID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, resourceIDKey{}, resourceID)
+}
+
+func ResourceIDFromContext(ctx context.Context) string {
+	id, _ := ctx.Value(resourceIDKey{}).(string)
+	return id
+}
+
+// A verified claim beats the header: anyone can set a header, nobody can forge
+// a signature. Empty when the deployment has no identity to offer.
+func resolveResourceID(r *http.Request) string {
+	if claimed := ResourceIDFromContext(r.Context()); claimed != "" {
+		return claimed
+	}
+	return r.Header.Get(ResourceIDHeader)
+}

--- a/internal/signaling/identity_test.go
+++ b/internal/signaling/identity_test.go
@@ -1,0 +1,49 @@
+package signaling
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func requestWith(claim, header string) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "/whip", nil)
+	if header != "" {
+		r.Header.Set(ResourceIDHeader, header)
+	}
+	if claim != "" {
+		r = r.WithContext(WithResourceID(r.Context(), claim))
+	}
+	return r
+}
+
+// If a header could override a claim, anything able to reach /whip could claim
+// to be someone else.
+func TestVerifiedClaimBeatsTheHeader(t *testing.T) {
+	got := resolveResourceID(requestWith("user_8891", "attacker"))
+	if got != "user_8891" {
+		t.Fatalf("resource id = %q, want user_8891", got)
+	}
+}
+
+func TestHeaderIsUsedWhenNoClaimIsPresent(t *testing.T) {
+	got := resolveResourceID(requestWith("", "+14155550123"))
+	if got != "+14155550123" {
+		t.Fatalf("resource id = %q, want +14155550123", got)
+	}
+}
+
+func TestNoIdentityIsANormalAnswer(t *testing.T) {
+	if got := resolveResourceID(requestWith("", "")); got != "" {
+		t.Fatalf("resource id = %q, want empty", got)
+	}
+}
+
+// Empty is dropped rather than stored. Absent and empty mean the same thing.
+func TestEmptyIdentityIsNotStoredInContext(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/whip", nil)
+	ctx := WithResourceID(r.Context(), "")
+	if got := ResourceIDFromContext(ctx); got != "" {
+		t.Fatalf("resource id = %q, want empty", got)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -153,6 +154,10 @@ func corsMiddleware(next http.Handler) http.Handler {
 // Clients call POST /token to get a token before connecting to /whip.
 // If apiKey is non-empty, the request must include a matching
 // Authorization: Bearer <apiKey> header.
+//
+// The body may carry {"resource_id": "..."} to bind the token to a caller.
+// It is minted here rather than accepted at /whip because this endpoint is
+// called by a backend holding the API key, which already knows who its user is.
 func tokenHandler(secret, apiKey string) http.HandlerFunc {
 	secretBytes := []byte(secret)
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -170,11 +175,24 @@ func tokenHandler(secret, apiKey string) http.HandlerFunc {
 			}
 		}
 
+		// Most callers want a plain anonymous token and send no body, so a
+		// missing or unparseable one is not an error.
+		var body struct {
+			ResourceID string `json:"resource_id"`
+		}
+		if r.Body != nil {
+			json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&body)
+		}
+
 		now := time.Now()
-		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		claims := jwt.MapClaims{
 			"iat": now.Unix(),
 			"exp": now.Add(1 * time.Hour).Unix(),
-		})
+		}
+		if resourceID := strings.TrimSpace(body.ResourceID); resourceID != "" {
+			claims["sub"] = resourceID
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 
 		signed, err := token.SignedString(secretBytes)
 		if err != nil {
@@ -190,6 +208,9 @@ func tokenHandler(secret, apiKey string) http.HandlerFunc {
 // jwtMiddleware validates a Bearer token in the Authorization header using
 // HMAC-SHA256. It wraps a handler and rejects requests with missing or
 // invalid tokens with 401 Unauthorized.
+//
+// A "sub" claim is passed through to the handler as the caller identity, read
+// only after the signature checks out.
 func jwtMiddleware(secret string, next http.HandlerFunc) http.HandlerFunc {
 	secretBytes := []byte(secret)
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -206,7 +227,7 @@ func jwtMiddleware(secret string, next http.HandlerFunc) http.HandlerFunc {
 		}
 
 		tokenStr := strings.TrimPrefix(auth, "Bearer ")
-		_, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
+		token, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
 			if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
 				return nil, jwt.ErrSignatureInvalid
 			}
@@ -215,6 +236,10 @@ func jwtMiddleware(secret string, next http.HandlerFunc) http.HandlerFunc {
 		if err != nil {
 			http.Error(w, "invalid token", http.StatusUnauthorized)
 			return
+		}
+
+		if subject, err := token.Claims.GetSubject(); err == nil && subject != "" {
+			r = r.WithContext(signaling.WithResourceID(r.Context(), subject))
 		}
 
 		next(w, r)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/streamcoreai/streamcore-server/internal/signaling"
+)
+
+// mintToken drives tokenHandler and returns the signed JWT it issued.
+func mintToken(t *testing.T, secret, apiKey, body string) string {
+	t.Helper()
+
+	var reader *strings.Reader
+	if body == "" {
+		reader = strings.NewReader("")
+	} else {
+		reader = strings.NewReader(body)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/token", reader)
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	rec := httptest.NewRecorder()
+	tokenHandler(secret, apiKey)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("token request: status %d, body %q", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode token response: %v", err)
+	}
+	return out.Token
+}
+
+// resourceSeenBy runs a token through jwtMiddleware and reports what the
+// wrapped handler saw.
+func resourceSeenBy(t *testing.T, secret, token string) string {
+	t.Helper()
+
+	var seen string
+	req := httptest.NewRequest(http.MethodPost, "/whip", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	jwtMiddleware(secret, func(w http.ResponseWriter, r *http.Request) {
+		seen = signaling.ResourceIDFromContext(r.Context())
+	})(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("middleware rejected a token it minted: status %d", rec.Code)
+	}
+	return seen
+}
+
+func TestTokenCarriesTheRequestedResourceID(t *testing.T) {
+	const secret = "test-secret"
+
+	token := mintToken(t, secret, "", `{"resource_id":"user_8891"}`)
+	if got := resourceSeenBy(t, secret, token); got != "user_8891" {
+		t.Fatalf("resource id = %q, want user_8891", got)
+	}
+}
+
+// The common case — the SDKs send no body at all.
+func TestTokenWithoutAResourceIDYieldsNoIdentity(t *testing.T) {
+	const secret = "test-secret"
+
+	for _, body := range []string{"", "{}", "not json at all"} {
+		token := mintToken(t, secret, "", body)
+		if got := resourceSeenBy(t, secret, token); got != "" {
+			t.Fatalf("body %q: resource id = %q, want empty", body, got)
+		}
+	}
+}
+
+// A whitespace-only resource_id would otherwise be forwarded as if it
+// identified someone.
+func TestBlankResourceIDIsNotMintedAsAClaim(t *testing.T) {
+	const secret = "test-secret"
+
+	token := mintToken(t, secret, "", `{"resource_id":"   "}`)
+	if got := resourceSeenBy(t, secret, token); got != "" {
+		t.Fatalf("resource id = %q, want empty", got)
+	}
+}
+
+// Wrong signature: reject the token instead of reading its claims.
+func TestForgedTokenIsRejectedBeforeItsClaimsAreRead(t *testing.T) {
+	forged := mintToken(t, "attacker-secret", "", `{"resource_id":"admin"}`)
+
+	var reached bool
+	req := httptest.NewRequest(http.MethodPost, "/whip", nil)
+	req.Header.Set("Authorization", "Bearer "+forged)
+	rec := httptest.NewRecorder()
+	jwtMiddleware("real-secret", func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+	})(rec, req)
+
+	if reached {
+		t.Fatal("a token signed with the wrong secret reached the handler")
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+// With an api_key configured, you need it to mint anything at all.
+func TestResourceIDCannotBeMintedWithoutTheAPIKey(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(`{"resource_id":"user_8891"}`))
+	rec := httptest.NewRecorder()
+	tokenHandler("test-secret", "the-api-key")(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}


### PR DESCRIPTION
This pull request introduces support for caller identity in the agent integration, enabling agents to distinguish between different callers across sessions and providing more robust memory and personalization. The changes propagate a new `resource_id` field through the system, ensure it is set and forwarded correctly, and update documentation and tests to reflect this new behavior.

**Caller identity propagation and handling:**

* Added a `resource_id` field to agent requests and responses, distinguishing the person on the call from the session, and ensured it is only set when available and never overwritten by subsequent requests or resets (`internal/llm/agent.go`, `internal/llm/llm.go`, `internal/pipeline/conversation.go`, `internal/pipeline/pipeline.go`, `internal/session/session.go`). [[1]](diffhunk://#diff-7ebdd8c58baf4f93114fddbbacce6d3f43a7ee34634089d0b89052abca0ac8d5R30-R39) [[2]](diffhunk://#diff-7ebdd8c58baf4f93114fddbbacce6d3f43a7ee34634089d0b89052abca0ac8d5R51-R63) [[3]](diffhunk://#diff-7ebdd8c58baf4f93114fddbbacce6d3f43a7ee34634089d0b89052abca0ac8d5R78) [[4]](diffhunk://#diff-7ebdd8c58baf4f93114fddbbacce6d3f43a7ee34634089d0b89052abca0ac8d5R90) [[5]](diffhunk://#diff-7ebdd8c58baf4f93114fddbbacce6d3f43a7ee34634089d0b89052abca0ac8d5R100) [[6]](diffhunk://#diff-7ebdd8c58baf4f93114fddbbacce6d3f43a7ee34634089d0b89052abca0ac8d5R122) [[7]](diffhunk://#diff-15e84642b9ee7cbb81fbfc09f439cc544bcabb6fc29b0835f8a31c77802d6aebL44-R47) [[8]](diffhunk://#diff-15e84642b9ee7cbb81fbfc09f439cc544bcabb6fc29b0835f8a31c77802d6aebL57-R60) [[9]](diffhunk://#diff-ef3fbffb84980049dbd295f62625f12746781f96eed32f4113a307ea38c5ece6R42-R57) [[10]](diffhunk://#diff-907bfb94a8c2367197d5b3de95c34ecd5cdab2944988165c644bd985722a3c56L196-R198) [[11]](diffhunk://#diff-9f48b39232d3fa7342b5dbf435a89fa50b248929a849aadfeb6d89845371de26R54-R78) [[12]](diffhunk://#diff-9f48b39232d3fa7342b5dbf435a89fa50b248929a849aadfeb6d89845371de26L171-R197) [[13]](diffhunk://#diff-73ec7904a8c6e73c0b0a98c92183cde93365309beb815818241e7618687e10bbR187-R191)

* Updated session management to bind the `resource_id` once per session and prevent it from being overwritten or cleared by subsequent or anonymous requests (`internal/session/session.go`, `internal/session/identity_test.go`). [[1]](diffhunk://#diff-9f48b39232d3fa7342b5dbf435a89fa50b248929a849aadfeb6d89845371de26R54-R78) [[2]](diffhunk://#diff-3878f858414686420714e76104c6a64e44de9dff94bd488b0504957b8c5b996aR1-R50)

**Documentation updates:**

* Documented the new `resource_id` field, its purpose, and its handling in both English and Chinese agent and protocol documentation, including how it is set, forwarded, and omitted for anonymous users (`docs/bring-your-own-agent.md`, `docs/bring-your-own-agent.zh-CN.md`, `docs/protocol.md`, `docs/protocol.zh-CN.md`). [[1]](diffhunk://#diff-e1025d02cdf88a9784f92a7b9489589108dfa3dc6f4e2c7d6eb954ad2f862415R34) [[2]](diffhunk://#diff-e1025d02cdf88a9784f92a7b9489589108dfa3dc6f4e2c7d6eb954ad2f862415R43-R46) [[3]](diffhunk://#diff-e1025d02cdf88a9784f92a7b9489589108dfa3dc6f4e2c7d6eb954ad2f862415R87-R88) [[4]](diffhunk://#diff-c9deb5efe8f32f9a990cfeddf192a49735182c7cfd1989dccbcbb6a0311b7ab7R34) [[5]](diffhunk://#diff-c9deb5efe8f32f9a990cfeddf192a49735182c7cfd1989dccbcbb6a0311b7ab7R43-R46) [[6]](diffhunk://#diff-c9deb5efe8f32f9a990cfeddf192a49735182c7cfd1989dccbcbb6a0311b7ab7R87-R88) [[7]](diffhunk://#diff-22634edea93be238f46f99eeaab282be9ba965bcaad98e987cb2557cda2c3195R153-R174) [[8]](diffhunk://#diff-93859aa9820f5ea91721f2a6c09dfe4fa6532e7a64e07697845496704499f457R145-R166)

**Testing:**

* Added tests to verify that `resource_id` is correctly set, forwarded, omitted when missing, and persists across session resets, as well as ensuring it cannot be overwritten (`internal/llm/agent_test.go`, `internal/session/identity_test.go`). [[1]](diffhunk://#diff-25b6d72edcf9914991fb65defa92d4a8888def19772731b39a68639f05023ddbR1-R116) [[2]](diffhunk://#diff-3878f858414686420714e76104c6a64e44de9dff94bd488b0504957b8c5b996aR1-R50)

These changes collectively ensure that agents can maintain caller-specific memory and context across calls, improving personalization and continuity for returning users.