### PR TITLE
turnbuffer: terminal punctuation should beat a pronoun tail

### DIFF
--- a/internal/pipeline/turnbuffer.go
+++ b/internal/pipeline/turnbuffer.go
@@ -20,6 +20,24 @@ const (
 	turnMergeIncomplete = 900 * time.Millisecond
 )
 
+// mergeWait returns how long to hold a pending turn before answering it.
+//
+// Terminal punctuation wins over a dangling-looking tail word. The tail list
+// exists to hold open utterances with no closer ("I already fixed it" — the
+// caller is still going), but it also matches pronouns, so a sentence the
+// provider punctuated as finished ("I already fixed it.") was taking the long
+// incomplete window too. When the STT has already judged the thought complete,
+// believe it; only an unpunctuated dangling tail extends the wait.
+func mergeWait(text string, base time.Duration) time.Duration {
+	if endsTerminal(text) {
+		return base
+	}
+	if endsIncomplete(text) || endsDictation(text) {
+		return turnMergeIncomplete
+	}
+	return base
+}
+
 // runTurnBuffer debounces final transcripts into whole turns. It waits a
 // short window after each final; a further final inside that window is merged
 // and the window restarts. The wait adapts to how the text ends:
@@ -98,12 +116,7 @@ func (p *Pipeline) runTurnBuffer() {
 			}
 
 			// A caller still mid-thought gets a longer grace period.
-			wait := base
-			if endsIncomplete(pending.Text) || endsDictation(pending.Text) {
-				wait = turnMergeIncomplete
-			} else if endsTerminal(pending.Text) {
-				wait = base
-			}
+			wait := mergeWait(pending.Text, base)
 			if elapsed := time.Since(turnBegan); elapsed+wait > turnMergeMax {
 				if remaining := turnMergeMax - elapsed; remaining > 0 {
 					wait = remaining

--- a/internal/pipeline/turnbuffer_test.go
+++ b/internal/pipeline/turnbuffer_test.go
@@ -1,0 +1,45 @@
+package pipeline
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMergeWait(t *testing.T) {
+	const base = 350 * time.Millisecond
+
+	cases := []struct {
+		name string
+		text string
+		want time.Duration
+	}{
+		// Terminal punctuation beats a pronoun tail: the provider already judged
+		// the thought complete, so the tail word is not evidence of a pause.
+		{"punctuated sentence ending on a pronoun", "I already fixed it.", base},
+		{"punctuated question", "can you check it?", base},
+		{"punctuated exclamation", "that worked!", base},
+
+		// The case the tail list exists for — same words, no closer.
+		{"unpunctuated pronoun tail", "I already fixed it", turnMergeIncomplete},
+		{"dangling conjunction", "I tried that and", turnMergeIncomplete},
+		{"filler tail", "so it was, um", turnMergeIncomplete},
+
+		// Dictation still extends: callers pause much longer between spelled
+		// segments than between words.
+		{"mid-dictation separator", "my email is gary dot", turnMergeIncomplete},
+		{"spelled letters", "it's g a r", turnMergeIncomplete},
+		{"digit run", "the number is 0 4 1 2", turnMergeIncomplete},
+		{"completed address is not mid-dictation", "gary@example.com.", base},
+
+		{"ordinary finished clause", "yes that's right", base},
+		{"empty", "", base},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := mergeWait(c.text, base); got != c.want {
+				t.Errorf("mergeWait(%q) = %v, want %v", c.text, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`endsIncomplete` is evaluated before `endsTerminal`, and `incompleteTailWords`
includes pronouns, so a sentence the provider punctuated as finished took the
long incomplete window — `"I already fixed it."` waited `turnMergeIncomplete`
rather than `base`. The `else if endsTerminal { wait = base }` branch below it
was unreachable for exactly those turns, and assigned `base` to `base` anyway.

The tail list is doing the right job for `"I already fixed it"` with no closer,
where the caller is still going. It just shouldn't outrank a terminal mark.

Pulls the selection into `mergeWait()` so the behaviour is testable without
standing up a `Pipeline`, and adds `turnbuffer_test.go` pinning both directions:
punctuated pronoun tails take `base`, unpunctuated ones still extend, and
dictation tails (`"gary dot"`, `"g a r"`, `"0 4 1 2"`) extend as before.

Verified locally with your CI steps — `gofmt -l`, `go build ./...`,
`go vet ./...`, `go test -race ./...` all clean. `internal/pipeline` passes as a
whole, so `acknowledgement_test.go` still exercises `runTurnBuffer` in situ.

Found while porting the turn-taking layer onto a telephony path (8 kHz µ-law, no
WebRTC): https://x.com/jasonshen_/status/2089925943385366962
