### PR TITLE
Lead with the live demo, fix provider docs, allow all keys from env

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,13 +32,13 @@ turn_merge_ms = 350                  # Debounce window for merging finals into o
 provider = ""                        # "grok", or empty for the classic pipeline
 
 [stt]
-provider = "deepgram"
+provider = "deepgram"                # aliyun | assemblyai | deepgram | openai | vibevoice | volcengine
 
 [llm]
-provider = "openai"
+provider = "openai"                  # openai | ollama | agent
 
 [tts]
-provider = "cartesia"
+provider = "cartesia"                # cartesia | deepgram | elevenlabs | mimo | minimax | speechify | vibevoice
 
 # [grok]                             # Used when realtime.provider = "grok"
 # api_key = ""
@@ -67,6 +67,19 @@ utterance_end_ms = "1000"            # Silence (ms) before UtteranceEnd; flushes
 # format_turns = true                # Auto-punctuate and capitalise the final turn
 # end_of_turn_silence_ms = 0         # Override how long the model waits before ending a turn
 # keyterms = []
+
+# [aliyun]                           # Alibaba Cloud Model Studio (DashScope) streaming ASR
+# api_key = ""
+# model = ""                         # Defaults to paraformer-realtime-v2; fun-asr-realtime is the alternative
+# language = ""                      # Hint for a multilingual model ("zh", "en"); empty auto-detects
+# vocabulary_id = ""                 # Hotword list from the console, for terms it keeps getting wrong
+# url = ""                           # Defaults to wss://dashscope.aliyuncs.com/api-ws/v1/inference
+
+# [volcengine]                       # Doubao streaming ASR
+# api_key = ""                       # Console API key, sent as X-Api-Key; app-id + access-token is rejected
+# resource_id = ""                   # Defaults to volc.seedasr.sauc.duration (hourly); .concurrent bills by concurrency
+# model = ""                         # Defaults to bigmodel
+# end_window_ms = 0                  # Silence that settles an utterance, defaults to 800. Same role as endpointing
 
 [openai]
 api_key = ""
@@ -159,6 +172,8 @@ Provider keys use each provider's conventional variable name; secrets owned by t
 | `STREAMCORE_AGENT_API_KEY` | `agent.api_key` |
 | `DEEPGRAM_API_KEY` | `deepgram.api_key` |
 | `ASSEMBLYAI_API_KEY` | `assemblyai.api_key` |
+| `ALIYUN_API_KEY` | `aliyun.api_key` |
+| `VOLCENGINE_API_KEY` | `volcengine.api_key` |
 | `OPENAI_API_KEY` | `openai.api_key` |
 | `XAI_API_KEY` | `grok.api_key` |
 | `CARTESIA_API_KEY` | `cartesia.api_key` |

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -32,13 +32,13 @@ turn_merge_ms = 350                  # Debounce window for merging finals into o
 provider = ""                        # "grok", or empty for the classic pipeline
 
 [stt]
-provider = "deepgram"
+provider = "deepgram"                # aliyun | assemblyai | deepgram | openai | vibevoice | volcengine
 
 [llm]
-provider = "openai"
+provider = "openai"                  # openai | ollama | agent
 
 [tts]
-provider = "cartesia"
+provider = "cartesia"                # cartesia | deepgram | elevenlabs | mimo | minimax | speechify | vibevoice
 
 # [grok]                             # Used when realtime.provider = "grok"
 # api_key = ""
@@ -67,6 +67,19 @@ utterance_end_ms = "1000"            # Silence (ms) before UtteranceEnd; flushes
 # format_turns = true                # Auto-punctuate and capitalise the final turn
 # end_of_turn_silence_ms = 0         # Override how long the model waits before ending a turn
 # keyterms = []
+
+# [aliyun]                           # Alibaba Cloud Model Studio (DashScope) streaming ASR
+# api_key = ""
+# model = ""                         # Defaults to paraformer-realtime-v2; fun-asr-realtime is the alternative
+# language = ""                      # Hint for a multilingual model ("zh", "en"); empty auto-detects
+# vocabulary_id = ""                 # Hotword list from the console, for terms it keeps getting wrong
+# url = ""                           # Defaults to wss://dashscope.aliyuncs.com/api-ws/v1/inference
+
+# [volcengine]                       # Doubao streaming ASR
+# api_key = ""                       # Console API key, sent as X-Api-Key; app-id + access-token is rejected
+# resource_id = ""                   # Defaults to volc.seedasr.sauc.duration (hourly); .concurrent bills by concurrency
+# model = ""                         # Defaults to bigmodel
+# end_window_ms = 0                  # Silence that settles an utterance, defaults to 800. Same role as endpointing
 
 [openai]
 api_key = ""
@@ -159,6 +172,8 @@ voice = "en-Emma_woman"
 | `STREAMCORE_AGENT_API_KEY` | `agent.api_key` |
 | `DEEPGRAM_API_KEY` | `deepgram.api_key` |
 | `ASSEMBLYAI_API_KEY` | `assemblyai.api_key` |
+| `ALIYUN_API_KEY` | `aliyun.api_key` |
+| `VOLCENGINE_API_KEY` | `volcengine.api_key` |
 | `OPENAI_API_KEY` | `openai.api_key` |
 | `XAI_API_KEY` | `grok.api_key` |
 | `CARTESIA_API_KEY` | `cartesia.api_key` |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -4,9 +4,9 @@
 
 | Role | Providers | Required credentials |
 |------|-----------|----------------------|
-| STT | `deepgram`, `assemblyai`, `openai`, `vibevoice` | Deepgram API key, AssemblyAI API key, OpenAI API key, or a local VibeVoice ASR server |
+| STT | `aliyun`, `assemblyai`, `deepgram`, `openai`, `vibevoice`, `volcengine` | Matching provider API key, or a local VibeVoice ASR server |
 | LLM | `openai`, `ollama`, `agent` | OpenAI API key, an Ollama instance you control, or your own HTTP agent endpoint |
-| TTS | `cartesia`, `deepgram`, `elevenlabs`, `minimax`, `speechify`, `vibevoice` | Matching provider API key, or a local VibeVoice TTS server |
+| TTS | `cartesia`, `deepgram`, `elevenlabs`, `mimo`, `minimax`, `speechify`, `vibevoice` | Matching provider API key, or a local VibeVoice TTS server |
 | Speech-to-speech | `grok` | xAI API key — replaces STT, LLM, and TTS together |
 | RAG (optional) | `pgvector`, `supabase` | Postgres connection string or Supabase URL + key, plus an OpenAI key for embeddings |
 
@@ -17,6 +17,9 @@ Notes:
 - `llm.provider = "agent"` POSTs each turn to an HTTP endpoint you host; your agent owns memory, prompting, and tools, and replies stream back as SSE, chunked text, or JSON. See [Bring your own agent](./bring-your-own-agent.md).
 - `stt.provider = "vibevoice"` and `tts.provider = "vibevoice"` use local models; start the Python sidecars first.
 - `tts.provider = "minimax"` covers 40+ languages and is the strongest option for Mandarin. See [MiniMax TTS](#minimax-tts) for the region and model-plan caveats.
+- `tts.provider = "mimo"` is Xiaomi's MiMo TTS, with Chinese and English voices and optional voice cloning on the paid models.
+- `stt.provider = "aliyun"` is Alibaba Cloud Model Studio (DashScope) streaming ASR; `vocabulary_id` biases it toward domain terms.
+- `stt.provider = "volcengine"` is Doubao streaming ASR — useful where Deepgram is slow to reach or its Mandarin is not good enough. The console gives a free hourly allowance.
 - `realtime.provider = "grok"` switches to speech-to-speech and ignores `[stt]`, `[llm]`, and `[tts]` entirely.
 
 Every key and knob lives in the [configuration reference](./configuration.md).

--- a/docs/providers.zh-CN.md
+++ b/docs/providers.zh-CN.md
@@ -4,9 +4,9 @@
 
 | 角色 | 服务商 | 所需凭据 |
 |------|-----------|----------------------|
-| STT | `deepgram`、`assemblyai`、`openai`、`vibevoice` | Deepgram API key、AssemblyAI API key、OpenAI API key，或一个本地 VibeVoice ASR 服务 |
+| STT | `aliyun`、`assemblyai`、`deepgram`、`openai`、`vibevoice`、`volcengine` | 对应服务商的 API key，或一个本地 VibeVoice ASR 服务 |
 | LLM | `openai`、`ollama`、`agent` | OpenAI API key、你自己掌控的 Ollama 实例，或你自己的 HTTP 智能体端点 |
-| TTS | `cartesia`、`deepgram`、`elevenlabs`、`minimax`、`speechify`、`vibevoice` | 对应服务商的 API key，或一个本地 VibeVoice TTS 服务 |
+| TTS | `cartesia`、`deepgram`、`elevenlabs`、`mimo`、`minimax`、`speechify`、`vibevoice` | 对应服务商的 API key，或一个本地 VibeVoice TTS 服务 |
 | 语音到语音 | `grok` | xAI API key —— 一并取代 STT、LLM 与 TTS |
 | RAG（可选） | `pgvector`、`supabase` | Postgres 连接串或 Supabase URL + key，另需 OpenAI key 用于 embedding |
 
@@ -17,6 +17,9 @@
 - `llm.provider = "agent"` 把每一轮对话 POST 到你托管的 HTTP 端点；记忆、提示词与工具都由你的智能体掌控，回复以 SSE、分块文本或 JSON 流式返回。见[接入你自己的智能体](./bring-your-own-agent.zh-CN.md)。
 - `stt.provider = "vibevoice"` 与 `tts.provider = "vibevoice"` 使用本地模型；请先启动 Python 边车进程。
 - `tts.provider = "minimax"` 覆盖 40+ 语言，是中文场景下最强的选项。区域与套餐相关的坑见 [MiniMax TTS](#minimax-tts)。
+- `tts.provider = "mimo"` 是小米 MiMo TTS，中英文音色齐备，付费模型还支持声音克隆。
+- `stt.provider = "aliyun"` 是阿里云百炼（DashScope）流式 ASR；`vocabulary_id` 可以把模型往你的领域词上带。
+- `stt.provider = "volcengine"` 是豆包流式 ASR —— 适合 Deepgram 访问慢、或它的中文识别不够好的场景。控制台有免费时长可以先试。
 - `realtime.provider = "grok"` 切换到语音到语音模式，并完全忽略 `[stt]`、`[llm]` 与 `[tts]`。
 
 所有 key 与可调项都在[配置参考](./configuration.zh-CN.md)里。

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -506,6 +506,8 @@ var envOverrides = []struct {
 	{"STREAMCORE_AGENT_API_KEY", func(c *Config) *string { return &c.Agent.APIKey }},
 	{"DEEPGRAM_API_KEY", func(c *Config) *string { return &c.Deepgram.APIKey }},
 	{"ASSEMBLYAI_API_KEY", func(c *Config) *string { return &c.AssemblyAI.APIKey }},
+	{"ALIYUN_API_KEY", func(c *Config) *string { return &c.Aliyun.APIKey }},
+	{"VOLCENGINE_API_KEY", func(c *Config) *string { return &c.Volcengine.APIKey }},
 	{"OPENAI_API_KEY", func(c *Config) *string { return &c.OpenAI.APIKey }},
 	{"XAI_API_KEY", func(c *Config) *string { return &c.Grok.APIKey }},
 	{"CARTESIA_API_KEY", func(c *Config) *string { return &c.Cartesia.APIKey }},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -81,6 +82,55 @@ func TestConfigExampleDocumentsEveryField(t *testing.T) {
 		sort.Strings(missing)
 		t.Fatalf("config.toml.example does not document: %s", strings.Join(missing, ", "))
 	}
+}
+
+// Every credential must be settable from the environment, with no exceptions —
+// a provider you can only configure through the file is one you cannot deploy
+// in a container without baking the secret into an image.
+func TestEveryCredentialHasAnEnvOverride(t *testing.T) {
+	covered := make(map[string]struct{}, len(envOverrides))
+	cfg := &Config{}
+	for _, o := range envOverrides {
+		covered[fmt.Sprintf("%p", o.field(cfg))] = struct{}{}
+	}
+
+	var missing []string
+	for _, path := range configPaths(reflect.TypeOf(Config{}), "") {
+		name := path[strings.LastIndex(path, ".")+1:]
+		if name != "api_key" && name != "connection_string" {
+			continue
+		}
+		if _, ok := covered[fmt.Sprintf("%p", fieldByTOMLPath(cfg, path))]; !ok {
+			missing = append(missing, path)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Fatalf("no environment override for: %s", strings.Join(missing, ", "))
+	}
+}
+
+// fieldByTOMLPath resolves a dotted path of TOML tags to the string field it
+// names, so the test can compare against the pointers envOverrides hands out.
+func fieldByTOMLPath(cfg *Config, path string) *string {
+	value := reflect.ValueOf(cfg).Elem()
+	for segment := range strings.SplitSeq(path, ".") {
+		found := false
+		for i := 0; i < value.NumField(); i++ {
+			if value.Type().Field(i).Tag.Get("toml") == segment {
+				value = value.Field(i)
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil
+		}
+	}
+	if value.Kind() != reflect.String {
+		return nil
+	}
+	return value.Addr().Interface().(*string)
 }
 
 // writeConfig writes a TOML file and returns its path.


### PR DESCRIPTION
This pull request expands support for speech-to-text (STT) providers by adding Alibaba Cloud Model Studio (DashScope, `aliyun`) and Doubao (`volcengine`) as new options. It updates documentation in both English and Chinese to reflect these additions, ensures that environment variable overrides are available for their credentials, and adds a test to guarantee every credential can be set via environment variables for containerized deployments.

**Provider support and documentation updates:**

* Added `aliyun` (Alibaba Cloud Model Studio/DashScope) and `volcengine` (Doubao) as supported STT providers in documentation (`docs/configuration.md`, `docs/configuration.zh-CN.md`, `docs/providers.md`, `docs/providers.zh-CN.md`). [[1]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180L35-R41) [[2]](diffhunk://#diff-d1e97b5eeb786f7481b6488bb3cdbfbe9f3ac0904f3e329374ac7b60553092b2L35-R41) [[3]](diffhunk://#diff-1f4530da7901bb174ea61b8e3a7736fef5a2e8c07b0fc526f0a9dfd9ece1d7b3L7-R9) [[4]](diffhunk://#diff-9c272a777681f23a51d1a1e68d0c3c7b455ec3b1635ac154dc8911b54e3eb9b9L7-R9)
* Documented new provider-specific configuration options and added explanatory notes for both providers in English and Chinese docs. [[1]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R71-R83) [[2]](diffhunk://#diff-d1e97b5eeb786f7481b6488bb3cdbfbe9f3ac0904f3e329374ac7b60553092b2R71-R83) [[3]](diffhunk://#diff-1f4530da7901bb174ea61b8e3a7736fef5a2e8c07b0fc526f0a9dfd9ece1d7b3R20-R22) [[4]](diffhunk://#diff-9c272a777681f23a51d1a1e68d0c3c7b455ec3b1635ac154dc8911b54e3eb9b9R20-R22)

**Environment variable and configuration support:**

* Registered `ALIYUN_API_KEY` and `VOLCENGINE_API_KEY` as environment variable overrides for their respective API keys in both documentation and code (`internal/config/config.go`). [[1]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R175-R176) [[2]](diffhunk://#diff-d1e97b5eeb786f7481b6488bb3cdbfbe9f3ac0904f3e329374ac7b60553092b2R175-R176) [[3]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR509-R510)

**Testing and reliability:**

* Added a test (`TestEveryCredentialHasAnEnvOverride`) to ensure every credential (API key or connection string) in the configuration can be set via an environment variable, preventing missed overrides and supporting secure container deployments (`internal/config/config_test.go`).

**Other provider list improvements:**

* Included `mimo` as a TTS provider in documentation, with a descriptive note about its features. [[1]](diffhunk://#diff-1f4530da7901bb174ea61b8e3a7736fef5a2e8c07b0fc526f0a9dfd9ece1d7b3L7-R9) [[2]](diffhunk://#diff-1f4530da7901bb174ea61b8e3a7736fef5a2e8c07b0fc526f0a9dfd9ece1d7b3R20-R22) [[3]](diffhunk://#diff-9c272a777681f23a51d1a1e68d0c3c7b455ec3b1635ac154dc8911b54e3eb9b9L7-R9) [[4]](diffhunk://#diff-9c272a777681f23a51d1a1e68d0c3c7b455ec3b1635ac154dc8911b54e3eb9b9R20-R22)

These changes improve flexibility and deployment security by broadening provider support and enforcing environment-based configuration for credentials.