### PR TITLE
fix: isolate pprof on a dedicated mux

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"net"
 	"net/http"
-	_ "net/http/pprof"
+	"net/http/pprof"
 	"os"
 	"os/signal"
 	"runtime"
@@ -153,6 +153,16 @@ func newPublicMux(whipHandler, issueToken http.HandlerFunc) *http.ServeMux {
 	return mux
 }
 
+func newDebugMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	return mux
+}
+
 func startDebugServer(cfg config.DebugConfig) (*http.Server, error) {
 	if cfg.Bind == "" {
 		return nil, nil
@@ -181,7 +191,7 @@ func startDebugServer(cfg config.DebugConfig) (*http.Server, error) {
 
 	srv := &http.Server{
 		Addr:              listener.Addr().String(),
-		Handler:           http.DefaultServeMux,
+		Handler:           newDebugMux(),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	go func() {

--- a/main_test.go
+++ b/main_test.go
@@ -159,6 +159,64 @@ func TestDebugServerServesPprofOnLoopback(t *testing.T) {
 	}
 }
 
+func TestDebugMuxRegistersEveryPprofRoute(t *testing.T) {
+	mux := newDebugMux()
+	tests := []struct {
+		path        string
+		wantPattern string
+	}{
+		{path: "/debug/pprof/", wantPattern: "/debug/pprof/"},
+		{path: "/debug/pprof/goroutine", wantPattern: "/debug/pprof/"},
+		{path: "/debug/pprof/cmdline", wantPattern: "/debug/pprof/cmdline"},
+		{path: "/debug/pprof/profile", wantPattern: "/debug/pprof/profile"},
+		{path: "/debug/pprof/symbol", wantPattern: "/debug/pprof/symbol"},
+		{path: "/debug/pprof/trace", wantPattern: "/debug/pprof/trace"},
+		{path: "/unrelated", wantPattern: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			_, pattern := mux.Handler(req)
+			if pattern != tt.wantPattern {
+				t.Fatalf("pattern = %q, want %q", pattern, tt.wantPattern)
+			}
+		})
+	}
+}
+
+func TestDebugServerDoesNotServeDefaultMuxHandlers(t *testing.T) {
+	previousDefaultMux := http.DefaultServeMux
+	http.DefaultServeMux = http.NewServeMux()
+	t.Cleanup(func() {
+		http.DefaultServeMux = previousDefaultMux
+	})
+	http.HandleFunc("/unrelated-default-handler", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	srv, err := startDebugServer(config.DebugConfig{Bind: "127.0.0.1:0"})
+	if err != nil {
+		t.Fatalf("startDebugServer: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			t.Errorf("shutdown debug server: %v", err)
+		}
+	})
+
+	client := &http.Client{Timeout: time.Second}
+	resp, err := client.Get("http://" + srv.Addr + "/unrelated-default-handler")
+	if err != nil {
+		t.Fatalf("GET unrelated default handler: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
 func TestDebugServerRejectsPublicBindWithoutAcknowledgement(t *testing.T) {
 	_, err := startDebugServer(config.DebugConfig{Bind: "0.0.0.0:0"})
 	if err == nil {


### PR DESCRIPTION
## What breaks today

The optional debug server uses `http.DefaultServeMux`. Any future package or application code that calls `http.Handle` can therefore become reachable on the profiling listener even though it is unrelated to pprof.

## What changed

- replace the blank pprof import with a named import
- build a dedicated debug mux containing only the standard pprof index, cmdline, profile, symbol, and trace handlers
- prove named profiles still resolve through the pprof index route
- prove a handler registered on `http.DefaultServeMux` returns 404 through the debug listener

This addresses item 2 of #64 only. Crash isolation, pre-bind validation, shutdown context, documentation, and translation remain separate as requested.

## Verification

- RED: the new default-mux isolation test returned 204 before the fix; GREEN: it returns 404 after the dedicated mux
- `gofmt -l .`: no output
- `go build ./...`
- `go vet ./...`
- `go test -count=1 -race ./...`
- focused route/isolation tests repeated 20 times
- `git diff --check`

The commit is GitHub-signed and marked Verified.