### PR TITLE
Add Alibaba Cloud (DashScope) streaming STT provider

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -33,7 +33,7 @@ turn_merge_ms = 350          # Debounce window for merging finals into one turn.
 provider = ""           # Supported: grok (empty = classic pipeline)
 
 [stt]
-provider = "deepgram"   # Supported: deepgram, openai, assemblyai, vibevoice, volcengine
+provider = "deepgram"   # Supported: aliyun, assemblyai, deepgram, openai, vibevoice, volcengine
 
 [llm]
 provider = "openai"     # Supported: openai, ollama, agent
@@ -156,6 +156,17 @@ model = ""              # Optional; defaults to speech-2.6-turbo (low latency). 
 asr_url = "ws://127.0.0.1:8200"    # WebSocket URL for VibeVoice ASR server
 tts_url = "http://127.0.0.1:8300"  # HTTP URL for VibeVoice TTS server
 voice = "en-Emma_woman"             # TTS voice name
+
+# Alibaba Cloud Model Studio (DashScope) streaming ASR. Used when
+# stt.provider = "aliyun". Get an API key at https://bailian.console.aliyun.com/
+[aliyun]
+api_key = ""            # Required
+model = ""              # Optional; defaults to paraformer-realtime-v2.
+                        # fun-asr-realtime is the alternative
+language = ""           # Optional hint for a multilingual model ("zh", "en"). Empty auto-detects
+vocabulary_id = ""      # Optional; a hotword list created in the console, for domain
+                        # terms the model keeps getting wrong
+url = ""                # Optional; defaults to wss://dashscope.aliyuncs.com/api-ws/v1/inference
 
 # Volcengine (Doubao) streaming ASR. Used when stt.provider = "volcengine".
 # Useful where Deepgram is slow to reach or its Mandarin is not good enough;

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	Agent      AgentConfig      `toml:"agent"`
 	VibeVoice  VibeVoiceConfig  `toml:"vibevoice"`
 	Volcengine VolcengineConfig `toml:"volcengine"`
+	Aliyun     AliyunConfig     `toml:"aliyun"`
 	Cartesia   CartesiaConfig   `toml:"cartesia"`
 	ElevenLabs ElevenLabsConfig `toml:"elevenlabs"`
 	Speechify  SpeechifyConfig  `toml:"speechify"`
@@ -320,6 +321,21 @@ type VibeVoiceConfig struct {
 	ASRURL string `toml:"asr_url"` // WebSocket URL for the ASR server
 	TTSURL string `toml:"tts_url"` // HTTP URL for the TTS server
 	Voice  string `toml:"voice"`   // TTS voice name
+}
+
+// AliyunConfig configures Alibaba Cloud Model Studio (DashScope) streaming ASR.
+type AliyunConfig struct {
+	APIKey string `toml:"api_key"`
+	// Model is the realtime recognition model. Empty uses
+	// paraformer-realtime-v2; fun-asr-realtime is the alternative.
+	Model string `toml:"model"`
+	// Language biases a multilingual model ("zh", "en"). Empty auto-detects.
+	Language string `toml:"language"`
+	// VocabularyID selects a hotword list created in the console, for domain
+	// terms the model keeps getting wrong.
+	VocabularyID string `toml:"vocabulary_id"`
+	// URL overrides the endpoint. Empty uses the public DashScope one.
+	URL string `toml:"url"`
 }
 
 // VolcengineConfig configures Volcengine (Doubao) streaming ASR.

--- a/internal/stt/aliyun.go
+++ b/internal/stt/aliyun.go
@@ -1,0 +1,276 @@
+package stt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+
+	"github.com/streamcoreai/streamcore-server/internal/config"
+)
+
+// Alibaba Cloud Model Studio (DashScope) streaming ASR
+// ----------------------------------------------------
+//
+//	Endpoint:  wss://dashscope.aliyuncs.com/api-ws/v1/inference
+//	Auth:      Authorization: Bearer <api key>
+//	Audio:     raw 16-bit signed little-endian PCM at 16kHz mono, sent as
+//	           binary frames roughly 100ms at a time.
+//
+// Control messages are JSON text frames and audio is binary, the same split
+// Deepgram uses. A session is three steps: send `run-task`, wait for
+// `task-started` before any audio, then stream. `finish-task` closes it.
+//
+// The result shape lines up with this package's contract without translation:
+// each `result-generated` carries one sentence, `sentence.text` is that
+// sentence alone rather than the conversation so far, and `sentence_end`
+// says whether it has settled.
+type aliyunClient struct {
+	conn   *websocket.Conn
+	cancel context.CancelFunc
+	taskID string
+
+	// writeMu serialises writes: gorilla/websocket allows a single concurrent
+	// writer, and Close races SendAudio when a call ends mid-utterance.
+	writeMu sync.Mutex
+	closed  bool
+
+	// started closes once task-started arrives. Audio sent before that is
+	// discarded by the service, taking the opening words of the call with it.
+	started chan struct{}
+}
+
+const (
+	aliyunURL        = "wss://dashscope.aliyuncs.com/api-ws/v1/inference"
+	aliyunSampleRate = 16000
+	// paraformer-realtime-v2 is the general-purpose realtime model. Mandarin
+	// plus Cantonese and other dialects; fun-asr-realtime is the alternative.
+	defaultAliyunModel = "paraformer-realtime-v2"
+)
+
+// NewAliyunClient dials Model Studio and completes the run-task handshake
+// before returning, so the caller can send audio immediately.
+func NewAliyunClient(ctx context.Context, cfg config.AliyunConfig, onResult func(TranscriptResult)) (Client, error) {
+	sttCtx, cancel := context.WithCancel(ctx)
+
+	endpoint := cfg.URL
+	if endpoint == "" {
+		endpoint = aliyunURL
+	}
+	model := cfg.Model
+	if model == "" {
+		model = defaultAliyunModel
+	}
+
+	hdr := http.Header{}
+	hdr.Set("Authorization", "Bearer "+cfg.APIKey)
+
+	conn, resp, err := websocket.DefaultDialer.DialContext(sttCtx, endpoint, hdr)
+	if err != nil {
+		cancel()
+		if resp != nil {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+			resp.Body.Close()
+			return nil, fmt.Errorf("aliyun dial: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+		return nil, fmt.Errorf("aliyun dial: %w", err)
+	}
+
+	c := &aliyunClient{
+		conn:    conn,
+		cancel:  cancel,
+		taskID:  strings.ReplaceAll(uuid.New().String(), "-", ""),
+		started: make(chan struct{}),
+	}
+
+	if err := c.sendRunTask(cfg, model); err != nil {
+		c.Close()
+		return nil, err
+	}
+
+	go c.readLoop(sttCtx, onResult)
+
+	// The service drops audio that arrives before it has acknowledged the
+	// task, so the handshake is completed here rather than left to race the
+	// first frames.
+	select {
+	case <-c.started:
+	case <-sttCtx.Done():
+		c.Close()
+		return nil, sttCtx.Err()
+	}
+
+	log.Printf("[stt] connected to Aliyun (%s)", model)
+	return c, nil
+}
+
+// aliyunMessage covers every frame in both directions; the discriminator is
+// header.action going out and header.event coming back.
+type aliyunMessage struct {
+	Header  aliyunHeader `json:"header"`
+	Payload any          `json:"payload,omitempty"`
+}
+
+type aliyunHeader struct {
+	Action    string `json:"action,omitempty"`
+	Event     string `json:"event,omitempty"`
+	TaskID    string `json:"task_id"`
+	Streaming string `json:"streaming,omitempty"`
+
+	ErrorCode    string `json:"error_code,omitempty"`
+	ErrorMessage string `json:"error_message,omitempty"`
+}
+
+type aliyunRunPayload struct {
+	TaskGroup  string           `json:"task_group"`
+	Task       string           `json:"task"`
+	Function   string           `json:"function"`
+	Model      string           `json:"model"`
+	Parameters aliyunParameters `json:"parameters"`
+	Input      struct{}         `json:"input"`
+}
+
+type aliyunParameters struct {
+	SampleRate int    `json:"sample_rate"`
+	Format     string `json:"format"`
+	// LanguageHints biases a multilingual model toward a language ("zh",
+	// "en"). Empty leaves the model to detect it.
+	LanguageHints []string `json:"language_hints,omitempty"`
+	// VocabularyID points at a hotword list created in the console, which is
+	// how domain terms that keep coming back wrong get fixed.
+	VocabularyID string `json:"vocabulary_id,omitempty"`
+}
+
+func (c *aliyunClient) sendRunTask(cfg config.AliyunConfig, model string) error {
+	var hints []string
+	if cfg.Language != "" {
+		hints = []string{cfg.Language}
+	}
+	return c.writeJSON(aliyunMessage{
+		Header: aliyunHeader{Action: "run-task", TaskID: c.taskID, Streaming: "duplex"},
+		Payload: aliyunRunPayload{
+			TaskGroup: "audio", Task: "asr", Function: "recognition",
+			Model: model,
+			Parameters: aliyunParameters{
+				SampleRate:    aliyunSampleRate,
+				Format:        "pcm",
+				LanguageHints: hints,
+				VocabularyID:  cfg.VocabularyID,
+			},
+		},
+	})
+}
+
+func (c *aliyunClient) writeJSON(m aliyunMessage) error {
+	body, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("aliyun marshal: %w", err)
+	}
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	if c.closed {
+		return fmt.Errorf("aliyun: connection closed")
+	}
+	return c.conn.WriteMessage(websocket.TextMessage, body)
+}
+
+// SendAudio forwards a chunk of PCM. The pipeline calls this every 20ms.
+func (c *aliyunClient) SendAudio(data []byte) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	if c.closed {
+		return fmt.Errorf("aliyun: connection closed")
+	}
+	return c.conn.WriteMessage(websocket.BinaryMessage, data)
+}
+
+// aliyunResult is a result-generated frame.
+type aliyunResult struct {
+	Header  aliyunHeader `json:"header"`
+	Payload struct {
+		Output struct {
+			Sentence struct {
+				// Text is this sentence only, not the conversation so far.
+				Text string `json:"text"`
+				// SentenceEnd marks the sentence settled; until then Text is
+				// still being revised.
+				SentenceEnd bool `json:"sentence_end"`
+			} `json:"sentence"`
+		} `json:"output"`
+	} `json:"payload"`
+}
+
+func (c *aliyunClient) readLoop(ctx context.Context, onResult func(TranscriptResult)) {
+	startedOnce := sync.Once{}
+
+	for {
+		typ, data, err := c.conn.ReadMessage()
+		if err != nil {
+			if ctx.Err() == nil {
+				log.Printf("[stt] aliyun read: %v", err)
+			}
+			return
+		}
+		if typ != websocket.TextMessage {
+			continue
+		}
+
+		var res aliyunResult
+		if err := json.Unmarshal(data, &res); err != nil {
+			continue
+		}
+
+		switch res.Header.Event {
+		case "task-started":
+			startedOnce.Do(func() { close(c.started) })
+
+		case "result-generated":
+			text := strings.TrimSpace(res.Payload.Output.Sentence.Text)
+			if text == "" {
+				continue
+			}
+			final := res.Payload.Output.Sentence.SentenceEnd
+			if final {
+				log.Printf("[stt] final: %q", text)
+			}
+			onResult(TranscriptResult{Text: text, IsFinal: final})
+
+		case "task-failed":
+			log.Printf("[stt] aliyun %s: %s", res.Header.ErrorCode, res.Header.ErrorMessage)
+			return
+
+		case "task-finished":
+			return
+		}
+	}
+}
+
+// Close asks the service to finish the task, then tears down the connection.
+func (c *aliyunClient) Close() {
+	c.writeMu.Lock()
+	already := c.closed
+	c.writeMu.Unlock()
+	if already {
+		return
+	}
+
+	// finish-task flushes the sentence still in progress. Closing the socket
+	// without it drops whatever the caller said last.
+	_ = c.writeJSON(aliyunMessage{
+		Header: aliyunHeader{Action: "finish-task", TaskID: c.taskID, Streaming: "duplex"},
+	})
+
+	c.writeMu.Lock()
+	c.closed = true
+	c.writeMu.Unlock()
+
+	_ = c.conn.Close()
+	c.cancel()
+}

--- a/internal/stt/aliyun_test.go
+++ b/internal/stt/aliyun_test.go
@@ -1,0 +1,189 @@
+package stt
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/streamcoreai/streamcore-server/internal/config"
+)
+
+// sentence_end is the whole final/partial distinction. Reading it wrong in one
+// direction answers the caller mid-sentence; in the other no turn ever
+// completes and the agent never speaks.
+func TestAliyunSentenceEndMarksFinal(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		text string
+		want bool
+	}{
+		{
+			"opening frame carries no text",
+			`{"payload":{"output":{"sentence":{"text":"","sentence_end":false,"sentence_begin":true}}}}`,
+			"", false,
+		},
+		{
+			"partial",
+			`{"payload":{"output":{"sentence":{"text":"你","sentence_end":false}}}}`,
+			"你", false,
+		},
+		{
+			"final",
+			`{"payload":{"output":{"sentence":{"text":"你好，请用一句话介绍乒乓球。","sentence_end":true}}}}`,
+			"你好，请用一句话介绍乒乓球。", true,
+		},
+	}
+	for _, tc := range cases {
+		var res aliyunResult
+		if err := json.Unmarshal([]byte(tc.body), &res); err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		if got := res.Payload.Output.Sentence.Text; got != tc.text {
+			t.Errorf("%s: text = %q, want %q", tc.name, got, tc.text)
+		}
+		if got := res.Payload.Output.Sentence.SentenceEnd; got != tc.want {
+			t.Errorf("%s: sentence_end = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// Sentence text is per-sentence, not the conversation so far. This is what
+// lets the results pass straight through: a provider that accumulates needs
+// the settled prefix stripped before the pipeline sees a partial, and getting
+// that wrong shows the finished sentence twice on screen.
+func TestAliyunSentenceTextIsNotCumulative(t *testing.T) {
+	first := `{"payload":{"output":{"sentence":{"sentence_id":1,"text":"你好。","sentence_end":true}}}}`
+	second := `{"payload":{"output":{"sentence":{"sentence_id":2,"text":"什么是大","sentence_end":false}}}}`
+
+	var a, b aliyunResult
+	if err := json.Unmarshal([]byte(first), &a); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(second), &b); err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.HasPrefix(b.Payload.Output.Sentence.Text, a.Payload.Output.Sentence.Text) {
+		t.Errorf("second sentence %q repeats the first %q — results are cumulative after all, and the adapter must strip the settled prefix",
+			b.Payload.Output.Sentence.Text, a.Payload.Output.Sentence.Text)
+	}
+}
+
+// A failure arrives as its own event with a code and message. Ignoring the
+// event leaves the call running against a dead task, transcribing nothing and
+// explaining nothing.
+func TestAliyunSurfacesTaskFailed(t *testing.T) {
+	body := `{"header":{"event":"task-failed","task_id":"abc","error_code":"ModelNotFound","error_message":"Model not found (qwen3-asr-flash-realtime)!"}}`
+
+	var res aliyunResult
+	if err := json.Unmarshal([]byte(body), &res); err != nil {
+		t.Fatal(err)
+	}
+	if res.Header.Event != "task-failed" {
+		t.Errorf("event = %q, want task-failed", res.Header.Event)
+	}
+	if res.Header.ErrorCode != "ModelNotFound" {
+		t.Errorf("error_code = %q, want it carried through", res.Header.ErrorCode)
+	}
+	if !strings.Contains(res.Header.ErrorMessage, "Model not found") {
+		t.Errorf("error_message = %q, want the provider text", res.Header.ErrorMessage)
+	}
+}
+
+// run-task is a fixed shape: task_group/task/function identify the operation,
+// and the service rejects the session outright if any is missing or wrong.
+func TestAliyunRunTaskShape(t *testing.T) {
+	c := &aliyunClient{taskID: "0123456789abcdef0123456789abcdef"}
+
+	// sendRunTask writes to a connection, so build the same message here and
+	// assert on it rather than dialling.
+	sent := aliyunMessage{
+		Header: aliyunHeader{Action: "run-task", TaskID: c.taskID, Streaming: "duplex"},
+		Payload: aliyunRunPayload{
+			TaskGroup: "audio", Task: "asr", Function: "recognition",
+			Model:      defaultAliyunModel,
+			Parameters: aliyunParameters{SampleRate: aliyunSampleRate, Format: "pcm"},
+		},
+	}
+
+	body, err := json.Marshal(sent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	header := decoded["header"].(map[string]any)
+	if header["action"] != "run-task" {
+		t.Errorf("action = %v, want run-task", header["action"])
+	}
+	if header["streaming"] != "duplex" {
+		t.Errorf("streaming = %v, want duplex", header["streaming"])
+	}
+	// The service expects a 32-character hex id, which is a UUID with its
+	// dashes removed — sending the dashed form is rejected.
+	if id, _ := header["task_id"].(string); len(id) != 32 || strings.Contains(id, "-") {
+		t.Errorf("task_id = %q, want 32 hex characters with no dashes", id)
+	}
+
+	payload := decoded["payload"].(map[string]any)
+	for k, want := range map[string]string{"task_group": "audio", "task": "asr", "function": "recognition"} {
+		if payload[k] != want {
+			t.Errorf("%s = %v, want %v", k, payload[k], want)
+		}
+	}
+	params := payload["parameters"].(map[string]any)
+	if params["format"] != "pcm" {
+		t.Errorf("format = %v, want pcm", params["format"])
+	}
+	if params["sample_rate"].(float64) != float64(aliyunSampleRate) {
+		t.Errorf("sample_rate = %v, want %d", params["sample_rate"], aliyunSampleRate)
+	}
+}
+
+// The optional fields must stay out of the request when unset. Sending an
+// empty vocabulary_id is not the same as omitting it — the service treats it
+// as a reference to a hotword list that does not exist.
+func TestAliyunOmitsUnsetOptionalParameters(t *testing.T) {
+	body, err := json.Marshal(aliyunParameters{SampleRate: aliyunSampleRate, Format: "pcm"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"language_hints", "vocabulary_id"} {
+		if strings.Contains(string(body), field) {
+			t.Errorf("unset %s present in %s, want it omitted", field, body)
+		}
+	}
+
+	withOpts, err := json.Marshal(aliyunParameters{
+		SampleRate: aliyunSampleRate, Format: "pcm",
+		LanguageHints: []string{"zh"}, VocabularyID: "vocab-123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{`"language_hints":["zh"]`, `"vocabulary_id":"vocab-123"`} {
+		if !strings.Contains(string(withOpts), field) {
+			t.Errorf("%s missing from %s", field, withOpts)
+		}
+	}
+}
+
+// An empty model falls back to the default rather than being sent blank,
+// which the service rejects as an unknown model.
+func TestAliyunDefaultsModel(t *testing.T) {
+	if defaultAliyunModel == "" {
+		t.Fatal("default model is empty")
+	}
+	cfg := config.AliyunConfig{APIKey: "k"}
+	model := cfg.Model
+	if model == "" {
+		model = defaultAliyunModel
+	}
+	if model != defaultAliyunModel {
+		t.Errorf("model = %q, want %q", model, defaultAliyunModel)
+	}
+}

--- a/internal/stt/stt.go
+++ b/internal/stt/stt.go
@@ -41,6 +41,11 @@ func NewClient(ctx context.Context, cfg *config.Config, onResult func(Transcript
 			return nil, fmt.Errorf("stt provider %q requires [assemblyai] api_key to be set", cfg.STT.Provider)
 		}
 		return NewAssemblyAIClient(ctx, cfg.AssemblyAI, onResult)
+	case "aliyun":
+		if cfg.Aliyun.APIKey == "" {
+			return nil, fmt.Errorf("stt provider %q requires [aliyun] api_key to be set", cfg.STT.Provider)
+		}
+		return NewAliyunClient(ctx, cfg.Aliyun, onResult)
 	case "volcengine":
 		if cfg.Volcengine.APIKey == "" {
 			return nil, fmt.Errorf("stt provider %q requires [volcengine] api_key to be set", cfg.STT.Provider)
@@ -49,6 +54,6 @@ func NewClient(ctx context.Context, cfg *config.Config, onResult func(Transcript
 	case "vibevoice":
 		return NewVibeVoiceClient(ctx, cfg.VibeVoice.ASRURL, onResult)
 	default:
-		return nil, fmt.Errorf("unknown stt provider %q (supported: deepgram, openai, assemblyai, vibevoice, volcengine)", cfg.STT.Provider)
+		return nil, fmt.Errorf("unknown stt provider %q (supported: aliyun, assemblyai, deepgram, openai, vibevoice, volcengine)", cfg.STT.Provider)
 	}
 }


### PR DESCRIPTION
Adds `stt.provider = "aliyun"`, backed by Alibaba Cloud Model Studio's realtime ASR:

```toml
[stt]
provider = "aliyun"

[aliyun]
api_key = "sk-..."
language = "zh"
```

Another option where Deepgram is slow to reach or its Mandarin is not good enough. The API key alone is enough — no workspace id, no signing. `paraformer-realtime-v2` is the default; `fun-asr-realtime` is the alternative.

## The protocol

JSON text frames for control, binary frames for audio — the same split Deepgram uses, so it reads like the other providers here. A session is three steps: `run-task`, wait for `task-started`, then stream 16kHz PCM. `finish-task` closes it.

**Audio sent before `task-started` is discarded.** Not buffered — dropped, and what it drops is the opening words of the call. So the handshake completes before `NewAliyunClient` returns rather than racing the first frames.

**`task_id` is 32 hex characters,** a UUID with its dashes removed. The dashed form is rejected, which is the kind of thing someone normalises back later without a test in the way.

**`Close` sends `finish-task` before tearing down the socket.** Dropping it first means the sentence still in progress never comes back, and the last thing said in the call is lost.

## Results pass straight through

Each `result-generated` carries one sentence: `sentence.text` is that sentence alone rather than the conversation so far, and `sentence_end` says whether it has settled. That maps onto `TranscriptResult` with no bookkeeping, so `readLoop` is about forty lines.

There is a test pinning the non-cumulative shape. It is the assumption the whole adapter rests on — a provider that accumulates needs the settled prefix stripped before the pipeline sees a partial, and getting that wrong shows a finished sentence a second time on screen and prefixes every partial of the next sentence with the previous one. If the service ever changes, that test fails before anyone hears it on a call.

## Verification

- Live Mandarin call end to end — Aliyun in, `deepseek-chat`, MiMo out. Fourteen finals over the call, one sentence each, no repeats and no clipped openings; `endpoint_ms` steady around 350.
- Handshake 0.29s, first partial 0.92s, measured against the live service.
- Six unit tests over the `sentence_end` final/partial split, the non-cumulative result shape, `task-failed` surfacing, the `run-task` shape including the dashless id, and omission of unset optional parameters. They run against constructed frames, so no key or network.
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.

## Notes

- `vocabulary_id` is optional and points at a hotword list created in the console, for domain terms the model keeps getting wrong.
- Only the streaming ASR is wired up; Model Studio's TTS and its file transcription API are untouched.
