### PR TITLE
Add Alibaba Cloud (DashScope) streaming TTS provider

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -45,7 +45,7 @@ provider = "deepgram"   # Supported: aliyun, assemblyai, deepgram, openai, vibev
 provider = "openai"     # Supported: openai, ollama, agent
 
 [tts]
-provider = "cartesia"   # Supported: cartesia, deepgram, elevenlabs, mimo, minimax, speechify, vibevoice
+provider = "cartesia"   # Supported: aliyun, cartesia, deepgram, elevenlabs, mimo, minimax, speechify, vibevoice
 
 # Provider credentials
 
@@ -163,15 +163,20 @@ asr_url = "ws://127.0.0.1:8200"    # WebSocket URL for VibeVoice ASR server
 tts_url = "http://127.0.0.1:8300"  # HTTP URL for VibeVoice TTS server
 voice = "en-Emma_woman"             # TTS voice name
 
-# Alibaba Cloud Model Studio (DashScope) streaming ASR. Used when
-# stt.provider = "aliyun". Get an API key at https://bailian.console.aliyun.com/
+# Alibaba Cloud Model Studio (DashScope). One endpoint and one key serve both
+# streaming ASR (stt.provider = "aliyun") and streaming TTS
+# (tts.provider = "aliyun"). Get an API key at https://bailian.console.aliyun.com/
 [aliyun]
 api_key = ""            # Required
-model = ""              # Optional; defaults to paraformer-realtime-v2.
+model = ""              # STT. Optional; defaults to paraformer-realtime-v2.
                         # fun-asr-realtime is the alternative
-language = ""           # Optional hint for a multilingual model ("zh", "en"). Empty auto-detects
-vocabulary_id = ""      # Optional; a hotword list created in the console, for domain
+language = ""           # STT. Optional hint for a multilingual model ("zh", "en"). Empty auto-detects
+vocabulary_id = ""      # STT. Optional; a hotword list created in the console, for domain
                         # terms the model keeps getting wrong
+tts_model = ""          # TTS. Optional; defaults to cosyvoice-v2
+voice = ""              # TTS. Optional; defaults to longxiaochun_v2. Voices are tied to a
+                        # model generation — a v1 voice on cosyvoice-v2 is rejected, so
+                        # change tts_model and voice together
 url = ""                # Optional; defaults to wss://dashscope.aliyuncs.com/api-ws/v1/inference
 
 # Volcengine (Doubao) streaming ASR. Used when stt.provider = "volcengine".

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -331,7 +331,8 @@ type VibeVoiceConfig struct {
 	Voice  string `toml:"voice"`   // TTS voice name
 }
 
-// AliyunConfig configures Alibaba Cloud Model Studio (DashScope) streaming ASR.
+// AliyunConfig configures Alibaba Cloud Model Studio (DashScope), which serves
+// both streaming ASR and streaming TTS from the same endpoint and key.
 type AliyunConfig struct {
 	APIKey string `toml:"api_key"`
 	// Model is the realtime recognition model. Empty uses
@@ -344,6 +345,14 @@ type AliyunConfig struct {
 	VocabularyID string `toml:"vocabulary_id"`
 	// URL overrides the endpoint. Empty uses the public DashScope one.
 	URL string `toml:"url"`
+
+	// TTSModel is the synthesis model used when tts.provider = "aliyun".
+	// Empty uses cosyvoice-v2. Kept separate from Model because one [aliyun]
+	// section can drive both directions at once.
+	TTSModel string `toml:"tts_model"`
+	// Voice is the synthesis voice. Voices are tied to a model generation —
+	// a v1 voice on cosyvoice-v2 is rejected — so change both together.
+	Voice string `toml:"voice"`
 }
 
 // VolcengineConfig configures Volcengine (Doubao) streaming ASR.

--- a/internal/tts/aliyun.go
+++ b/internal/tts/aliyun.go
@@ -1,0 +1,312 @@
+package tts
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+)
+
+// Alibaba Cloud Model Studio (DashScope) streaming TTS
+// ----------------------------------------------------
+//
+//	Endpoint:  wss://dashscope.aliyuncs.com/api-ws/v1/inference
+//	Auth:      Authorization: Bearer <api key>
+//	Audio:     raw 16-bit signed little-endian PCM at 16kHz mono, arriving as
+//	           binary frames.
+//
+// This is the same endpoint, key and event vocabulary as the ASR client in
+// internal/stt, run in the other direction: `run-task` opens the session,
+// `continue-task` feeds text, `finish-task` closes it, and audio comes back on
+// the binary channel while control messages stay JSON.
+//
+// The service emits 16kHz PCM directly, so unlike MiMo there is no resampling
+// stage here — what arrives on the wire is what the pipeline plays.
+const (
+	aliyunTTSURL = "wss://dashscope.aliyuncs.com/api-ws/v1/inference"
+	// aliyunSampleRate is what the pipeline plays; the service honours it, so
+	// no conversion is needed on this path.
+	aliyunSampleRate = 16000
+	// cosyvoice-v2 is the current general-purpose synthesis model.
+	defaultAliyunTTSModel = "cosyvoice-v2"
+	// Voices are versioned alongside the model: longxiaochun_v2 belongs to
+	// cosyvoice-v2, and cosyvoice-v1 wants plain longxiaochun.
+	defaultAliyunVoice = "longxiaochun_v2"
+)
+
+type aliyunClient struct {
+	apiKey string
+	voice  string
+	model  string
+	url    string
+}
+
+// NewAliyunClient creates a Model Studio TTS client. Empty voice, model and
+// url fall back to the package defaults.
+func NewAliyunClient(apiKey, voice, model, url string) Client {
+	if voice == "" {
+		voice = defaultAliyunVoice
+	}
+	if model == "" {
+		model = defaultAliyunTTSModel
+	}
+	if url == "" {
+		url = aliyunTTSURL
+	}
+	return &aliyunClient{apiKey: apiKey, voice: voice, model: model, url: url}
+}
+
+// aliyunMessage covers every frame sent to the service.
+type aliyunMessage struct {
+	Header  aliyunHeader `json:"header"`
+	Payload any          `json:"payload,omitempty"`
+}
+
+type aliyunHeader struct {
+	Action    string `json:"action,omitempty"`
+	Event     string `json:"event,omitempty"`
+	TaskID    string `json:"task_id"`
+	Streaming string `json:"streaming,omitempty"`
+
+	ErrorCode    string `json:"error_code,omitempty"`
+	ErrorMessage string `json:"error_message,omitempty"`
+}
+
+type aliyunRunPayload struct {
+	TaskGroup  string              `json:"task_group"`
+	Task       string              `json:"task"`
+	Function   string              `json:"function"`
+	Model      string              `json:"model"`
+	Parameters aliyunTTSParameters `json:"parameters"`
+	Input      struct{}            `json:"input"`
+}
+
+type aliyunTTSParameters struct {
+	TextType   string `json:"text_type"`
+	Voice      string `json:"voice"`
+	Format     string `json:"format"`
+	SampleRate int    `json:"sample_rate"`
+}
+
+// aliyunTextPayload carries text on continue-task, and is empty on finish-task.
+type aliyunTextPayload struct {
+	Input struct {
+		Text string `json:"text,omitempty"`
+	} `json:"input"`
+}
+
+// aliyunSession is one synthesis: a connection, its task id, and the write
+// lock that keeps the teardown path from racing the send path.
+type aliyunSession struct {
+	conn    *websocket.Conn
+	taskID  string
+	writeMu sync.Mutex
+	closed  bool
+}
+
+func (s *aliyunSession) writeJSON(m aliyunMessage) error {
+	body, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("aliyun marshal: %w", err)
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	if s.closed {
+		return fmt.Errorf("aliyun: connection closed")
+	}
+	return s.conn.WriteMessage(websocket.TextMessage, body)
+}
+
+func (s *aliyunSession) close() {
+	s.writeMu.Lock()
+	if s.closed {
+		s.writeMu.Unlock()
+		return
+	}
+	s.closed = true
+	s.writeMu.Unlock()
+	_ = s.conn.Close()
+}
+
+// open dials and completes the run-task handshake.
+//
+// It returns only once `task-started` has arrived, because text sent before
+// that is discarded — the same rule the ASR path lives by, and the failure is
+// just as quiet: a session that synthesizes nothing and reports no error.
+//
+// One connection per utterance. The pipeline synthesizes sentence by sentence
+// while earlier audio is still playing, so the dial for sentence two overlaps
+// sentence one's playback and only the first sentence of a turn pays for it.
+func (c *aliyunClient) open(ctx context.Context) (*aliyunSession, error) {
+	hdr := http.Header{}
+	hdr.Set("Authorization", "Bearer "+c.apiKey)
+
+	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, c.url, hdr)
+	if err != nil {
+		if resp != nil {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+			resp.Body.Close()
+			return nil, fmt.Errorf("aliyun dial: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+		return nil, fmt.Errorf("aliyun dial: %w", err)
+	}
+
+	s := &aliyunSession{conn: conn, taskID: strings.ReplaceAll(uuid.New().String(), "-", "")}
+
+	if err := s.writeJSON(aliyunMessage{
+		Header: aliyunHeader{Action: "run-task", TaskID: s.taskID, Streaming: "duplex"},
+		Payload: aliyunRunPayload{
+			TaskGroup: "audio", Task: "tts", Function: "SpeechSynthesizer",
+			Model: c.model,
+			Parameters: aliyunTTSParameters{
+				TextType:   "PlainText",
+				Voice:      c.voice,
+				Format:     "pcm",
+				SampleRate: aliyunSampleRate,
+			},
+		},
+	}); err != nil {
+		s.close()
+		return nil, err
+	}
+
+	for {
+		typ, data, err := conn.ReadMessage()
+		if err != nil {
+			s.close()
+			return nil, fmt.Errorf("aliyun handshake: %w", err)
+		}
+		if typ != websocket.TextMessage {
+			continue
+		}
+		var res aliyunMessage
+		if err := json.Unmarshal(data, &res); err != nil {
+			continue
+		}
+		switch res.Header.Event {
+		case "task-started":
+			return s, nil
+		case "task-failed":
+			s.close()
+			return nil, fmt.Errorf("aliyun %s: %s", res.Header.ErrorCode, res.Header.ErrorMessage)
+		}
+	}
+}
+
+func (c *aliyunClient) SynthesizeStream(ctx context.Context, text string) (<-chan StreamChunk, error) {
+	s, err := c.open(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Text and the end-of-input marker go together: this client is handed a
+	// whole sentence, so there is nothing to add after it.
+	var textPayload aliyunTextPayload
+	textPayload.Input.Text = text
+	if err := s.writeJSON(aliyunMessage{
+		Header:  aliyunHeader{Action: "continue-task", TaskID: s.taskID, Streaming: "duplex"},
+		Payload: textPayload,
+	}); err != nil {
+		s.close()
+		return nil, err
+	}
+	if err := s.writeJSON(aliyunMessage{
+		Header:  aliyunHeader{Action: "finish-task", TaskID: s.taskID, Streaming: "duplex"},
+		Payload: aliyunTextPayload{},
+	}); err != nil {
+		s.close()
+		return nil, err
+	}
+
+	ch := make(chan StreamChunk, 8)
+	go func() {
+		defer close(ch)
+		defer s.close()
+		c.pump(ctx, s, ch)
+	}()
+	return ch, nil
+}
+
+// pump forwards binary frames as PCM until the task finishes.
+//
+// A barge-in cancels ctx mid-utterance, and ReadMessage does not watch a
+// context — so the connection is closed from a second goroutine to break the
+// read, rather than leaving it blocked until the service decides to hang up.
+func (c *aliyunClient) pump(ctx context.Context, s *aliyunSession, ch chan<- StreamChunk) {
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.close()
+		case <-done:
+		}
+	}()
+
+	emit := func(chunk StreamChunk) bool {
+		select {
+		case ch <- chunk:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+
+	total := 0
+	for {
+		typ, data, err := s.conn.ReadMessage()
+		if err != nil {
+			// A cancelled turn is the expected way this ends, not a fault.
+			if ctx.Err() == nil {
+				emit(StreamChunk{Err: fmt.Errorf("aliyun stream read: %w", err)})
+			}
+			return
+		}
+
+		if typ == websocket.BinaryMessage {
+			total += len(data)
+			if !emit(StreamChunk{PCM: data}) {
+				return
+			}
+			continue
+		}
+
+		var res aliyunMessage
+		if err := json.Unmarshal(data, &res); err != nil {
+			continue
+		}
+		switch res.Header.Event {
+		case "task-failed":
+			emit(StreamChunk{Err: fmt.Errorf("aliyun %s: %s", res.Header.ErrorCode, res.Header.ErrorMessage)})
+			return
+		case "task-finished":
+			log.Printf("[tts:aliyun] synthesized %d bytes (%.2fs of audio)",
+				total, float64(total)/2/float64(aliyunSampleRate))
+			return
+		}
+	}
+}
+
+// Synthesize drains the stream into one buffer, for callers that want the
+// whole utterance at once.
+func (c *aliyunClient) Synthesize(ctx context.Context, text string) ([]byte, error) {
+	ch, err := c.SynthesizeStream(ctx, text)
+	if err != nil {
+		return nil, err
+	}
+	var pcm []byte
+	for chunk := range ch {
+		if chunk.Err != nil {
+			return nil, chunk.Err
+		}
+		pcm = append(pcm, chunk.PCM...)
+	}
+	return pcm, nil
+}

--- a/internal/tts/aliyun_test.go
+++ b/internal/tts/aliyun_test.go
@@ -1,0 +1,157 @@
+package tts
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// run-task is a fixed shape, and the service rejects the session outright when
+// any of task_group/task/function is missing or wrong — as an opaque protocol
+// error that names none of them.
+func TestAliyunTTSRunTaskShape(t *testing.T) {
+	c := NewAliyunClient("k", "", "", "").(*aliyunClient)
+
+	body, err := json.Marshal(aliyunMessage{
+		Header: aliyunHeader{Action: "run-task", TaskID: "0123456789abcdef0123456789abcdef", Streaming: "duplex"},
+		Payload: aliyunRunPayload{
+			TaskGroup: "audio", Task: "tts", Function: "SpeechSynthesizer",
+			Model: c.model,
+			Parameters: aliyunTTSParameters{
+				TextType: "PlainText", Voice: c.voice, Format: "pcm", SampleRate: aliyunSampleRate,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	header := decoded["header"].(map[string]any)
+	if header["action"] != "run-task" {
+		t.Errorf("action = %v, want run-task", header["action"])
+	}
+	if header["streaming"] != "duplex" {
+		t.Errorf("streaming = %v, want duplex", header["streaming"])
+	}
+	// A 32-character hex id: a UUID with its dashes removed. The dashed form
+	// is rejected.
+	if id, _ := header["task_id"].(string); len(id) != 32 || strings.Contains(id, "-") {
+		t.Errorf("task_id = %q, want 32 hex characters with no dashes", id)
+	}
+
+	payload := decoded["payload"].(map[string]any)
+	// task is "tts" and function is "SpeechSynthesizer" — the ASR path on this
+	// same endpoint uses "asr"/"recognition", and swapping one in leaves the
+	// other looking plausible.
+	for k, want := range map[string]string{
+		"task_group": "audio", "task": "tts", "function": "SpeechSynthesizer",
+	} {
+		if payload[k] != want {
+			t.Errorf("%s = %v, want %v", k, payload[k], want)
+		}
+	}
+
+	params := payload["parameters"].(map[string]any)
+	if params["format"] != "pcm" {
+		t.Errorf("format = %v, want pcm", params["format"])
+	}
+	// The pipeline plays 16kHz linear16. This provider honours the request, so
+	// a wrong rate here is not resampled anywhere — it plays back at the wrong
+	// speed and pitch.
+	if params["sample_rate"].(float64) != 16000 {
+		t.Errorf("sample_rate = %v, want 16000", params["sample_rate"])
+	}
+	if params["text_type"] != "PlainText" {
+		t.Errorf("text_type = %v, want PlainText", params["text_type"])
+	}
+}
+
+// Text rides on continue-task under input.text. Putting it anywhere else is
+// accepted by the service and synthesizes silence.
+func TestAliyunTTSTextPayloadShape(t *testing.T) {
+	var p aliyunTextPayload
+	p.Input.Text = "你好"
+
+	body, err := json.Marshal(aliyunMessage{
+		Header:  aliyunHeader{Action: "continue-task", TaskID: "t", Streaming: "duplex"},
+		Payload: p,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), `"payload":{"input":{"text":"你好"}}`) {
+		t.Errorf("payload = %s, want text nested under input", body)
+	}
+}
+
+// finish-task carries no text, and the empty input object must still be
+// present — the field is not optional even when it holds nothing.
+func TestAliyunTTSFinishTaskKeepsEmptyInput(t *testing.T) {
+	body, err := json.Marshal(aliyunMessage{
+		Header:  aliyunHeader{Action: "finish-task", TaskID: "t", Streaming: "duplex"},
+		Payload: aliyunTextPayload{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), `"payload":{"input":{}}`) {
+		t.Errorf("payload = %s, want an empty input object", body)
+	}
+	if strings.Contains(string(body), `"text"`) {
+		t.Errorf("payload = %s, want no text field on finish-task", body)
+	}
+}
+
+// A failure arrives as its own event carrying a code and message. Dropping it
+// leaves the caller waiting on a channel that only ever closes empty, with
+// nothing said about why.
+func TestAliyunTTSSurfacesTaskFailed(t *testing.T) {
+	body := `{"header":{"event":"task-failed","task_id":"abc","error_code":"InvalidParameter","error_message":"[cosyvoice:]Engine return error code: 418"}}`
+
+	var res aliyunMessage
+	if err := json.Unmarshal([]byte(body), &res); err != nil {
+		t.Fatal(err)
+	}
+	if res.Header.Event != "task-failed" {
+		t.Errorf("event = %q, want task-failed", res.Header.Event)
+	}
+	if res.Header.ErrorCode != "InvalidParameter" {
+		t.Errorf("error_code = %q, want it carried through", res.Header.ErrorCode)
+	}
+	if !strings.Contains(res.Header.ErrorMessage, "418") {
+		t.Errorf("error_message = %q, want the provider text", res.Header.ErrorMessage)
+	}
+}
+
+// Empty voice, model and url fall back rather than being sent blank, which the
+// service rejects as an unknown model or voice.
+func TestAliyunTTSDefaults(t *testing.T) {
+	c := NewAliyunClient("k", "", "", "").(*aliyunClient)
+	if c.model != defaultAliyunTTSModel {
+		t.Errorf("model = %q, want %q", c.model, defaultAliyunTTSModel)
+	}
+	if c.voice != defaultAliyunVoice {
+		t.Errorf("voice = %q, want %q", c.voice, defaultAliyunVoice)
+	}
+	if c.url != aliyunTTSURL {
+		t.Errorf("url = %q, want %q", c.url, aliyunTTSURL)
+	}
+
+	custom := NewAliyunClient("k", "longwan_v2", "cosyvoice-v1", "wss://example/x").(*aliyunClient)
+	if custom.voice != "longwan_v2" || custom.model != "cosyvoice-v1" || custom.url != "wss://example/x" {
+		t.Errorf("explicit values overwritten: %+v", custom)
+	}
+}
+
+// The session must not send after Close: gorilla allows a single writer, and a
+// barge-in closes the connection while the send path may still be running.
+func TestAliyunTTSSessionRejectsWriteAfterClose(t *testing.T) {
+	s := &aliyunSession{closed: true}
+	if err := s.writeJSON(aliyunMessage{Header: aliyunHeader{Action: "continue-task"}}); err == nil {
+		t.Error("write on a closed session succeeded, want an error instead of touching a nil conn")
+	}
+}

--- a/internal/tts/client.go
+++ b/internal/tts/client.go
@@ -82,10 +82,15 @@ func newProviderClient(cfg *config.Config) (Client, error) {
 			return nil, ErrMissingAPIKey{Provider: "mimo", Field: "[mimo] api_key"}
 		}
 		return NewMiMoClient(cfg.MiMo.APIKey, cfg.MiMo.Voice, cfg.MiMo.Model, cfg.MiMo.BaseURL), nil
+	case "aliyun":
+		if cfg.Aliyun.APIKey == "" {
+			return nil, ErrMissingAPIKey{Provider: "aliyun", Field: "[aliyun] api_key"}
+		}
+		return NewAliyunClient(cfg.Aliyun.APIKey, cfg.Aliyun.Voice, cfg.Aliyun.TTSModel, cfg.Aliyun.URL), nil
 	case "vibevoice":
 		return NewVibeVoiceClient(cfg.VibeVoice.TTSURL, cfg.VibeVoice.Voice), nil
 	default:
-		return nil, fmt.Errorf("unknown tts provider %q (supported: cartesia, deepgram, elevenlabs, mimo, minimax, speechify, vibevoice)", cfg.TTS.Provider)
+		return nil, fmt.Errorf("unknown tts provider %q (supported: aliyun, cartesia, deepgram, elevenlabs, mimo, minimax, speechify, vibevoice)", cfg.TTS.Provider)
 	}
 }
 


### PR DESCRIPTION
Adds `tts.provider = "aliyun"`, backed by Alibaba Cloud Model Studio's CosyVoice:

```toml
[tts]
provider = "aliyun"

[aliyun]
api_key = "sk-..."
voice = "longxiaochun_v2"
```

This is the same endpoint, key and event vocabulary as the ASR provider added in #49, run in the other direction: `run-task` opens the session, `continue-task` feeds text, `finish-task` closes it, and audio comes back on the binary channel while control messages stay JSON. One `[aliyun]` section can now drive both directions of a call, so `tts_model`/`voice` sit alongside the existing `model`/`language`.

## No resampling on this path

The service emits 16kHz PCM directly — the rate the pipeline plays. MiMo needs a streaming resampler because it only produces 24kHz and resampling each chunk independently clicks at every boundary; here that whole stage is absent, and what arrives on the wire is what gets played.

## What the session depends on

**Text sent before `task-started` is discarded.** Not buffered — dropped, and it takes the start of the sentence with it. `open()` completes the handshake before returning rather than racing the first frames. Same rule as the ASR path, same quiet failure: synthesis that produces nothing and reports no error.

**`finish-task` carries an empty `input` object.** The field is not optional even when it holds nothing, so `omitempty` sits on the inner `text` and not on `input`. There is a test pinning that, because it is the kind of thing a later cleanup removes as dead weight.

## Cancellation

`ReadMessage` does not watch a context, so a barge-in cannot interrupt it from the outside. A second goroutine waits on `ctx.Done()` and closes the connection, which breaks the read.

Without it the client keeps synthesizing to the end of the sentence after the turn was already cancelled, and the audio it produces is discarded — the caller hears the agent stop, but the next reply queues behind work nobody wanted. Measured at **2ms** from cancel to closed channel.

## One connection per utterance

The pipeline synthesizes sentence by sentence while earlier audio is still playing, so the dial for sentence two overlaps sentence one's playback and only the first sentence of a turn pays for it. Cartesia's client pools connections; that optimisation is deliberately not in this first version, which keeps the provider's behaviour identical to the others.

## Voices are tied to a model generation

`longxiaochun_v2` belongs to `cosyvoice-v2`; `cosyvoice-v1` wants plain `longxiaochun`, and crossing them is rejected with `InvalidParameter ... Engine return error code: 418`. `tts_model` and `voice` therefore have to change together, which the config comment says explicitly.

## Verification

- Live synthesis end to end against the service: first chunk at **0.63s**, 23 chunks, 150080 bytes = 4.69s of 16kHz audio.
- Cancellation mid-utterance: channel closed **2ms** after `cancel()`.
- Live Mandarin call end to end — Aliyun ASR in, `deepseek-chat`, Aliyun TTS out.
- Six unit tests over the `run-task` shape (including the dashless task id and the 16kHz request), the `continue-task` text nesting, the empty `input` on `finish-task`, `task-failed` surfacing, the defaults, and the write-after-close guard. They run against constructed frames, so no key or network.
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.

## Notes

- Only synthesis is wired up here; the ASR side landed in #49 and is untouched.
- `qwen3-tts-flash-realtime` is not reachable on this endpoint (`ModelNotFound`), and `cosyvoice-v3-flash` rejects the v2 voices — hence the v2 default.
