### PR TITLE
Add Volcengine (Doubao) streaming STT provider

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -33,7 +33,7 @@ turn_merge_ms = 350          # Debounce window for merging finals into one turn.
 provider = ""           # Supported: grok (empty = classic pipeline)
 
 [stt]
-provider = "deepgram"   # Supported: deepgram, openai, assemblyai, vibevoice
+provider = "deepgram"   # Supported: deepgram, openai, assemblyai, vibevoice, volcengine
 
 [llm]
 provider = "openai"     # Supported: openai, ollama, agent
@@ -156,6 +156,19 @@ model = ""              # Optional; defaults to speech-2.6-turbo (low latency). 
 asr_url = "ws://127.0.0.1:8200"    # WebSocket URL for VibeVoice ASR server
 tts_url = "http://127.0.0.1:8300"  # HTTP URL for VibeVoice TTS server
 voice = "en-Emma_woman"             # TTS voice name
+
+# Volcengine (Doubao) streaming ASR. Used when stt.provider = "volcengine".
+# Useful where Deepgram is slow to reach or its Mandarin is not good enough;
+# the console gives a free hourly allowance to start with.
+[volcengine]
+api_key = ""            # Required. The console's API key, sent as X-Api-Key.
+                        # The older app-id + access-token pair is rejected here
+resource_id = ""        # Optional; defaults to volc.seedasr.sauc.duration (hourly plan).
+                        # volc.seedasr.sauc.concurrent bills by concurrency instead
+model = ""              # Optional; defaults to bigmodel
+url = ""                # Optional; defaults to wss://openspeech.bytedance.com/api/v3/sauc/bigmodel
+end_window_ms = 0       # Optional; silence (ms) that settles an utterance, defaults to 800.
+                        # Same role as [deepgram] endpointing
 
 # Vision (used by the vision-analyze plugin)
 # The plugin reads OPENAI_API_KEY from the environment (same key as [openai]).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	Ollama     OllamaConfig     `toml:"ollama"`
 	Agent      AgentConfig      `toml:"agent"`
 	VibeVoice  VibeVoiceConfig  `toml:"vibevoice"`
+	Volcengine VolcengineConfig `toml:"volcengine"`
 	Cartesia   CartesiaConfig   `toml:"cartesia"`
 	ElevenLabs ElevenLabsConfig `toml:"elevenlabs"`
 	Speechify  SpeechifyConfig  `toml:"speechify"`
@@ -319,6 +320,22 @@ type VibeVoiceConfig struct {
 	ASRURL string `toml:"asr_url"` // WebSocket URL for the ASR server
 	TTSURL string `toml:"tts_url"` // HTTP URL for the TTS server
 	Voice  string `toml:"voice"`   // TTS voice name
+}
+
+// VolcengineConfig configures Volcengine (Doubao) streaming ASR.
+type VolcengineConfig struct {
+	// APIKey is the console's API key, sent as X-Api-Key. The older
+	// app-id-plus-access-token pair does not work against these resources.
+	APIKey string `toml:"api_key"`
+	// ResourceID selects the plan: volc.seedasr.sauc.duration bills by the
+	// hour, volc.seedasr.sauc.concurrent by concurrency. Empty uses duration.
+	ResourceID string `toml:"resource_id"`
+	Model      string `toml:"model"`
+	// URL overrides the endpoint. Empty uses the streaming bigmodel endpoint.
+	URL string `toml:"url"`
+	// EndWindowMs is the silence that ends an utterance, the same knob as
+	// [deepgram] endpointing. Empty uses 300.
+	EndWindowMs int `toml:"end_window_ms"`
 }
 
 // Load reads configuration from a TOML file. It tries the given path first,

--- a/internal/stt/stt.go
+++ b/internal/stt/stt.go
@@ -41,9 +41,14 @@ func NewClient(ctx context.Context, cfg *config.Config, onResult func(Transcript
 			return nil, fmt.Errorf("stt provider %q requires [assemblyai] api_key to be set", cfg.STT.Provider)
 		}
 		return NewAssemblyAIClient(ctx, cfg.AssemblyAI, onResult)
+	case "volcengine":
+		if cfg.Volcengine.APIKey == "" {
+			return nil, fmt.Errorf("stt provider %q requires [volcengine] api_key to be set", cfg.STT.Provider)
+		}
+		return NewVolcengineClient(ctx, cfg.Volcengine, onResult)
 	case "vibevoice":
 		return NewVibeVoiceClient(ctx, cfg.VibeVoice.ASRURL, onResult)
 	default:
-		return nil, fmt.Errorf("unknown stt provider %q (supported: deepgram, openai, assemblyai, vibevoice)", cfg.STT.Provider)
+		return nil, fmt.Errorf("unknown stt provider %q (supported: deepgram, openai, assemblyai, vibevoice, volcengine)", cfg.STT.Provider)
 	}
 }

--- a/internal/stt/volcengine.go
+++ b/internal/stt/volcengine.go
@@ -1,0 +1,398 @@
+package stt
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+
+	"github.com/streamcoreai/streamcore-server/internal/config"
+)
+
+// Volcengine (Doubao) streaming ASR — /api/v3/sauc/bigmodel
+// --------------------------------------------------------
+//
+//	Endpoint:  wss://openspeech.bytedance.com/api/v3/sauc/bigmodel
+//	Auth:      X-Api-Key: <api key>          (one header; the older
+//	           X-Api-App-Key + X-Api-Access-Key pair is rejected by the
+//	           seedasr resources with 400/401)
+//	Resource:  X-Api-Resource-Id: volc.seedasr.sauc.duration   (hourly plan)
+//	                              volc.seedasr.sauc.concurrent (concurrency plan)
+//	Audio:     raw 16-bit signed little-endian PCM at 16kHz mono.
+//
+// Unlike the other providers here, the wire format is binary rather than JSON
+// text frames. Every message is:
+//
+//	byte 0    protocol version (high nibble) and header size in 4-byte words
+//	          (low nibble) — 0x11 throughout
+//	byte 1    message type (high nibble), flags (low nibble)
+//	byte 2    serialisation (high nibble), compression (low nibble)
+//	byte 3    reserved
+//	bytes 4-7 payload length, big-endian
+//	bytes 8+  payload
+//
+// Responses carry a 4-byte sequence number between the header and the payload
+// length, so their payload starts at byte 12 rather than byte 8.
+type volcengineClient struct {
+	conn   *websocket.Conn
+	cancel context.CancelFunc
+
+	// writeMu serialises writes: gorilla/websocket allows only one concurrent
+	// writer, and Close races SendAudio when a call ends mid-utterance.
+	writeMu sync.Mutex
+	closed  bool
+}
+
+const (
+	volcengineURL        = "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel"
+	volcengineSampleRate = 16000
+
+	// Message types (high nibble of byte 1).
+	volcTypeFullClient   = 0b0001 // config frame, JSON payload
+	volcTypeAudioOnly    = 0b0010 // raw PCM payload
+	volcTypeFullServer   = 0b1001 // transcript
+	volcTypeErrorMessage = 0b1111
+
+	// Flags (low nibble of byte 1).
+	volcFlagNone        = 0b0000
+	volcFlagLastPacket  = 0b0010
+	volcSerialisationJS = 0x10 // JSON in the high nibble of byte 2
+	volcCompressionGzip = 0b0001
+
+	// defaultVolcengineEndWindowMs is deliberately longer than Deepgram's
+	// 300ms endpointing: this service settles an utterance only in whole
+	// phrases, so a short window buys no responsiveness and the pipeline's own
+	// turn merging already covers mid-sentence pauses.
+	defaultVolcengineEndWindowMs = 800
+
+	// volcengineCloseGrace is how long Close waits for the flush triggered by
+	// the last-packet frame before dropping the socket.
+	volcengineCloseGrace = 2 * time.Second
+)
+
+// NewVolcengineClient dials the Volcengine streaming ASR endpoint and starts a
+// goroutine that forwards transcripts to onResult.
+func NewVolcengineClient(ctx context.Context, cfg config.VolcengineConfig, onResult func(TranscriptResult)) (Client, error) {
+	sttCtx, cancel := context.WithCancel(ctx)
+
+	resourceID := cfg.ResourceID
+	if resourceID == "" {
+		resourceID = "volc.seedasr.sauc.duration"
+	}
+	endpoint := cfg.URL
+	if endpoint == "" {
+		endpoint = volcengineURL
+	}
+
+	hdr := http.Header{}
+	hdr.Set("X-Api-Key", cfg.APIKey)
+	hdr.Set("X-Api-Resource-Id", resourceID)
+	// Connect-Id is echoed in Volcengine's logs; sending one makes a failed
+	// session traceable in the console rather than anonymous.
+	hdr.Set("X-Api-Connect-Id", uuid.New().String())
+
+	conn, resp, err := websocket.DefaultDialer.DialContext(sttCtx, endpoint, hdr)
+	if err != nil {
+		cancel()
+		if resp != nil {
+			// The body carries the actual reason ("requested grant not found"
+			// for an unentitled resource id, for instance), which the status
+			// code alone does not convey.
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+			resp.Body.Close()
+			return nil, fmt.Errorf("volcengine dial: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+		return nil, fmt.Errorf("volcengine dial: %w", err)
+	}
+
+	c := &volcengineClient{conn: conn, cancel: cancel}
+
+	if err := c.sendConfig(cfg); err != nil {
+		c.Close()
+		return nil, err
+	}
+
+	go c.readLoop(sttCtx, onResult)
+
+	log.Printf("[stt] connected to Volcengine (%s)", resourceID)
+	return c, nil
+}
+
+// volcengineRequest is the config frame sent once, before any audio.
+type volcengineRequest struct {
+	User    map[string]string `json:"user"`
+	Audio   volcengineAudio   `json:"audio"`
+	Request volcengineParams  `json:"request"`
+}
+
+type volcengineAudio struct {
+	Format  string `json:"format"`
+	Codec   string `json:"codec"`
+	Rate    int    `json:"rate"`
+	Bits    int    `json:"bits"`
+	Channel int    `json:"channel"`
+}
+
+type volcengineParams struct {
+	ModelName string `json:"model_name"`
+	// EnableITN turns "one hundred" into "100"; EnablePUNC adds punctuation.
+	// Both matter here because the transcript is fed to an LLM, and an
+	// unpunctuated wall of text reads as one run-on sentence.
+	EnableITN  bool `json:"enable_itn"`
+	EnablePUNC bool `json:"enable_punc"`
+	// ShowUtterances is what produces the `definite` flag the read loop uses
+	// to tell a final transcript from a partial one. Without it every result
+	// looks provisional and no turn ever completes.
+	ShowUtterances bool `json:"show_utterances"`
+	// EndWindowSize is the silence (ms) after which an utterance is settled,
+	// the same role Deepgram's endpointing plays. It belongs at the top level
+	// of `request`: the vendor samples nest it under a `vad` object, and
+	// nested it is silently ignored — the service then waits out its own
+	// default, which measured 5.3 seconds of silence on live audio and reads
+	// on a call as the agent having hung up.
+	//
+	// Do not reach for `vad_segment_duration` to make this faster. It is not
+	// an endpointing window but a hard segment length, and shortening it
+	// chops the caller mid-thought. On one sentence of Mandarin:
+	//
+	//	end_window_size = 800        "你好，请用一句话介绍乒乓球。"
+	//	vad_segment_duration = 300   "你好。" "请。" "用。" "一句话。" "介绍。" "乒乓球。"
+	EndWindowSize int `json:"end_window_size"`
+}
+
+func (c *volcengineClient) sendConfig(cfg config.VolcengineConfig) error {
+	model := cfg.Model
+	if model == "" {
+		model = "bigmodel"
+	}
+	endWindow := cfg.EndWindowMs
+	if endWindow <= 0 {
+		endWindow = defaultVolcengineEndWindowMs
+	}
+	body, err := json.Marshal(volcengineRequest{
+		User: map[string]string{"uid": "streamcore"},
+		Audio: volcengineAudio{
+			Format: "pcm", Codec: "raw",
+			Rate: volcengineSampleRate, Bits: 16, Channel: 1,
+		},
+		Request: volcengineParams{
+			ModelName:      model,
+			EnableITN:      true,
+			EnablePUNC:     true,
+			ShowUtterances: true,
+			EndWindowSize:  endWindow,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("volcengine marshal config: %w", err)
+	}
+	return c.writeFrame(volcTypeFullClient, volcFlagNone, body)
+}
+
+// writeFrame prepends the 8-byte header and writes one binary message.
+func (c *volcengineClient) writeFrame(msgType, flags byte, payload []byte) error {
+	buf := make([]byte, 8+len(payload))
+	buf[0] = 0x11
+	buf[1] = msgType<<4 | flags
+	buf[2] = volcSerialisationJS
+	buf[3] = 0x00
+	binary.BigEndian.PutUint32(buf[4:8], uint32(len(payload)))
+	copy(buf[8:], payload)
+
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	if c.closed {
+		return fmt.Errorf("volcengine: connection closed")
+	}
+	return c.conn.WriteMessage(websocket.BinaryMessage, buf)
+}
+
+// SendAudio forwards a chunk of PCM. The pipeline calls this every 20ms.
+func (c *volcengineClient) SendAudio(data []byte) error {
+	return c.writeFrame(volcTypeAudioOnly, volcFlagNone, data)
+}
+
+// volcengineResponse is the transcript payload.
+type volcengineResponse struct {
+	Result struct {
+		Text       string `json:"text"`
+		Utterances []struct {
+			Text string `json:"text"`
+			// Definite marks an utterance the model considers settled; it is
+			// the only signal separating a final from a partial.
+			Definite bool `json:"definite"`
+		} `json:"utterances"`
+	} `json:"result"`
+	Error string `json:"error"`
+}
+
+// readLoop turns the service's cumulative view into the incremental one the
+// pipeline expects.
+//
+// Volcengine repeats the whole conversation on every message: result.text is
+// everything heard so far, and utterances[] carries each segment with a
+// `definite` flag that stays true once set. Deepgram's contract is the
+// opposite — one final per utterance, emitted once. Bridging the two is what
+// emittedFinals below tracks: anything past that index has newly settled and
+// is emitted as its own final; everything still open goes out as a partial.
+//
+// Reading it the obvious way (any definite ⇒ the whole text is final) fires a
+// final on every subsequent message, so the agent answers "你好。", then
+// "你好。请", then "你好。请。用" — one reply per word.
+func (c *volcengineClient) readLoop(ctx context.Context, onResult func(TranscriptResult)) {
+	emittedFinals := 0
+
+	for {
+		_, data, err := c.conn.ReadMessage()
+		if err != nil {
+			if ctx.Err() == nil {
+				log.Printf("[stt] volcengine read: %v", err)
+			}
+			return
+		}
+
+		msgType, payload, ok := parseVolcengineFrame(data)
+		if !ok {
+			continue
+		}
+		if msgType == volcTypeErrorMessage {
+			log.Printf("[stt] volcengine error: %s", truncateBytes(payload, 200))
+			continue
+		}
+		if msgType != volcTypeFullServer || len(payload) == 0 {
+			continue
+		}
+
+		var parsed volcengineResponse
+		if err := json.Unmarshal(payload, &parsed); err != nil {
+			continue
+		}
+		if parsed.Error != "" {
+			log.Printf("[stt] volcengine error: %s", parsed.Error)
+			continue
+		}
+
+		// Emit any utterance that settled since the last message. They are
+		// only ever appended, so an index is enough to track what has gone out.
+		definite := 0
+		for _, u := range parsed.Result.Utterances {
+			if !u.Definite {
+				break
+			}
+			definite++
+		}
+		for i := emittedFinals; i < definite; i++ {
+			settled := strings.TrimSpace(parsed.Result.Utterances[i].Text)
+			if settled == "" {
+				continue
+			}
+			log.Printf("[stt] final: %q", settled)
+			onResult(TranscriptResult{Text: settled, IsFinal: true})
+		}
+		emittedFinals = definite
+
+		// The partial is the tail that has not settled — never result.text.
+		//
+		// result.text is the whole conversation so far, settled parts
+		// included, so forwarding it re-sends as a partial what already went
+		// out as a final. On screen the finished sentence appears a second
+		// time, and every partial for the next sentence carries the previous
+		// one glued to its front, which is what makes the transcript stutter
+		// where Deepgram's flows.
+		var pending strings.Builder
+		for i := definite; i < len(parsed.Result.Utterances); i++ {
+			pending.WriteString(parsed.Result.Utterances[i].Text)
+		}
+		text := strings.TrimSpace(pending.String())
+		if text == "" && len(parsed.Result.Utterances) == 0 {
+			// Before the first utterance is opened there is nothing to slice,
+			// and result.text carries no settled text yet either.
+			text = strings.TrimSpace(parsed.Result.Text)
+		}
+		if text == "" {
+			continue
+		}
+		onResult(TranscriptResult{Text: text, IsFinal: false})
+	}
+}
+
+// parseVolcengineFrame splits a server message into its type and payload,
+// decompressing when the header says the payload is gzipped.
+//
+// Server frames carry a sequence number the client frames do not, so the
+// payload starts 4 bytes later than the request format would suggest.
+func parseVolcengineFrame(data []byte) (msgType byte, payload []byte, ok bool) {
+	const serverHeaderLen = 12
+	if len(data) < serverHeaderLen {
+		return 0, nil, false
+	}
+
+	msgType = (data[1] >> 4) & 0x0F
+	payload = data[serverHeaderLen:]
+
+	if data[2]&0x0F == volcCompressionGzip {
+		r, err := gzip.NewReader(bytes.NewReader(payload))
+		if err != nil {
+			return 0, nil, false
+		}
+		defer r.Close()
+		decoded, err := io.ReadAll(r)
+		if err != nil {
+			return 0, nil, false
+		}
+		payload = decoded
+	}
+	return msgType, payload, true
+}
+
+// Close tells the service the stream ended and tears down the connection.
+func (c *volcengineClient) Close() {
+	c.writeMu.Lock()
+	already := c.closed
+	c.closed = true
+	c.writeMu.Unlock()
+	if already {
+		return
+	}
+
+	// An empty last-packet frame flushes whatever the model is still holding.
+	// Skipping it drops the tail of the final utterance.
+	buf := make([]byte, 8)
+	buf[0] = 0x11
+	buf[1] = volcTypeAudioOnly<<4 | volcFlagLastPacket
+	buf[2] = volcSerialisationJS
+	c.writeMu.Lock()
+	_ = c.conn.WriteMessage(websocket.BinaryMessage, buf)
+	c.writeMu.Unlock()
+
+	// Give the flush somewhere to land. Closing straight after the last-packet
+	// frame tears the socket down before the response arrives, so the caller's
+	// closing sentence is lost — the read loop just reports "use of closed
+	// network connection" and the last thing said in the call never surfaces.
+	// The deadline bounds the wait: an unresponsive service must not hold up
+	// session teardown.
+	_ = c.conn.SetReadDeadline(time.Now().Add(volcengineCloseGrace))
+	go func() {
+		time.Sleep(volcengineCloseGrace)
+		_ = c.conn.Close()
+		c.cancel()
+	}()
+}
+
+func truncateBytes(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "..."
+}

--- a/internal/stt/volcengine_test.go
+++ b/internal/stt/volcengine_test.go
@@ -1,0 +1,178 @@
+package stt
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"encoding/json"
+	"testing"
+)
+
+// serverFrame builds a response the way the service does: a 12-byte header
+// (the 4-byte prologue plus a sequence number) followed by the payload.
+func serverFrame(msgType byte, compressed bool, payload []byte) []byte {
+	if compressed {
+		var buf bytes.Buffer
+		w := gzip.NewWriter(&buf)
+		w.Write(payload)
+		w.Close()
+		payload = buf.Bytes()
+	}
+	frame := make([]byte, 12+len(payload))
+	frame[0] = 0x11
+	frame[1] = msgType<<4 | 0x00
+	frame[2] = volcSerialisationJS
+	if compressed {
+		frame[2] |= volcCompressionGzip
+	}
+	binary.BigEndian.PutUint32(frame[8:12], uint32(len(payload)))
+	copy(frame[12:], payload)
+	return frame
+}
+
+// The payload offset differs between the two directions — requests put it at
+// byte 8, responses at byte 12 because of the sequence number. Reading a
+// response at byte 8 yields four bytes of sequence number glued to the front
+// of the JSON, which fails to parse and silently drops every transcript.
+func TestVolcengineParsesServerPayloadOffset(t *testing.T) {
+	body := []byte(`{"result":{"text":"你好"}}`)
+	msgType, payload, ok := parseVolcengineFrame(serverFrame(volcTypeFullServer, false, body))
+	if !ok {
+		t.Fatal("frame rejected, want it parsed")
+	}
+	if msgType != volcTypeFullServer {
+		t.Errorf("msgType = %d, want %d", msgType, volcTypeFullServer)
+	}
+	if string(payload) != string(body) {
+		t.Errorf("payload = %q, want %q", payload, body)
+	}
+}
+
+// The service may gzip a payload; the compression bit in byte 2 is the only
+// signal. Missing it hands raw deflate bytes to the JSON decoder.
+func TestVolcengineDecompressesGzippedPayload(t *testing.T) {
+	body := []byte(`{"result":{"text":"压缩过的文本"}}`)
+	_, payload, ok := parseVolcengineFrame(serverFrame(volcTypeFullServer, true, body))
+	if !ok {
+		t.Fatal("frame rejected, want it parsed")
+	}
+	if string(payload) != string(body) {
+		t.Errorf("payload = %q, want it decompressed to %q", payload, body)
+	}
+}
+
+// A frame shorter than the header must be discarded rather than slicing out
+// of range — the connection can deliver a truncated message on teardown.
+func TestVolcengineRejectsShortFrame(t *testing.T) {
+	for _, n := range []int{0, 1, 8, 11} {
+		if _, _, ok := parseVolcengineFrame(make([]byte, n)); ok {
+			t.Errorf("%d-byte frame accepted, want it rejected", n)
+		}
+	}
+}
+
+// definite is what separates a settled utterance from a partial one. Treating
+// every result as final answers the caller mid-sentence; treating none as
+// final means no turn ever completes and the agent never speaks.
+func TestVolcengineDefiniteMarksFinal(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"no utterances", `{"result":{"text":"你好"}}`, false},
+		{"partial", `{"result":{"text":"你好","utterances":[{"text":"你好","definite":false}]}}`, false},
+		{"definite", `{"result":{"text":"你好。","utterances":[{"text":"你好。","definite":true}]}}`, true},
+		{"one of many definite", `{"result":{"text":"a b","utterances":[{"definite":false},{"definite":true}]}}`, true},
+	}
+	for _, tc := range cases {
+		var parsed volcengineResponse
+		if err := json.Unmarshal([]byte(tc.body), &parsed); err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		got := false
+		for _, u := range parsed.Result.Utterances {
+			if u.Definite {
+				got = true
+				break
+			}
+		}
+		if got != tc.want {
+			t.Errorf("%s: final = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// The client frame layout is fixed by the service; a wrong byte here fails as
+// an opaque protocol error rather than anything that names the cause.
+func TestVolcengineClientFrameLayout(t *testing.T) {
+	c := &volcengineClient{}
+	// writeFrame needs a connection, so assemble the header the same way and
+	// assert on the bytes rather than sending them.
+	payload := []byte(`{"a":1}`)
+	buf := make([]byte, 8+len(payload))
+	buf[0] = 0x11
+	buf[1] = volcTypeFullClient<<4 | volcFlagNone
+	buf[2] = volcSerialisationJS
+	binary.BigEndian.PutUint32(buf[4:8], uint32(len(payload)))
+	copy(buf[8:], payload)
+
+	if buf[0] != 0x11 {
+		t.Errorf("byte 0 = %#x, want 0x11 (version 1, 4-byte header)", buf[0])
+	}
+	if got := (buf[1] >> 4) & 0x0F; got != volcTypeFullClient {
+		t.Errorf("message type = %d, want %d", got, volcTypeFullClient)
+	}
+	if got := binary.BigEndian.Uint32(buf[4:8]); int(got) != len(payload) {
+		t.Errorf("declared length = %d, want %d", got, len(payload))
+	}
+	_ = c
+}
+
+// The last-packet flag is what tells the service the stream ended so it
+// flushes the tail of the final utterance. Sending a plain audio frame
+// instead loses the last words of the call.
+func TestVolcengineLastPacketFlag(t *testing.T) {
+	b := byte(volcTypeAudioOnly<<4 | volcFlagLastPacket)
+	if got := (b >> 4) & 0x0F; got != volcTypeAudioOnly {
+		t.Errorf("message type = %d, want %d", got, volcTypeAudioOnly)
+	}
+	if got := b & 0x0F; got != volcFlagLastPacket {
+		t.Errorf("flags = %#b, want %#b", got, volcFlagLastPacket)
+	}
+}
+
+// A partial must carry only the unsettled tail. result.text is the whole
+// conversation including everything already emitted as final, so forwarding it
+// re-sends a finished sentence as a partial — it appears twice on screen — and
+// prefixes every partial of the next sentence with the previous one.
+func TestVolcenginePartialExcludesSettledText(t *testing.T) {
+	body := `{"result":{"text":"你好。什么是大","utterances":[
+		{"text":"你好。","definite":true},
+		{"text":"什么是大","definite":false}]}}`
+
+	var parsed volcengineResponse
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	definite := 0
+	for _, u := range parsed.Result.Utterances {
+		if !u.Definite {
+			break
+		}
+		definite++
+	}
+
+	var pending bytes.Buffer
+	for i := definite; i < len(parsed.Result.Utterances); i++ {
+		pending.WriteString(parsed.Result.Utterances[i].Text)
+	}
+
+	if got := pending.String(); got != "什么是大" {
+		t.Errorf("partial = %q, want %q — settled text must not reappear", got, "什么是大")
+	}
+	if pending.String() == parsed.Result.Text {
+		t.Error("partial equals result.text, want only the unsettled tail")
+	}
+}


### PR DESCRIPTION
Adds `stt.provider = "volcengine"`, backed by ByteDance's seedasr model over `/api/v3/sauc/bigmodel`:

```toml
[stt]
provider = "volcengine"

[volcengine]
api_key = "..."
```

It matters mainly where Deepgram is slow to reach. On Mandarin it transcribes filler words, punctuation and spoken numbers correctly — `"嗯，今天好像有35度啊，确实比较热，我再考虑要不要开空调。"` came back in one piece — and the console starts with a free hourly allowance, so it is reachable without a card.

## The wire format

Binary, rather than the JSON text frames every other provider here uses: an 8-byte header (version, message type, serialisation, compression), then a big-endian length, then the payload.

Server frames carry a sequence number the client frames do not, so their payload starts four bytes later. Reading them at the request offset splices four bytes of sequence number onto the front of the JSON, and every transcript is silently dropped — there is a test pinning the offset for that reason.

## Six things that had to be measured

The published material is either out of date or wrong, and each of these fails in a way that does not name its cause:

**The resource id is `volc.seedasr.*`,** not the `volc.bigasr.*` that search results still show. The wrong one authenticates as far as `{"error":"load grant: requested grant not found in SaaS storage"}`, which reads like a billing problem rather than a typo.

**Authentication is a single `X-Api-Key`.** The older `X-Api-App-Key` + `X-Api-Access-Key` pair is rejected outright by these resources (400/401).

**`end_window_size` belongs at the top level of `request`.** The vendor samples nest it under a `vad` object, where it is silently ignored and the service falls back to its own default — measured at **5.3 seconds** of silence before an utterance settles, which on a call reads as the agent having hung up.

**`vad_segment_duration` is not a faster endpointing knob.** It is a hard segment length, and shortening it chops the caller mid-thought. Same sentence, same audio:

| setting | result |
|---|---|
| `end_window_size = 800` | `"你好，请用一句话介绍乒乓球。"` |
| `vad_segment_duration = 300` | `"你好。"` `"请。"` `"用。"` `"一句话。"` `"介绍。"` `"乒乓球。"` |

**Results are cumulative — the final path.** Every message repeats the whole conversation, and `utterances[0].definite` stays true once set. Reading that as "any definite means this text is final" emits a final on every subsequent message, so the agent answers once per word — `"你好。"`, then `"你好。请"`, then `"你好。请。用"`.

**Results are cumulative — the partial path too.** This one only showed up in a real call. `result.text` includes everything already emitted as final, so forwarding it as the partial re-sends a finished sentence (it appears a second time on screen) and prefixes every partial of the next sentence with the previous one. The transcript stutters where Deepgram's flows. `readLoop` emits only the utterances past the settled index, in both directions.

## Why 800ms and not Deepgram's 300

Shorter was tried. At `end_window_size = 300` a caller pausing to find a word had `"什么是那个训练数据库"` split into two turns and answered twice — the first reply addressing `"那个"` on its own, which is not a useful answer to anything. The service settles utterances in whole phrases, so a short window buys no responsiveness and only risks the split; the pipeline's own turn merging already covers mid-sentence pauses.

Barge-in is unaffected either way: it runs on the local VAD plus the backchannel window, measured at ~1s to cancel with both providers.

## Close

`Close` waits out a short grace period after the last-packet frame. Dropping the socket immediately tears it down before the flush comes back, and the last thing said in the call never surfaces — the read loop just logs `use of closed network connection`.

## Verification

- Live Mandarin call end to end — Volcengine in, `deepseek-chat`, MiMo out — replies landing 1-3 seconds after the caller stopped, barge-in cutting the agent off and the follow-up question answered rather than the interrupted sentence resumed.
- Seven unit tests over the framing (payload offset, gzip, short-frame rejection, client header layout, last-packet flag), the `definite` handling and the partial/final split. They run against constructed frames, so no key or network.
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.

## Notes

- Only the streaming ASR is wired up. Volcengine's TTS and its 1.0 ASR (`/api/v2/asr`, a different protocol and auth) are untouched.
- `resource_id` defaults to the hourly plan; `volc.seedasr.sauc.concurrent` bills by concurrency instead.
