### PR TITLE
Add internal pprof listener

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -9,6 +9,12 @@ api_key = ""            # API key required to call POST /token. Leave empty to a
 session_grace_ms = 30000 # How long a session with no connected peers is kept before it is reaped. The window lets a client recover a dropped connection (ICE restart or redial) without losing the conversation.
 max_sessions = 0        # Global cap on live sessions; past it POST /whip returns 503 with Retry-After. 0 = unlimited. Each session burns CPU and provider spend, so set this to what one instance can actually serve.
 
+[debug]
+bind = ""                      # pprof listener. Empty disables it; use 127.0.0.1:6060 and an SSH tunnel in production.
+allow_public = false            # Required acknowledgement when bind is not loopback. Public pprof endpoints expose process data and can consume CPU.
+block_profile_rate = 0          # Average nanoseconds blocked per sample; 1 records every event. 0 disables block profiling.
+mutex_profile_fraction = 0      # Sample 1 in this many mutex contention events; 1 records every event. 0 disables mutex profiling.
+
 [plugins]
 directory = "./plugins"     # Required if you want plugins and skills loaded
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,12 @@ port = "8080"
 # session_grace_ms = 30000  # Grace period before a session with no peers is reaped (allows ICE restart / redial)
 # max_sessions = 0     # Global cap on live sessions; past it POST /whip returns 503 + Retry-After. 0 = unlimited
 
+[debug]
+bind = ""                      # Empty disables pprof; use 127.0.0.1:6060 and an SSH tunnel in production
+allow_public = false            # Must be true to bind pprof to a non-loopback address
+block_profile_rate = 0          # 1 records every blocking event; 0 disables block profiling
+mutex_profile_fraction = 0      # 1 records every mutex contention event; 0 disables mutex profiling
+
 [plugins]
 directory = "./plugins"
 
@@ -144,6 +150,8 @@ Notes:
 
 - `server.public_ip` plus `server.turn_secret` enables the built-in Pion STUN/TURN server, replacing an external coturn container. TURN listens on UDP and TCP 3478 and relays media on UDP 50001–60000.
 - `server.max_sessions` bounds the blast radius of distributed clients: the per-IP rate limit cannot, and every session burns CPU and provider spend. Past the cap, `POST /whip` returns 503 with `Retry-After`; session resumes are exempt, since they reattach to a session that is already counted. Size it to what one instance can actually serve.
+- `debug.bind` enables Go's pprof handlers on a separate listener. Keep it on loopback and reach it through an SSH tunnel; a non-loopback address is rejected unless `debug.allow_public = true` explicitly acknowledges that profiles expose process data and CPU profiles consume resources. The public server never serves `/debug/pprof/`.
+- `debug.block_profile_rate` and `debug.mutex_profile_fraction` enable the corresponding runtime profiles while the debug listener is active. Both default to `0` (off); set either to `1` to record every event while diagnosing contention.
 - `plugins.directory` is required for plugins and skills to load; omit it and discovery is skipped.
 - `pipeline.barge_in` lets users interrupt the agent while it is speaking. Agent audio ducks as soon as the caller starts talking over it and recovers if the interruption turns out to be a backchannel.
 - `pipeline.greeting` plays when a session connects. `pipeline.greeting_outgoing` is used for outbound SIP calls when present.
@@ -157,6 +165,14 @@ Notes:
 - `cartesia.max_concurrency` should match your plan's TTS concurrency limit — Cartesia counts active generations, not calls, and returns 429 past the limit.
 - `minimax.base_url` selects the region. Leave it unset for the global endpoint; mainland-China accounts must point it at `https://api.minimaxi.com/v1`, since keys do not work across the two platforms.
 - `minimax.model` must match your plan: a Token Plan key (`sk-cp-`) only covers `speech-2.8-hd`, while any other model bills pay-as-you-go and errors with `2056` on a zero balance.
+
+With `debug.bind = "127.0.0.1:6060"`, collect the profiles most useful for a long-running server with:
+
+```bash
+go tool pprof http://localhost:6060/debug/pprof/heap
+go tool pprof http://localhost:6060/debug/pprof/profile  # collects a 30-second CPU profile
+curl 'http://localhost:6060/debug/pprof/goroutine?debug=2'
+```
 
 ## Secrets from environment variables
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ import (
 // then unused.
 type Config struct {
 	Server     ServerConfig     `toml:"server"`
+	Debug      DebugConfig      `toml:"debug"`
 	Plugins    PluginsConfig    `toml:"plugins"`
 	Pipeline   PipelineConfig   `toml:"pipeline"`
 	Realtime   RealtimeConfig   `toml:"realtime"`
@@ -42,6 +43,13 @@ type Config struct {
 	MiMo       MiMoConfig       `toml:"mimo"`
 	Pgvector   PgvectorConfig   `toml:"pgvector"`
 	Supabase   SupabaseConfig   `toml:"supabase"`
+}
+
+type DebugConfig struct {
+	Bind                 string `toml:"bind"`
+	AllowPublic          bool   `toml:"allow_public"`
+	BlockProfileRate     int    `toml:"block_profile_rate"`
+	MutexProfileFraction int    `toml:"mutex_profile_fraction"`
 }
 
 type PluginsConfig struct {

--- a/main.go
+++ b/main.go
@@ -2,16 +2,19 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
-
-	"encoding/json"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/streamcoreai/streamcore-server/internal/config"
@@ -27,6 +30,10 @@ func main() {
 	cfg, err := config.Load("")
 	if err != nil {
 		log.Fatalf("config: %v", err)
+	}
+	debugSrv, err := startDebugServer(cfg.Debug)
+	if err != nil {
+		log.Fatalf("debug server: %v", err)
 	}
 
 	if cfg.RealtimeEnabled() {
@@ -72,24 +79,18 @@ func main() {
 
 	sm := session.NewManager(cfg, pluginMgr, ragClient)
 
-	mux := http.NewServeMux()
 	whipHandler := signaling.NewWHIPHandler(sm)
 	if cfg.Server.JWTSecret != "" {
 		log.Println("JWT authentication enabled for /whip")
 		whipHandler = jwtMiddleware(cfg.Server.JWTSecret, whipHandler)
 	}
-	mux.HandleFunc("/whip", whipHandler)
-	mux.HandleFunc("/whip/", whipHandler)
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
-	})
 
+	var issueToken http.HandlerFunc
 	if cfg.Server.JWTSecret != "" {
-		mux.HandleFunc("/token", tokenHandler(cfg.Server.JWTSecret, cfg.Server.APIKey))
+		issueToken = tokenHandler(cfg.Server.JWTSecret, cfg.Server.APIKey)
 	}
 
-	handler := corsMiddleware(mux)
+	handler := corsMiddleware(newPublicMux(whipHandler, issueToken))
 
 	srv := &http.Server{
 		Addr:    ":" + cfg.Server.Port,
@@ -130,7 +131,66 @@ func main() {
 	if err := srv.Shutdown(shutdownCtx); err != nil {
 		log.Printf("HTTP shutdown error: %v", err)
 	}
+	if debugSrv != nil {
+		if err := debugSrv.Shutdown(shutdownCtx); err != nil {
+			log.Printf("debug HTTP shutdown error: %v", err)
+		}
+	}
 	log.Println("Server stopped")
+}
+
+func newPublicMux(whipHandler, issueToken http.HandlerFunc) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/whip", whipHandler)
+	mux.HandleFunc("/whip/", whipHandler)
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+	if issueToken != nil {
+		mux.HandleFunc("/token", issueToken)
+	}
+	return mux
+}
+
+func startDebugServer(cfg config.DebugConfig) (*http.Server, error) {
+	if cfg.Bind == "" {
+		return nil, nil
+	}
+	if cfg.BlockProfileRate < 0 {
+		return nil, fmt.Errorf("block_profile_rate must not be negative")
+	}
+	if cfg.MutexProfileFraction < 0 {
+		return nil, fmt.Errorf("mutex_profile_fraction must not be negative")
+	}
+
+	listener, err := net.Listen("tcp", cfg.Bind)
+	if err != nil {
+		return nil, fmt.Errorf("listen on %q: %w", cfg.Bind, err)
+	}
+	if !cfg.AllowPublic {
+		addr, ok := listener.Addr().(*net.TCPAddr)
+		if !ok || !addr.IP.IsLoopback() {
+			listener.Close()
+			return nil, fmt.Errorf("bind %q resolves to a non-loopback address; set debug.allow_public = true to acknowledge public pprof exposure", cfg.Bind)
+		}
+	}
+
+	runtime.SetBlockProfileRate(cfg.BlockProfileRate)
+	runtime.SetMutexProfileFraction(cfg.MutexProfileFraction)
+
+	srv := &http.Server{
+		Addr:              listener.Addr().String(),
+		Handler:           http.DefaultServeMux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() {
+		log.Printf("Debug pprof server listening on %s", srv.Addr)
+		if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("debug server error: %v", err)
+		}
+	}()
+	return srv, nil
 }
 
 func corsMiddleware(next http.Handler) http.Handler {

--- a/main_test.go
+++ b/main_test.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/streamcoreai/streamcore-server/internal/config"
 	"github.com/streamcoreai/streamcore-server/internal/signaling"
 )
 
@@ -118,5 +121,50 @@ func TestResourceIDCannotBeMintedWithoutTheAPIKey(t *testing.T) {
 
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestPublicMuxDoesNotServePprof(t *testing.T) {
+	mux := newPublicMux(func(http.ResponseWriter, *http.Request) {}, nil)
+	req := httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestDebugServerServesPprofOnLoopback(t *testing.T) {
+	srv, err := startDebugServer(config.DebugConfig{Bind: "127.0.0.1:0"})
+	if err != nil {
+		t.Fatalf("startDebugServer: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			t.Errorf("shutdown debug server: %v", err)
+		}
+	})
+
+	resp, err := http.Get("http://" + srv.Addr + "/debug/pprof/")
+	if err != nil {
+		t.Fatalf("GET pprof index: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestDebugServerRejectsPublicBindWithoutAcknowledgement(t *testing.T) {
+	_, err := startDebugServer(config.DebugConfig{Bind: "0.0.0.0:0"})
+	if err == nil {
+		t.Fatal("public debug bind was accepted without allow_public")
+	}
+	if !strings.Contains(err.Error(), "debug.allow_public = true") {
+		t.Fatalf("error = %q, want allow_public guidance", err)
 	}
 }


### PR DESCRIPTION
## Summary

  - add an opt-in pprof server on a separate internal listener
  - reject non-loopback binds unless `debug.allow_public` is explicitly enabled
  - add optional block and mutex profiling settings
  - keep pprof endpoints off the public HTTP mux
  - document configuration and common profiling commands
  - add tests for listener isolation and bind safety

  ## Testing

  - `gofmt -l .`
  - `go build ./...`
  - `go vet ./...`
  - `go test -race ./...`

  Closes #57