### PR TITLE
Add Volcengine (Doubao) streaming TTS provider

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -45,7 +45,7 @@ provider = "deepgram"   # Supported: aliyun, assemblyai, deepgram, openai, vibev
 provider = "openai"     # Supported: openai, ollama, agent
 
 [tts]
-provider = "cartesia"   # Supported: aliyun, cartesia, deepgram, elevenlabs, mimo, minimax, speechify, vibevoice
+provider = "cartesia"   # Supported: aliyun, cartesia, deepgram, elevenlabs, mimo, minimax, speechify, vibevoice, volcengine
 
 # Provider credentials
 
@@ -179,7 +179,8 @@ voice = ""              # TTS. Optional; defaults to longxiaochun_v2. Voices are
                         # change tts_model and voice together
 url = ""                # Optional; defaults to wss://dashscope.aliyuncs.com/api-ws/v1/inference
 
-# Volcengine (Doubao) streaming ASR. Used when stt.provider = "volcengine".
+# Volcengine (Doubao). One console API key serves both streaming ASR
+# (stt.provider = "volcengine") and streaming TTS (tts.provider = "volcengine").
 # Useful where Deepgram is slow to reach or its Mandarin is not good enough;
 # the console gives a free hourly allowance to start with.
 [volcengine]
@@ -189,8 +190,16 @@ resource_id = ""        # Optional; defaults to volc.seedasr.sauc.duration (hour
                         # volc.seedasr.sauc.concurrent bills by concurrency instead
 model = ""              # Optional; defaults to bigmodel
 url = ""                # Optional; defaults to wss://openspeech.bytedance.com/api/v3/sauc/bigmodel
-end_window_ms = 0       # Optional; silence (ms) that settles an utterance, defaults to 800.
+end_window_ms = 0       # STT. Optional; silence (ms) that settles an utterance, defaults to 800.
                         # Same role as [deepgram] endpointing
+tts_resource_id = ""    # TTS. Optional; defaults to seed-tts-2.0. The 1.0 resource
+                        # (volc.service_type.10029) is a separate entitlement and answers 403
+                        # until it is activated
+speaker = ""            # TTS. Optional; defaults to zh_female_vv_uranus_bigtts. Voices belong to a
+                        # model generation — the 2.0 resource takes the `_uranus_bigtts` voices and
+                        # refuses the older `_moon_` / `_mars_` / `_jupiter_` ones, so change
+                        # speaker and tts_resource_id together
+tts_url = ""            # Optional; defaults to wss://openspeech.bytedance.com/api/v3/tts/bidirection
 
 # Vision (used by the vision-analyze plugin)
 # The plugin reads OPENAI_API_KEY from the environment (same key as [openai]).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -355,7 +355,8 @@ type AliyunConfig struct {
 	Voice string `toml:"voice"`
 }
 
-// VolcengineConfig configures Volcengine (Doubao) streaming ASR.
+// VolcengineConfig configures Volcengine (Doubao), which serves both
+// streaming ASR and streaming TTS from the same console API key.
 type VolcengineConfig struct {
 	// APIKey is the console's API key, sent as X-Api-Key. The older
 	// app-id-plus-access-token pair does not work against these resources.
@@ -369,6 +370,19 @@ type VolcengineConfig struct {
 	// EndWindowMs is the silence that ends an utterance, the same knob as
 	// [deepgram] endpointing. Empty uses 300.
 	EndWindowMs int `toml:"end_window_ms"`
+
+	// TTSResourceID selects the synthesis entitlement, kept separate from
+	// ResourceID because one [volcengine] section can drive both directions.
+	// Empty uses seed-tts-2.0; the 1.0 resource is activated separately.
+	TTSResourceID string `toml:"tts_resource_id"`
+	// Speaker is the synthesis voice. Voices belong to a model generation —
+	// the 2.0 resource takes the `_uranus_bigtts` voices and refuses the
+	// older `_moon_` / `_mars_` / `_jupiter_` ones — so change this and
+	// TTSResourceID together.
+	Speaker string `toml:"speaker"`
+	// TTSURL overrides the synthesis endpoint. Empty uses the bidirectional
+	// streaming one.
+	TTSURL string `toml:"tts_url"`
 }
 
 // Load reads configuration from a TOML file. It tries the given path first,

--- a/internal/tts/client.go
+++ b/internal/tts/client.go
@@ -87,10 +87,16 @@ func newProviderClient(cfg *config.Config) (Client, error) {
 			return nil, ErrMissingAPIKey{Provider: "aliyun", Field: "[aliyun] api_key"}
 		}
 		return NewAliyunClient(cfg.Aliyun.APIKey, cfg.Aliyun.Voice, cfg.Aliyun.TTSModel, cfg.Aliyun.URL), nil
+	case "volcengine":
+		if cfg.Volcengine.APIKey == "" {
+			return nil, ErrMissingAPIKey{Provider: "volcengine", Field: "[volcengine] api_key"}
+		}
+		return NewVolcengineClient(cfg.Volcengine.APIKey, cfg.Volcengine.Speaker,
+			cfg.Volcengine.TTSResourceID, cfg.Volcengine.TTSURL), nil
 	case "vibevoice":
 		return NewVibeVoiceClient(cfg.VibeVoice.TTSURL, cfg.VibeVoice.Voice), nil
 	default:
-		return nil, fmt.Errorf("unknown tts provider %q (supported: aliyun, cartesia, deepgram, elevenlabs, mimo, minimax, speechify, vibevoice)", cfg.TTS.Provider)
+		return nil, fmt.Errorf("unknown tts provider %q (supported: aliyun, cartesia, deepgram, elevenlabs, mimo, minimax, speechify, vibevoice, volcengine)", cfg.TTS.Provider)
 	}
 }
 

--- a/internal/tts/volcengine.go
+++ b/internal/tts/volcengine.go
@@ -1,0 +1,427 @@
+package tts
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+)
+
+// Volcengine (Doubao) streaming TTS — /api/v3/tts/bidirection
+// -----------------------------------------------------------
+//
+//	Endpoint:  wss://openspeech.bytedance.com/api/v3/tts/bidirection
+//	Auth:      X-Api-Key: <api key>       (the same console key the ASR
+//	           provider uses; the older app-id + access-token pair is
+//	           rejected here too)
+//	Resource:  X-Api-Resource-Id: seed-tts-2.0
+//	Audio:     raw 16-bit signed little-endian PCM at 16kHz mono, so nothing
+//	           is resampled on this path.
+//
+// The framing is the same binary family as the ASR provider in internal/stt,
+// but not the same layout: these frames carry a 4-byte event number after the
+// header, and session-scoped events carry a length-prefixed session id after
+// that. Copying the ASR parser over lands the payload at the wrong offset,
+// which fails as silence rather than as an error.
+//
+//	byte 0     protocol version (high nibble), header size in 4-byte words
+//	byte 1     message type (high nibble), flags (low nibble)
+//	byte 2     serialisation (high nibble), compression (low nibble)
+//	byte 3     reserved
+//	bytes 4-7  event number, big-endian          (present when flags has 0x04)
+//	then       session id length + session id    (session-scoped events only)
+//	then       payload length, big-endian
+//	then       payload
+//
+// A synthesis is three nested scopes: StartConnection opens the connection,
+// StartSession opens one utterance, TaskRequest submits the text, and
+// FinishSession closes the utterance. That nesting is what makes connection
+// reuse possible later — the connection outlives the utterance — though this
+// first version opens one per utterance to match the other providers here.
+const (
+	volcengineTTSURL = "wss://openspeech.bytedance.com/api/v3/tts/bidirection"
+	// volcengineTTSSampleRate is what the pipeline plays; the service honours
+	// it, so no conversion is needed.
+	volcengineTTSSampleRate = 16000
+
+	// defaultVolcengineTTSResource is the 2.0 speech synthesis resource.
+	// The 1.0 resource (volc.service_type.10029) is a separate entitlement and
+	// answers 403 when it has not been activated.
+	defaultVolcengineTTSResource = "seed-tts-2.0"
+	// Voices belong to a model generation. The 2.0 voices carry the
+	// `_uranus_bigtts` suffix; the widely-published `_moon_` / `_mars_` /
+	// `_jupiter_` names are 1.0 and are refused under this resource with
+	// "resource ID is mismatched with speaker related resource" — a message
+	// that names neither the voice nor the entitlement.
+	defaultVolcengineSpeaker = "zh_female_vv_uranus_bigtts"
+
+	// Message type (high nibble of byte 1) and the flag that says an event
+	// number follows the header.
+	volcTTSTypeFullClient  = 0b0001
+	volcTTSFlagWithEvent   = 0b0100
+	volcTTSSerialisationJS = 0x10
+
+	// Client events.
+	volcEventStartConnection = 1
+	volcEventStartSession    = 100
+	volcEventFinishSession   = 102
+	volcEventTaskRequest     = 200
+
+	// Server events.
+	volcEventConnectionStarted = 50
+	volcEventSessionStarted    = 150
+	volcEventSessionFinished   = 152
+	volcEventSessionFailed     = 153
+	volcEventTTSResponse       = 352
+)
+
+type volcengineClient struct {
+	apiKey   string
+	speaker  string
+	resource string
+	url      string
+}
+
+// NewVolcengineClient creates a Doubao TTS client. Empty speaker, resource and
+// url fall back to the package defaults.
+func NewVolcengineClient(apiKey, speaker, resource, url string) Client {
+	if speaker == "" {
+		speaker = defaultVolcengineSpeaker
+	}
+	if resource == "" {
+		resource = defaultVolcengineTTSResource
+	}
+	if url == "" {
+		url = volcengineTTSURL
+	}
+	return &volcengineClient{apiKey: apiKey, speaker: speaker, resource: resource, url: url}
+}
+
+// volcFrame assembles one client frame. sessionID is empty for
+// connection-scoped events, which carry no session id at all.
+func volcFrame(event int32, sessionID string, payload []byte) []byte {
+	buf := []byte{
+		0x11,
+		volcTTSTypeFullClient<<4 | volcTTSFlagWithEvent,
+		volcTTSSerialisationJS,
+		0x00,
+	}
+
+	ev := make([]byte, 4)
+	binary.BigEndian.PutUint32(ev, uint32(event))
+	buf = append(buf, ev...)
+
+	if sessionID != "" {
+		l := make([]byte, 4)
+		binary.BigEndian.PutUint32(l, uint32(len(sessionID)))
+		buf = append(append(buf, l...), sessionID...)
+	}
+
+	l := make([]byte, 4)
+	binary.BigEndian.PutUint32(l, uint32(len(payload)))
+	return append(append(buf, l...), payload...)
+}
+
+// volcSessionScopedEvent reports whether a server event carries a session id
+// between the event number and the payload length. Getting this wrong shifts
+// every subsequent field and turns audio into garbage.
+func volcSessionScopedEvent(event int32) bool {
+	switch event {
+	case volcEventSessionStarted, volcEventSessionFinished, volcEventSessionFailed,
+		volcEventTTSResponse, 350, 351, 359:
+		return true
+	}
+	return false
+}
+
+// parseVolcTTSFrame returns the event number and payload of a server frame.
+func parseVolcTTSFrame(data []byte) (event int32, payload []byte, ok bool) {
+	if len(data) < 8 {
+		return 0, nil, false
+	}
+
+	p := 4
+	if data[1]&0x0F&volcTTSFlagWithEvent != 0 {
+		if p+4 > len(data) {
+			return 0, nil, false
+		}
+		event = int32(binary.BigEndian.Uint32(data[p : p+4]))
+		p += 4
+	}
+
+	if volcSessionScopedEvent(event) {
+		if p+4 > len(data) {
+			return event, nil, false
+		}
+		n := int(binary.BigEndian.Uint32(data[p : p+4]))
+		p += 4
+		if p+n > len(data) {
+			return event, nil, false
+		}
+		p += n
+	}
+
+	if p+4 > len(data) {
+		return event, nil, false
+	}
+	n := int(binary.BigEndian.Uint32(data[p : p+4]))
+	p += 4
+	if p+n > len(data) {
+		n = len(data) - p
+	}
+	return event, data[p : p+n], true
+}
+
+// volcSession is one synthesis: a connection, its session id, and the write
+// lock that keeps teardown from racing the send path.
+type volcSession struct {
+	conn      *websocket.Conn
+	sessionID string
+	writeMu   sync.Mutex
+	closed    bool
+}
+
+func (s *volcSession) write(event int32, sessionID string, payload []byte) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	if s.closed {
+		return fmt.Errorf("volcengine: connection closed")
+	}
+	return s.conn.WriteMessage(websocket.BinaryMessage, volcFrame(event, sessionID, payload))
+}
+
+func (s *volcSession) close() {
+	s.writeMu.Lock()
+	if s.closed {
+		s.writeMu.Unlock()
+		return
+	}
+	s.closed = true
+	s.writeMu.Unlock()
+	_ = s.conn.Close()
+}
+
+// volcAudioParams is the audio half of req_params.
+type volcAudioParams struct {
+	Format     string `json:"format"`
+	SampleRate int    `json:"sample_rate"`
+}
+
+type volcReqParams struct {
+	Text        string          `json:"text,omitempty"`
+	Speaker     string          `json:"speaker"`
+	AudioParams volcAudioParams `json:"audio_params"`
+}
+
+type volcRequest struct {
+	User struct {
+		UID string `json:"uid"`
+	} `json:"user"`
+	Event     int32         `json:"event"`
+	Namespace string        `json:"namespace"`
+	ReqParams volcReqParams `json:"req_params"`
+}
+
+func (c *volcengineClient) request(event int32, text string) ([]byte, error) {
+	var r volcRequest
+	r.User.UID = "streamcore"
+	r.Event = event
+	r.Namespace = "BidirectionalTTS"
+	r.ReqParams = volcReqParams{
+		Text:    text,
+		Speaker: c.speaker,
+		AudioParams: volcAudioParams{
+			Format:     "pcm",
+			SampleRate: volcengineTTSSampleRate,
+		},
+	}
+	return json.Marshal(r)
+}
+
+// open dials and walks the connection and session handshakes, returning only
+// once the service has accepted both. Sending a TaskRequest before
+// SessionStarted is answered with a protocol error rather than audio.
+func (c *volcengineClient) open(ctx context.Context) (*volcSession, error) {
+	hdr := http.Header{}
+	hdr.Set("X-Api-Key", c.apiKey)
+	hdr.Set("X-Api-Resource-Id", c.resource)
+	hdr.Set("X-Api-Connect-Id", uuid.New().String())
+
+	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, c.url, hdr)
+	if err != nil {
+		if resp != nil {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+			resp.Body.Close()
+			return nil, fmt.Errorf("volcengine dial: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+		return nil, fmt.Errorf("volcengine dial: %w", err)
+	}
+
+	s := &volcSession{conn: conn, sessionID: uuid.New().String()}
+
+	if err := s.write(volcEventStartConnection, "", []byte(`{}`)); err != nil {
+		s.close()
+		return nil, err
+	}
+	if err := c.expect(s, volcEventConnectionStarted); err != nil {
+		s.close()
+		return nil, fmt.Errorf("volcengine connection: %w", err)
+	}
+
+	start, err := c.request(volcEventStartSession, "")
+	if err != nil {
+		s.close()
+		return nil, err
+	}
+	if err := s.write(volcEventStartSession, s.sessionID, start); err != nil {
+		s.close()
+		return nil, err
+	}
+	if err := c.expect(s, volcEventSessionStarted); err != nil {
+		s.close()
+		return nil, fmt.Errorf("volcengine session: %w", err)
+	}
+
+	return s, nil
+}
+
+// expect reads until the given event arrives, turning a rejection into an
+// error that carries the service's own words.
+func (c *volcengineClient) expect(s *volcSession, want int32) error {
+	for {
+		_, data, err := s.conn.ReadMessage()
+		if err != nil {
+			return err
+		}
+		event, payload, ok := parseVolcTTSFrame(data)
+		if !ok {
+			continue
+		}
+		if event == want {
+			return nil
+		}
+		if event == volcEventSessionFailed || event == 0 {
+			return fmt.Errorf("%s", strings.TrimSpace(string(payload)))
+		}
+	}
+}
+
+func (c *volcengineClient) SynthesizeStream(ctx context.Context, text string) (<-chan StreamChunk, error) {
+	s, err := c.open(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	task, err := c.request(volcEventTaskRequest, text)
+	if err != nil {
+		s.close()
+		return nil, err
+	}
+	if err := s.write(volcEventTaskRequest, s.sessionID, task); err != nil {
+		s.close()
+		return nil, err
+	}
+	// This client is handed a whole sentence, so the utterance is closed
+	// immediately; the service still streams the audio back afterwards.
+	fin, err := json.Marshal(map[string]any{"event": volcEventFinishSession, "namespace": "BidirectionalTTS"})
+	if err != nil {
+		s.close()
+		return nil, err
+	}
+	if err := s.write(volcEventFinishSession, s.sessionID, fin); err != nil {
+		s.close()
+		return nil, err
+	}
+
+	ch := make(chan StreamChunk, 8)
+	go func() {
+		defer close(ch)
+		defer s.close()
+		c.pump(ctx, s, ch)
+	}()
+	return ch, nil
+}
+
+// pump forwards TTSResponse payloads as PCM until the session finishes.
+//
+// A barge-in cancels ctx mid-utterance and ReadMessage does not watch a
+// context, so the connection is closed from a second goroutine to break the
+// read. Without it the client keeps receiving audio for a turn that was
+// already cancelled.
+func (c *volcengineClient) pump(ctx context.Context, s *volcSession, ch chan<- StreamChunk) {
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.close()
+		case <-done:
+		}
+	}()
+
+	emit := func(chunk StreamChunk) bool {
+		select {
+		case ch <- chunk:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+
+	total := 0
+	for {
+		_, data, err := s.conn.ReadMessage()
+		if err != nil {
+			// A cancelled turn is the expected way this ends, not a fault.
+			if ctx.Err() == nil {
+				emit(StreamChunk{Err: fmt.Errorf("volcengine stream read: %w", err)})
+			}
+			return
+		}
+
+		event, payload, ok := parseVolcTTSFrame(data)
+		if !ok {
+			continue
+		}
+
+		switch event {
+		case volcEventTTSResponse:
+			total += len(payload)
+			if !emit(StreamChunk{PCM: payload}) {
+				return
+			}
+		case volcEventSessionFinished:
+			log.Printf("[tts:volcengine] synthesized %d bytes (%.2fs of audio)",
+				total, float64(total)/2/float64(volcengineTTSSampleRate))
+			return
+		case volcEventSessionFailed, 0:
+			emit(StreamChunk{Err: fmt.Errorf("volcengine: %s", strings.TrimSpace(string(payload)))})
+			return
+		}
+	}
+}
+
+// Synthesize drains the stream into one buffer, for callers that want the
+// whole utterance at once.
+func (c *volcengineClient) Synthesize(ctx context.Context, text string) ([]byte, error) {
+	ch, err := c.SynthesizeStream(ctx, text)
+	if err != nil {
+		return nil, err
+	}
+	var pcm []byte
+	for chunk := range ch {
+		if chunk.Err != nil {
+			return nil, chunk.Err
+		}
+		pcm = append(pcm, chunk.PCM...)
+	}
+	return pcm, nil
+}

--- a/internal/tts/volcengine_test.go
+++ b/internal/tts/volcengine_test.go
@@ -1,0 +1,223 @@
+package tts
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// serverFrame builds a response the way the service does: the 4-byte header, a
+// 4-byte event number, a length-prefixed session id for session-scoped events,
+// then the payload.
+func serverFrame(event int32, sessionID string, payload []byte) []byte {
+	f := []byte{0x11, volcTTSTypeFullClient<<4 | volcTTSFlagWithEvent, volcTTSSerialisationJS, 0x00}
+	ev := make([]byte, 4)
+	binary.BigEndian.PutUint32(ev, uint32(event))
+	f = append(f, ev...)
+	if sessionID != "" {
+		l := make([]byte, 4)
+		binary.BigEndian.PutUint32(l, uint32(len(sessionID)))
+		f = append(append(f, l...), sessionID...)
+	}
+	l := make([]byte, 4)
+	binary.BigEndian.PutUint32(l, uint32(len(payload)))
+	return append(append(f, l...), payload...)
+}
+
+// Session-scoped events carry a session id that connection-scoped ones do not.
+// Reading a TTSResponse without skipping it prepends the id's length and bytes
+// to the audio, which plays as a burst of noise at the start of every chunk
+// rather than failing.
+func TestVolcTTSSkipsSessionIDOnScopedEvents(t *testing.T) {
+	audio := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
+	sid := "1f2e3d4c-5b6a-7988-9a0b-1c2d3e4f5061"
+
+	event, payload, ok := parseVolcTTSFrame(serverFrame(volcEventTTSResponse, sid, audio))
+	if !ok {
+		t.Fatal("frame rejected, want it parsed")
+	}
+	if event != volcEventTTSResponse {
+		t.Errorf("event = %d, want %d", event, volcEventTTSResponse)
+	}
+	if string(payload) != string(audio) {
+		t.Errorf("payload = %v, want %v — the session id was not skipped", payload, audio)
+	}
+}
+
+// ConnectionStarted carries no session id. Skipping one that is not there eats
+// the first four bytes of the payload as a phantom length.
+func TestVolcTTSConnectionScopedEventHasNoSessionID(t *testing.T) {
+	body := []byte("6526d0c4-9426-4dd3-a91e-49caa67d85c7")
+
+	event, payload, ok := parseVolcTTSFrame(serverFrame(volcEventConnectionStarted, "", body))
+	if !ok {
+		t.Fatal("frame rejected, want it parsed")
+	}
+	if event != volcEventConnectionStarted {
+		t.Errorf("event = %d, want %d", event, volcEventConnectionStarted)
+	}
+	if string(payload) != string(body) {
+		t.Errorf("payload = %q, want %q", payload, body)
+	}
+}
+
+// The scoped/unscoped split is the whole hazard of this layout, so pin which
+// events fall on which side.
+func TestVolcTTSSessionScopedEventSet(t *testing.T) {
+	for _, ev := range []int32{
+		volcEventSessionStarted, volcEventSessionFinished,
+		volcEventSessionFailed, volcEventTTSResponse,
+	} {
+		if !volcSessionScopedEvent(ev) {
+			t.Errorf("event %d not treated as session-scoped, want it to be", ev)
+		}
+	}
+	for _, ev := range []int32{volcEventConnectionStarted, volcEventStartConnection} {
+		if volcSessionScopedEvent(ev) {
+			t.Errorf("event %d treated as session-scoped, want it not to be", ev)
+		}
+	}
+}
+
+// A frame shorter than the header must be discarded rather than slicing out of
+// range — the connection can deliver a truncated message on teardown.
+func TestVolcTTSRejectsShortFrame(t *testing.T) {
+	for _, n := range []int{0, 1, 4, 7} {
+		if _, _, ok := parseVolcTTSFrame(make([]byte, n)); ok {
+			t.Errorf("%d-byte frame accepted, want it rejected", n)
+		}
+	}
+}
+
+// The client frame layout is fixed by the service; a wrong byte fails as an
+// opaque protocol error that names nothing.
+func TestVolcTTSClientFrameLayout(t *testing.T) {
+	sid := "abc"
+	payload := []byte(`{"a":1}`)
+	f := volcFrame(volcEventTaskRequest, sid, payload)
+
+	if f[0] != 0x11 {
+		t.Errorf("byte 0 = %#x, want 0x11", f[0])
+	}
+	if got := (f[1] >> 4) & 0x0F; got != volcTTSTypeFullClient {
+		t.Errorf("message type = %d, want %d", got, volcTTSTypeFullClient)
+	}
+	// The event flag is what tells the service an event number follows;
+	// without it the header is read as a plain frame and the event becomes
+	// the first four bytes of the payload.
+	if got := f[1] & 0x0F; got&volcTTSFlagWithEvent == 0 {
+		t.Errorf("flags = %#b, want the event bit %#b set", got, volcTTSFlagWithEvent)
+	}
+	if got := int32(binary.BigEndian.Uint32(f[4:8])); got != volcEventTaskRequest {
+		t.Errorf("event = %d, want %d", got, volcEventTaskRequest)
+	}
+	if got := int(binary.BigEndian.Uint32(f[8:12])); got != len(sid) {
+		t.Errorf("session id length = %d, want %d", got, len(sid))
+	}
+	if got := string(f[12 : 12+len(sid)]); got != sid {
+		t.Errorf("session id = %q, want %q", got, sid)
+	}
+	if got := int(binary.BigEndian.Uint32(f[12+len(sid) : 16+len(sid)])); got != len(payload) {
+		t.Errorf("payload length = %d, want %d", got, len(payload))
+	}
+}
+
+// A connection-scoped frame must omit the session id entirely, not send an
+// empty one — a zero-length id shifts the payload by four bytes.
+func TestVolcTTSConnectionFrameOmitsSessionID(t *testing.T) {
+	payload := []byte(`{}`)
+	f := volcFrame(volcEventStartConnection, "", payload)
+
+	if got := int(binary.BigEndian.Uint32(f[8:12])); got != len(payload) {
+		t.Errorf("bytes 8-12 = %d, want the payload length %d — a session id was written", got, len(payload))
+	}
+	if got := string(f[12:]); got != string(payload) {
+		t.Errorf("payload = %q, want %q", got, payload)
+	}
+}
+
+// The request body is a fixed shape; the service rejects the session outright
+// when namespace or audio_params are wrong.
+func TestVolcTTSRequestShape(t *testing.T) {
+	c := NewVolcengineClient("k", "", "", "").(*volcengineClient)
+
+	body, err := c.request(volcEventTaskRequest, "你好")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	if decoded["namespace"] != "BidirectionalTTS" {
+		t.Errorf("namespace = %v, want BidirectionalTTS", decoded["namespace"])
+	}
+	if decoded["event"].(float64) != float64(volcEventTaskRequest) {
+		t.Errorf("event = %v, want %d", decoded["event"], volcEventTaskRequest)
+	}
+
+	rp := decoded["req_params"].(map[string]any)
+	if rp["text"] != "你好" {
+		t.Errorf("text = %v, want 你好", rp["text"])
+	}
+	if rp["speaker"] != defaultVolcengineSpeaker {
+		t.Errorf("speaker = %v, want %s", rp["speaker"], defaultVolcengineSpeaker)
+	}
+
+	ap := rp["audio_params"].(map[string]any)
+	if ap["format"] != "pcm" {
+		t.Errorf("format = %v, want pcm", ap["format"])
+	}
+	// The pipeline plays 16kHz linear16 and this provider honours the request,
+	// so a wrong rate is not resampled anywhere — it plays back at the wrong
+	// speed and pitch.
+	if ap["sample_rate"].(float64) != 16000 {
+		t.Errorf("sample_rate = %v, want 16000", ap["sample_rate"])
+	}
+}
+
+// StartSession carries no text; leaving an empty field in would be read as a
+// request to synthesize nothing.
+func TestVolcTTSStartSessionOmitsText(t *testing.T) {
+	c := NewVolcengineClient("k", "", "", "").(*volcengineClient)
+
+	body, err := c.request(volcEventStartSession, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), `"text"`) {
+		t.Errorf("body = %s, want no text field on StartSession", body)
+	}
+}
+
+// Empty speaker, resource and url fall back rather than being sent blank.
+func TestVolcTTSDefaults(t *testing.T) {
+	c := NewVolcengineClient("k", "", "", "").(*volcengineClient)
+	if c.speaker != defaultVolcengineSpeaker {
+		t.Errorf("speaker = %q, want %q", c.speaker, defaultVolcengineSpeaker)
+	}
+	// The 2.0 resource is the default because the 1.0 one is a separate
+	// entitlement that answers 403 until activated.
+	if c.resource != defaultVolcengineTTSResource {
+		t.Errorf("resource = %q, want %q", c.resource, defaultVolcengineTTSResource)
+	}
+	if c.url != volcengineTTSURL {
+		t.Errorf("url = %q, want %q", c.url, volcengineTTSURL)
+	}
+
+	custom := NewVolcengineClient("k", "zh_male_m191_uranus_bigtts", "seed-icl-2.0", "wss://example/x").(*volcengineClient)
+	if custom.speaker != "zh_male_m191_uranus_bigtts" || custom.resource != "seed-icl-2.0" || custom.url != "wss://example/x" {
+		t.Errorf("explicit values overwritten: %+v", custom)
+	}
+}
+
+// Writing after close must fail rather than touching the connection: a
+// barge-in closes it while the send path may still be running.
+func TestVolcTTSSessionRejectsWriteAfterClose(t *testing.T) {
+	s := &volcSession{closed: true}
+	if err := s.write(volcEventTaskRequest, "sid", []byte(`{}`)); err == nil {
+		t.Error("write on a closed session succeeded, want an error instead of a nil-conn panic")
+	}
+}


### PR DESCRIPTION
Adds `tts.provider = "volcengine"`, backed by Doubao's `seed-tts-2.0`:

```toml
[tts]
provider = "volcengine"

[volcengine]
api_key = "..."
speaker = "zh_female_vv_uranus_bigtts"
```

One console API key now serves both directions of a call — the ASR provider added in #46 and this one — differing only in the resource header. `tts_resource_id`, `speaker` and `tts_url` sit alongside the existing ASR fields for that reason.

## No resampling on this path

The service emits 16kHz PCM directly, the rate the pipeline plays. MiMo needs a streaming resampler because it only produces 24kHz; here that stage is absent.

## The framing is *nearly* the ASR one, which is the hazard

Same binary family, different layout. These frames carry a 4-byte event number after the header, and **session-scoped events carry a length-prefixed session id after that while connection-scoped ones do not**:

| event | session id |
|---|---|
| `StartSession` 100, `SessionStarted` 150, `SessionFinished` 152, `SessionFailed` 153, `TTSResponse` 352 | yes |
| `StartConnection` 1, `ConnectionStarted` 50 | no |

Reading a `TTSResponse` without skipping the id prepends its length and bytes to the audio — a burst of noise at the start of every chunk, with nothing logged. Writing a connection-scoped frame *with* an empty id shifts the payload by four bytes in the other direction.

So the split is a named predicate (`volcSessionScopedEvent`) with tests pinning which events fall on which side, and `internal/stt/volcengine.go`'s parser is deliberately **not** reused: it has neither event numbers nor session ids, and the resemblance invites a copy that is subtly wrong.

## Cancellation

`ReadMessage` does not watch a context, so a barge-in cannot interrupt it from outside. A second goroutine waits on `ctx.Done()` and closes the connection to break the read. Without it the client keeps receiving audio for a turn that was already cancelled and the pipeline discards it — the caller hears the agent stop, but the next reply queues behind work nobody wanted. Measured at **2ms** from cancel to closed channel.

## Voices are tied to a model generation

`seed-tts-2.0` takes the `_uranus_bigtts` voices. The widely-published `_moon_` / `_mars_` / `_jupiter_` names are 1.0 and are refused with `resource ID is mismatched with speaker related resource` — which names neither the voice nor the entitlement, and reads like a billing problem. The 1.0 resource (`volc.service_type.10029`) is a separate entitlement that answers **403** until activated, so the default is 2.0 and the config comment says to change `speaker` and `tts_resource_id` together.

Verified working: `zh_female_vv_uranus_bigtts`, `zh_male_liufei_uranus_bigtts`, `zh_male_m191_uranus_bigtts`.

## Verification

- Live synthesis end to end against the service: first chunk at **0.54s**, 13 chunks, 152536 bytes = 4.77s of 16kHz audio.
- Cancellation mid-utterance: channel closed **2ms** after `cancel()`.
- Sample rates probed: `pcm@16000` ✓, `24000` ✓, `8000` ✓, `48000` ✓ — 16000 chosen so nothing is resampled.
- Ten unit tests over the framing (session-id skipping in both directions, the scoped-event set, short-frame rejection, client header layout, connection frames omitting the id), the request shape including the 16kHz `audio_params`, `StartSession` omitting `text`, the defaults, and the write-after-close guard. They run against constructed frames, so no key or network.
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.

## Notes

- Only synthesis is wired up; the ASR side from #46 is untouched.
- One connection per utterance, matching the other providers. The three-scope design makes connection reuse natural later — the connection outlives the session — but that is deliberately not in this first version.
